### PR TITLE
fix: 対戦記録編集画面で対戦相手が選択されない不具合を修正

### DIFF
--- a/karuta-tracker-ui/src/pages/matches/MatchForm.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchForm.jsx
@@ -116,9 +116,11 @@ const MatchForm = () => {
             }
           }
 
+          const opponentId = match.player1Id === currentPlayer.id ? match.player2Id : match.player1Id;
           setFormData({
             matchDate: match.matchDate,
             opponentName: match.opponentName,
+            opponentId: opponentId || null,
             result: match.result,
             scoreDifference: match.scoreDifference,
             matchNumber: match.matchNumber,


### PR DESCRIPTION
## Summary
- 対戦記録の編集画面（/matches/:id/edit）で、既存の対戦相手がフォームに反映されず「選択してください」のまま表示されるバグを修正
- 編集モードの初期データロードで `opponentId` の計算が欠落していたため追加

## Bug
Fixes #302

## Test plan
- [ ] /matches/:id 画面で編集ボタンを押し、/matches/:id/edit で対戦相手が正しく選択済みになることを確認

Generated with [Claude Code](https://claude.com/claude-code)