### PR TITLE
fix: レビュープロンプト生成スクリプトの改善

### DIFF
--- a/scripts/review/generate-review-prompt.sh
+++ b/scripts/review/generate-review-prompt.sh
@@ -31,29 +31,34 @@ echo "PR #${PR_NUMBER} のレビュープロンプトを生成中..."
 PR_URL=$(gh pr view "$PR_NUMBER" --json url -q '.url')
 PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q '.title')
 BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName')
-
-# 差分の取得
-DIFF=$(gh pr diff "$PR_NUMBER")
+BASE_BRANCH=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
 
 # テンプレートの読み込みと置換
 OUTPUT="$OUTPUT_DIR/review-prompt-pr${PR_NUMBER}.md"
+
+# 差分をファイルに保存（変数経由だと特殊文字が破損するため）
+DIFF_FILE=$(mktemp)
+trap 'rm -f "$OUTPUT.tmp" "$DIFF_FILE"' EXIT
+gh pr diff "$PR_NUMBER" > "$DIFF_FILE"
 
 sed \
     -e "s|{{PR_URL}}|${PR_URL}|g" \
     -e "s|{{PR_TITLE}}|${PR_TITLE}|g" \
     -e "s|{{BRANCH}}|${BRANCH}|g" \
+    -e "s|{{BASE_BRANCH}}|${BASE_BRANCH}|g" \
     "$TEMPLATE" > "$OUTPUT.tmp"
 
-# {{DIFF}} の置換（差分は複数行なのでsedでは難しいためawkを使用）
-awk -v diff="$DIFF" '{
+# {{DIFF}} の置換（差分をファイルから読み込み、特殊文字を安全に埋め込む）
+awk -v difffile="$DIFF_FILE" '{
     if ($0 ~ /\{\{DIFF\}\}/) {
-        print diff
+        while ((getline line < difffile) > 0) print line
+        close(difffile)
     } else {
         print $0
     }
 }' "$OUTPUT.tmp" > "$OUTPUT"
 
-rm -f "$OUTPUT.tmp"
+rm -f "$OUTPUT.tmp" "$DIFF_FILE"
 
 echo ""
 echo "=== レビュープロンプト生成完了 ==="


### PR DESCRIPTION
## Summary
- 差分を変数経由からファイル経由に変更（特殊文字の破損を防止）
- `OUTPUT`変数を`trap`より前に定義（早期終了時の`.tmp`誤削除を防止）
- `{{BASE_BRANCH}}`プレースホルダーの置換を追加

PR #342 ブランチで行われたスクリプト改善がマージに含まれていなかったため、mainに反映します。

## Test plan
- [ ] `./scripts/review/generate-review-prompt.sh {PR番号}` でプロンプトが正常に生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)