### PR TITLE
fix: リッチメニュー「次の練習」を所属練習会でフィルタリング

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LineWebhookController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LineWebhookController.java
@@ -41,7 +41,7 @@ public class LineWebhookController {
     private final LineNotificationService lineNotificationService;
     private final LineConfirmationService lineConfirmationService;
     private final LotteryDeadlineHelper lotteryDeadlineHelper;
-    private final OrganizationService organizationService;
+    private final PracticeSessionService practiceSessionService;
     private final ObjectMapper objectMapper;
 
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("M月d日");
@@ -551,7 +551,7 @@ public class LineWebhookController {
      */
     private void handleCheckTodayParticipants(LineChannel channel, String replyToken, Long playerId) {
         try {
-            PracticeSession session = findNextPracticeSession(playerId);
+            PracticeSession session = practiceSessionService.findNextSessionForPlayer(playerId);
 
             if (session == null) {
                 sendReply(channel, replyToken, "予定されている練習はありません");
@@ -648,39 +648,6 @@ public class LineWebhookController {
             log.error("Failed to check same-day join: player={}, error={}", playerId, e.getMessage());
             sendReply(channel, replyToken, "参加申込情報の取得に失敗しました。");
         }
-    }
-
-    /**
-     * プレイヤーの所属団体に基づいて、次の練習セッションを取得する。
-     * 今日の練習が開始時間前ならその日、開始時間を過ぎていたら翌日以降の直近の練習。
-     */
-    private PracticeSession findNextPracticeSession(Long playerId) {
-        List<Long> orgIds = organizationService.getPlayerOrganizationIds(playerId);
-        if (orgIds.isEmpty()) {
-            return null;
-        }
-
-        LocalDate today = JstDateTimeUtil.today();
-
-        // 所属団体の今日以降の練習を日付昇順で取得
-        List<PracticeSession> upcomingSessions = practiceSessionRepository
-                .findUpcomingSessionsByOrganizationIdIn(orgIds, today);
-
-        for (PracticeSession session : upcomingSessions) {
-            if (session.getSessionDate().isEqual(today)) {
-                // 今日の練習：開始時間が未設定、またはまだ開始時間前なら返す
-                if (session.getStartTime() == null
-                        || JstDateTimeUtil.now().isBefore(today.atTime(session.getStartTime()))) {
-                    return session;
-                }
-                // 開始時間を過ぎている → スキップして次の練習へ
-            } else {
-                // 明日以降の練習 → そのまま返す
-                return session;
-            }
-        }
-
-        return null;
     }
 
     private void handleUnfollow(LineChannel channel, JsonNode event) {

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/PracticeSessionRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/PracticeSessionRepository.java
@@ -63,7 +63,7 @@ public interface PracticeSessionRepository extends JpaRepository<PracticeSession
     @Query("SELECT ps FROM PracticeSession ps WHERE ps.organizationId IN :orgIds AND YEAR(ps.sessionDate) = :year AND MONTH(ps.sessionDate) = :month ORDER BY ps.sessionDate ASC")
     List<PracticeSession> findByOrganizationIdInAndYearAndMonth(@Param("orgIds") List<Long> orgIds, @Param("year") int year, @Param("month") int month);
 
-    @Query("SELECT ps FROM PracticeSession ps WHERE ps.organizationId IN :orgIds AND ps.sessionDate >= :date ORDER BY ps.sessionDate ASC")
+    @Query("SELECT ps FROM PracticeSession ps WHERE ps.organizationId IN :orgIds AND ps.sessionDate >= :date ORDER BY ps.sessionDate ASC, ps.startTime ASC NULLS FIRST, ps.id ASC")
     List<PracticeSession> findUpcomingSessionsByOrganizationIdIn(@Param("orgIds") List<Long> orgIds, @Param("date") LocalDate date);
 
     @Query("SELECT ps.sessionDate FROM PracticeSession ps WHERE ps.organizationId IN :orgIds AND ps.sessionDate >= :date ORDER BY ps.sessionDate DESC")

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
@@ -158,6 +158,34 @@ public class PracticeSessionService {
     }
 
     /**
+     * プレイヤーの所属団体に基づいて、次の練習セッションを取得する。
+     * 今日の練習が開始時間前ならその日、開始時間を過ぎていたら翌日以降の直近の練習。
+     */
+    public PracticeSession findNextSessionForPlayer(Long playerId) {
+        List<Long> orgIds = organizationService.getPlayerOrganizationIds(playerId);
+        if (orgIds.isEmpty()) {
+            return null;
+        }
+
+        LocalDate today = JstDateTimeUtil.today();
+        List<PracticeSession> upcomingSessions = practiceSessionRepository
+                .findUpcomingSessionsByOrganizationIdIn(orgIds, today);
+
+        for (PracticeSession session : upcomingSessions) {
+            if (session.getSessionDate().isEqual(today)) {
+                if (session.getStartTime() == null
+                        || JstDateTimeUtil.now().isBefore(today.atTime(session.getStartTime()))) {
+                    return session;
+                }
+            } else {
+                return session;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * 次の参加予定練習を取得（ホーム画面用・軽量）
      */
     @Transactional(readOnly = true)

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LineWebhookControllerTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LineWebhookControllerTest.java
@@ -5,6 +5,7 @@ import com.karuta.matchtracker.entity.ChannelType;
 import com.karuta.matchtracker.entity.LineChannel;
 import com.karuta.matchtracker.entity.LineChannelAssignment;
 import com.karuta.matchtracker.entity.LineConfirmationToken;
+import com.karuta.matchtracker.entity.PracticeSession;
 import com.karuta.matchtracker.repository.LineChannelAssignmentRepository;
 import com.karuta.matchtracker.repository.LineChannelRepository;
 import com.karuta.matchtracker.repository.PlayerRepository;
@@ -17,7 +18,7 @@ import com.karuta.matchtracker.service.LineLinkingService;
 import com.karuta.matchtracker.service.LineMessagingService;
 import com.karuta.matchtracker.service.LineNotificationService;
 import com.karuta.matchtracker.service.LotteryDeadlineHelper;
-import com.karuta.matchtracker.service.OrganizationService;
+import com.karuta.matchtracker.service.PracticeSessionService;
 import com.karuta.matchtracker.service.WaitlistPromotionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,11 +28,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -61,7 +65,7 @@ class LineWebhookControllerTest {
     @MockitoBean private LineNotificationService lineNotificationService;
     @MockitoBean private LineConfirmationService lineConfirmationService;
     @MockitoBean private LotteryDeadlineHelper lotteryDeadlineHelper;
-    @MockitoBean private OrganizationService organizationService;
+    @MockitoBean private PracticeSessionService practiceSessionService;
 
     @Test
     @DisplayName("invalid signature returns 400")
@@ -157,6 +161,84 @@ class LineWebhookControllerTest {
 
         verify(waitlistPromotionService).handleSameDayJoin(200L, 2, 77L);
         verify(lineMessagingService).sendReplyMessage(eq("token"), eq("reply-token-2"), anyString());
+    }
+
+    @Test
+    @DisplayName("check_today_participants returns no-session message when player has no organization")
+    void checkTodayParticipants_noOrganization_returnsNoSession() throws Exception {
+        LineChannel channel = channel();
+        LineChannelAssignment assignment = linkedAssignment();
+        when(lineChannelRepository.findByLineChannelId("CH001")).thenReturn(Optional.of(channel));
+        when(lineMessagingService.verifySignature(eq("secret"), anyString(), eq("sig"))).thenReturn(true);
+        when(lineChannelAssignmentRepository.findByLineUserIdAndLineChannelIdAndStatus(
+                "U777", 10L, LineChannelAssignment.AssignmentStatus.LINKED))
+                .thenReturn(Optional.of(assignment));
+        when(practiceSessionService.findNextSessionForPlayer(77L)).thenReturn(null);
+
+        String body = postbackBody("action=check_today_participants");
+
+        mockMvc.perform(post("/api/line/webhook/CH001")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("x-line-signature", "sig")
+                        .content(body))
+                .andExpect(status().isOk());
+
+        verify(lineMessagingService).sendReplyMessage(eq("token"), eq("reply-token-2"), eq("予定されている練習はありません"));
+    }
+
+    @Test
+    @DisplayName("check_today_participants returns session info when next session exists")
+    void checkTodayParticipants_withSession_returnsParticipants() throws Exception {
+        LineChannel channel = channel();
+        LineChannelAssignment assignment = linkedAssignment();
+        PracticeSession session = PracticeSession.builder()
+                .id(100L)
+                .sessionDate(LocalDate.now())
+                .organizationId(1L)
+                .build();
+
+        when(lineChannelRepository.findByLineChannelId("CH001")).thenReturn(Optional.of(channel));
+        when(lineMessagingService.verifySignature(eq("secret"), anyString(), eq("sig"))).thenReturn(true);
+        when(lineChannelAssignmentRepository.findByLineUserIdAndLineChannelIdAndStatus(
+                "U777", 10L, LineChannelAssignment.AssignmentStatus.LINKED))
+                .thenReturn(Optional.of(assignment));
+        when(practiceSessionService.findNextSessionForPlayer(77L)).thenReturn(session);
+        when(practiceParticipantRepository.findBySessionIdAndStatus(eq(100L), any()))
+                .thenReturn(java.util.List.of());
+
+        String body = postbackBody("action=check_today_participants");
+
+        mockMvc.perform(post("/api/line/webhook/CH001")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("x-line-signature", "sig")
+                        .content(body))
+                .andExpect(status().isOk());
+
+        // セッションが存在するので「予定されている練習はありません」は送信されない
+        verify(lineMessagingService, never()).sendReplyMessage(eq("token"), eq("reply-token-2"), eq("予定されている練習はありません"));
+    }
+
+    private LineChannelAssignment linkedAssignment() {
+        return LineChannelAssignment.builder()
+                .lineChannelId(10L)
+                .playerId(77L)
+                .lineUserId("U777")
+                .channelType(ChannelType.PLAYER)
+                .status(LineChannelAssignment.AssignmentStatus.LINKED)
+                .build();
+    }
+
+    private String postbackBody(String data) throws Exception {
+        return objectMapper.writeValueAsString(
+                java.util.Map.of("events", java.util.List.of(
+                        java.util.Map.of(
+                                "type", "postback",
+                                "replyToken", "reply-token-2",
+                                "source", java.util.Map.of("userId", "U777"),
+                                "postback", java.util.Map.of("data", data)
+                        )
+                ))
+        );
     }
 
     private LineChannel channel() {

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -316,5 +317,88 @@ class PracticeSessionServiceTest {
                 .hasMessageContaining("PracticeSession")
                 .hasMessageContaining("999");
         verify(practiceSessionRepository, never()).deleteById(any());
+    }
+
+    // === findNextSessionForPlayer テスト ===
+
+    @Test
+    @DisplayName("所属団体がない場合はnullを返す")
+    void findNextSessionForPlayer_noOrganizations_returnsNull() {
+        when(organizationService.getPlayerOrganizationIds(1L)).thenReturn(List.of());
+
+        PracticeSession result = practiceSessionService.findNextSessionForPlayer(1L);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("所属団体の次の練習セッションを返す")
+    void findNextSessionForPlayer_withUpcomingSession_returnsSession() {
+        LocalDate tomorrow = today.plusDays(1);
+        PracticeSession futureSession = PracticeSession.builder()
+                .id(2L).sessionDate(tomorrow).organizationId(10L).build();
+
+        when(organizationService.getPlayerOrganizationIds(1L)).thenReturn(List.of(10L));
+        when(practiceSessionRepository.findUpcomingSessionsByOrganizationIdIn(List.of(10L), today))
+                .thenReturn(List.of(futureSession));
+
+        PracticeSession result = practiceSessionService.findNextSessionForPlayer(1L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("今日の練習で開始時間前なら今日の練習を返す")
+    void findNextSessionForPlayer_todayBeforeStart_returnsTodaySession() {
+        PracticeSession todaySession = PracticeSession.builder()
+                .id(3L).sessionDate(today).organizationId(10L)
+                .startTime(LocalTime.of(23, 59)).build();
+
+        when(organizationService.getPlayerOrganizationIds(1L)).thenReturn(List.of(10L));
+        when(practiceSessionRepository.findUpcomingSessionsByOrganizationIdIn(List.of(10L), today))
+                .thenReturn(List.of(todaySession));
+
+        PracticeSession result = practiceSessionService.findNextSessionForPlayer(1L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("今日の練習で開始時間を過ぎていたら翌日以降の練習を返す")
+    void findNextSessionForPlayer_todayAfterStart_returnsFutureSession() {
+        LocalDate tomorrow = today.plusDays(1);
+        PracticeSession todaySession = PracticeSession.builder()
+                .id(3L).sessionDate(today).organizationId(10L)
+                .startTime(LocalTime.of(0, 0)).build();
+        PracticeSession tomorrowSession = PracticeSession.builder()
+                .id(4L).sessionDate(tomorrow).organizationId(10L).build();
+
+        when(organizationService.getPlayerOrganizationIds(1L)).thenReturn(List.of(10L));
+        when(practiceSessionRepository.findUpcomingSessionsByOrganizationIdIn(List.of(10L), today))
+                .thenReturn(List.of(todaySession, tomorrowSession));
+
+        PracticeSession result = practiceSessionService.findNextSessionForPlayer(1L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(4L);
+    }
+
+    @Test
+    @DisplayName("開始時間がnullの今日の練習は返す")
+    void findNextSessionForPlayer_todayNullStartTime_returnsTodaySession() {
+        PracticeSession todaySession = PracticeSession.builder()
+                .id(5L).sessionDate(today).organizationId(10L)
+                .startTime(null).build();
+
+        when(organizationService.getPlayerOrganizationIds(1L)).thenReturn(List.of(10L));
+        when(practiceSessionRepository.findUpcomingSessionsByOrganizationIdIn(List.of(10L), today))
+                .thenReturn(List.of(todaySession));
+
+        PracticeSession result = practiceSessionService.findNextSessionForPlayer(1L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(5L);
     }
 }


### PR DESCRIPTION
## Summary
- リッチメニューの「次の練習に参加する」ボタンが所属練習会に関係なく全練習を返すバグを修正
- `findNextPracticeSession()` に `playerId` を渡し、`OrganizationService` で所属団体を取得してフィルタリング
- ホーム画面(`PracticeSessionService.findNextParticipation()`)と同じフィルタリングロジックを適用

## Bug
Fixes #307

## Test plan
- [ ] 複数練習会が存在する状態で、所属練習会の次の練習のみが返されることを確認
- [ ] 所属練習会がないプレイヤーで「予定されている練習はありません」と表示されることを確認
- [ ] 既存テスト（LineWebhookControllerTest）が全て通過することを確認 ✅

Generated with [Claude Code](https://claude.com/claude-code)