### PR TITLE
練習参加者照会Flexのヘッダー・本文表示形式を改善

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LineWebhookController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LineWebhookController.java
@@ -582,7 +582,7 @@ public class LineWebhookController {
 
             String sessionLabel = getSessionLabel(session);
             Map<String, Object> flex = lineNotificationService.buildTodayParticipantsFlex(
-                    sessionLabel, byMatch, playerMap);
+                    sessionLabel, byMatch, playerMap, session.getCapacity());
             sendReplyFlex(channel, replyToken, sessionLabel + "の参加者", flex);
 
         } catch (Exception e) {

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1093,11 +1093,76 @@ public class LineNotificationService {
 
     /**
      * 今日の参加者一覧のFlex Messageを構築する（リッチメニュー照会用）
-     * buildSameDayConfirmationFlex() と同じ形式
+     * ヘッダーに「〇月〇日（会場名：定員〇名）」、本文に「〇試合目：〇名」形式で表示
      */
     public Map<String, Object> buildTodayParticipantsFlex(
-            String sessionLabel, Map<Integer, List<PracticeParticipant>> byMatch, Map<Long, Player> playerMap) {
-        return buildSameDayConfirmationFlex(sessionLabel, byMatch, playerMap);
+            String sessionLabel, Map<Integer, List<PracticeParticipant>> byMatch, Map<Long, Player> playerMap,
+            Integer capacity) {
+
+        String headerText = capacity != null
+                ? sessionLabel.replaceAll("）$", "：定員" + capacity + "名）")
+                : sessionLabel;
+
+        Map<String, Object> header = Map.of(
+            "type", "box",
+            "layout", "vertical",
+            "contents", List.of(
+                Map.of("type", "text", "text", headerText,
+                    "color", "#ffffff", "weight", "bold", "size", "md", "wrap", true)
+            ),
+            "backgroundColor", "#2196F3",
+            "paddingAll", "15px"
+        );
+
+        List<Object> bodyContents = new java.util.ArrayList<>();
+
+        for (Map.Entry<Integer, List<PracticeParticipant>> entry : byMatch.entrySet()) {
+            if (!bodyContents.isEmpty()) {
+                bodyContents.add(Map.of("type", "separator", "margin", "lg"));
+            }
+            bodyContents.add(Map.of("type", "text", "text",
+                    entry.getKey() + "試合目：" + entry.getValue().size() + "名",
+                    "weight", "bold", "size", "md", "margin", "lg", "color", "#333333"));
+
+            // 段位順（高段位→低段位）でソート
+            List<PracticeParticipant> sorted = entry.getValue().stream()
+                    .sorted((a, b) -> Integer.compare(
+                            danRankOrdinal(playerMap.get(b.getPlayerId())),
+                            danRankOrdinal(playerMap.get(a.getPlayerId()))))
+                    .toList();
+
+            // 3人ずつ1行に並べる
+            for (int i = 0; i < sorted.size(); i += 3) {
+                List<Object> rowContents = new java.util.ArrayList<>();
+                for (int j = 0; j < 3; j++) {
+                    if (i + j < sorted.size()) {
+                        Player p = playerMap.get(sorted.get(i + j).getPlayerId());
+                        String name = p != null ? p.getName() : "不明";
+                        rowContents.add(Map.of("type", "text", "text", name,
+                                "flex", 1, "size", "sm", "color", "#555555"));
+                    } else {
+                        rowContents.add(Map.of("type", "text", "text", " ",
+                                "flex", 1, "size", "sm"));
+                    }
+                }
+
+                bodyContents.add(Map.of("type", "box", "layout", "horizontal",
+                        "contents", rowContents, "margin", "sm"));
+            }
+        }
+
+        Map<String, Object> body = Map.of(
+            "type", "box",
+            "layout", "vertical",
+            "contents", bodyContents,
+            "paddingAll", "20px"
+        );
+
+        return Map.of(
+            "type", "bubble",
+            "header", header,
+            "body", body
+        );
     }
 
     /**

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineRichMenuHandlerTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineRichMenuHandlerTest.java
@@ -119,7 +119,7 @@ class LineRichMenuHandlerTest {
             Map<Long, Player> playerMap = Map.of(10L, player1, 20L, player2);
 
             Map<String, Object> flex = lineNotificationService.buildTodayParticipantsFlex(
-                    "4月2日（中央公民館）", byMatch, playerMap);
+                    "4月2日（中央公民館）", byMatch, playerMap, 4);
 
             assertThat(flex.get("type")).isEqualTo("bubble");
             assertThat(flex).containsKey("header");


### PR DESCRIPTION
## Summary
- リッチメニュー「次の練習参加者を確認する」ボタンのFlex Messageの表示形式を改善
- ヘッダーを「本日の練習メンバー」→「〇月〇日（会場名：定員〇名）」形式に変更
- 本文冒頭の「〇月〇日（会場名）の練習」を削除
- 試合目の表示を「〇試合目：〇名」形式に変更（参加人数を表示）

## Test plan
- [x] `LineRichMenuHandlerTest` の `buildTodayParticipantsFlex` テストが通ること
- [ ] LINEリッチメニューから「次の練習参加者を確認する」を押して表示形式を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)