### PR TITLE
fix: 同一セッション複数試合参加時の通知を統合送信

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1825,6 +1825,58 @@ public class LineNotificationService {
     }
 
     /**
+     * 複数試合の参加通知をセッション単位でまとめて送信する。
+     * 参加した試合のWONメンバー（参加した本人除く）に「〇〇さんがX,Y,Z試合目に参加します」通知。
+     *
+     * @param session          対象セッション
+     * @param joinedMatches    参加した試合番号リスト
+     * @param joinedPlayerName 参加したプレイヤー名
+     * @param joinedPlayerId   参加したプレイヤーID
+     */
+    public void sendConsolidatedSameDayJoinNotification(PracticeSession session, List<Integer> joinedMatches,
+                                                         String joinedPlayerName, Long joinedPlayerId) {
+        if (joinedMatches.isEmpty()) return;
+
+        String matchList = joinedMatches.stream()
+                .sorted()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+        String message = String.format("%sさんが今日の%s試合目に参加します", joinedPlayerName, matchList);
+
+        // 送信先: 参加した試合のいずれかでWONのメンバー（本人除く）
+        Set<Long> recipientSet = new java.util.LinkedHashSet<>();
+        for (int matchNumber : joinedMatches) {
+            List<PracticeParticipant> wonParticipants = practiceParticipantRepository
+                    .findBySessionIdAndMatchNumberAndStatus(session.getId(), matchNumber, ParticipantStatus.WON);
+            wonParticipants.stream()
+                    .map(PracticeParticipant::getPlayerId)
+                    .filter(id -> !id.equals(joinedPlayerId))
+                    .forEach(recipientSet::add);
+        }
+
+        for (Long playerId : recipientSet) {
+            try {
+                sendToPlayer(playerId, LineNotificationType.SAME_DAY_CANCEL, message);
+            } catch (Exception e) {
+                log.error("Failed to send consolidated join notification to player {}: {}", playerId, e.getMessage());
+            }
+        }
+
+        // 管理者にも送信
+        List<Player> adminRecipients = getAdminRecipientsForSession(session);
+        for (Player admin : adminRecipients) {
+            try {
+                sendToPlayer(admin.getId(), LineNotificationType.ADMIN_SAME_DAY_CANCEL, message);
+            } catch (Exception e) {
+                log.error("Failed to send admin consolidated join notification to player {}: {}", admin.getId(), e.getMessage());
+            }
+        }
+
+        log.info("Sent consolidated join notification for session {} matches {} player {}",
+                session.getId(), matchList, joinedPlayerId);
+    }
+
+    /**
      * 当日補充参加通知を送信する。
      * その試合のWONメンバー（参加した本人除く）に「〇〇さんが参加します」通知。
      */

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1582,7 +1582,9 @@ public class LineNotificationService {
 
             String matchSummary = playerVacancies.entrySet().stream()
                     .sorted(Map.Entry.comparingByKey())
-                    .map(e -> e.getKey() + "試合目:" + e.getValue() + "名")
+                    .map(e -> e.getValue() > 0
+                            ? e.getKey() + "試合目:" + e.getValue() + "名"
+                            : e.getKey() + "試合目:満枠")
                     .collect(Collectors.joining(", "));
             String altText = String.format("%s 空き枠のお知らせ（%s）", sessionLabel, matchSummary);
 
@@ -1614,7 +1616,9 @@ public class LineNotificationService {
 
         String matchSummary = vacanciesByMatch.entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
-                .map(e -> e.getKey() + "試合目:" + e.getValue() + "名")
+                .map(e -> e.getValue() > 0
+                        ? e.getKey() + "試合目:" + e.getValue() + "名"
+                        : e.getKey() + "試合目:満枠")
                 .collect(Collectors.joining(", "));
         String altText = String.format("【管理者通知】%s 空き枠のお知らせ（%s）", sessionLabel, matchSummary);
 
@@ -1667,9 +1671,18 @@ public class LineNotificationService {
                 .toList();
 
         for (Map.Entry<Integer, Integer> entry : sortedEntries) {
+            String matchText;
+            String textColor;
+            if (entry.getValue() > 0) {
+                matchText = entry.getKey() + "試合目: " + entry.getValue() + "名分空き";
+                textColor = "#333333";
+            } else {
+                matchText = entry.getKey() + "試合目: 定員に達しました";
+                textColor = "#999999";
+            }
             bodyContents.add(Map.of("type", "text",
-                    "text", entry.getKey() + "試合目: " + entry.getValue() + "名分空き",
-                    "size", "md", "margin", "sm", "color", "#333333", "wrap", true));
+                    "text", matchText,
+                    "size", "md", "margin", "sm", "color", textColor, "wrap", true));
         }
 
         if (includeButtons) {
@@ -1693,8 +1706,15 @@ public class LineNotificationService {
             );
         }
 
-        // フッター（ボタン群）
+        // フッター（ボタン群）— 空きのある試合がない場合はボタンなし
         List<Object> footerContents = buildVacancyJoinButtons(vacanciesByMatch, sessionId);
+        if (footerContents.isEmpty()) {
+            return Map.of(
+                    "type", "bubble",
+                    "header", header,
+                    "body", body
+            );
+        }
         Map<String, Object> footer = Map.of(
                 "type", "box",
                 "layout", "vertical",
@@ -1719,8 +1739,14 @@ public class LineNotificationService {
     private List<Object> buildVacancyJoinButtons(Map<Integer, Integer> vacanciesByMatch, Long sessionId) {
         List<Object> buttons = new ArrayList<>();
 
+        // 空きのある試合のみボタン対象
+        Map<Integer, Integer> availableMatches = vacanciesByMatch.entrySet().stream()
+                .filter(e -> e.getValue() > 0)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                        (a, b) -> a, LinkedHashMap::new));
+
         // 個別参加ボタン（オレンジ）
-        List<Integer> sortedMatchNumbers = vacanciesByMatch.keySet().stream().sorted().toList();
+        List<Integer> sortedMatchNumbers = availableMatches.keySet().stream().sorted().toList();
         for (Integer matchNumber : sortedMatchNumbers) {
             buttons.add(Map.of(
                     "type", "button",
@@ -1735,15 +1761,15 @@ public class LineNotificationService {
             ));
         }
 
-        // 全試合参加（青）※2試合以上の場合のみ
-        if (vacanciesByMatch.size() >= 2) {
+        // 全試合参加（青）※空きのある試合が2試合以上の場合のみ
+        if (availableMatches.size() >= 2) {
             buttons.add(Map.of(
                     "type", "button",
                     "action", Map.of(
                             "type", "postback",
                             "label", "すべての試合に参加",
                             "data", "action=same_day_join_all&sessionId=" + sessionId
-                                    + "&matchNumbers=" + vacanciesByMatch.keySet().stream()
+                                    + "&matchNumbers=" + availableMatches.keySet().stream()
                                     .sorted().map(String::valueOf).collect(Collectors.joining(","))
                     ),
                     "style", "primary",

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1685,7 +1685,25 @@ public class LineNotificationService {
                     "size", "md", "margin", "sm", "color", textColor, "wrap", true));
         }
 
-        if (includeButtons) {
+        if (!includeButtons) {
+            Map<String, Object> body = Map.of(
+                    "type", "box",
+                    "layout", "vertical",
+                    "contents", bodyContents,
+                    "paddingAll", "20px"
+            );
+            return Map.of(
+                    "type", "bubble",
+                    "header", header,
+                    "body", body
+            );
+        }
+
+        // フッター（ボタン群）— 空きのある試合がない場合はボタンなし
+        List<Object> footerContents = buildVacancyJoinButtons(vacanciesByMatch, sessionId);
+
+        // CTA文言はボタンがある場合のみ表示（満枠時の表示不整合を防止）
+        if (!footerContents.isEmpty()) {
             bodyContents.add(Map.of("type", "text",
                     "text", "参加希望の場合はボタンを押してください",
                     "size", "sm", "margin", "lg", "color", "#888888", "wrap", true));
@@ -1698,16 +1716,6 @@ public class LineNotificationService {
                 "paddingAll", "20px"
         );
 
-        if (!includeButtons) {
-            return Map.of(
-                    "type", "bubble",
-                    "header", header,
-                    "body", body
-            );
-        }
-
-        // フッター（ボタン群）— 空きのある試合がない場合はボタンなし
-        List<Object> footerContents = buildVacancyJoinButtons(vacanciesByMatch, sessionId);
         if (footerContents.isEmpty()) {
             return Map.of(
                     "type", "bubble",

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
@@ -312,6 +312,14 @@ public class WaitlistPromotionService {
         lineNotificationService.sendSameDayJoinNotification(session, matchNumber, playerName, playerId);
         lineNotificationService.sendSameDayVacancyUpdateNotification(session, matchNumber, playerName, playerId);
 
+        // 管理者向け空き枠通知
+        int adminCapacity = session.getCapacity() != null ? session.getCapacity() : 0;
+        List<PracticeParticipant> currentWonAfterJoin = practiceParticipantRepository
+                .findBySessionIdAndMatchNumberAndStatus(sessionId, matchNumber, ParticipantStatus.WON);
+        int adminVacancies = Math.max(0, adminCapacity - currentWonAfterJoin.size());
+        lineNotificationService.sendConsolidatedAdminVacancyNotification(session,
+                Map.of(matchNumber, adminVacancies));
+
         densukeSyncService.triggerWriteAsync();
     }
 
@@ -413,9 +421,7 @@ public class WaitlistPromotionService {
             // 参加登録後の空き枠数を計算（save後なので+1された状態）
             int currentWonCount = currentWon.size() + 1; // 今登録した分を加算
             int vacancies = Math.max(0, capacity - currentWonCount);
-            if (vacancies > 0) {
-                vacanciesByMatch.put(matchNumber, vacancies);
-            }
+            vacanciesByMatch.put(matchNumber, vacancies);
 
             joinedCount++;
             log.info("Same-day join all: player {} ({}) joined session {} match {}",

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
@@ -369,6 +369,8 @@ public class WaitlistPromotionService {
         String playerName = joinedPlayer != null ? joinedPlayer.getName() : "不明";
 
         int joinedCount = 0;
+        List<Integer> joinedMatches = new java.util.ArrayList<>();
+        Map<Integer, Integer> vacanciesByMatch = new java.util.LinkedHashMap<>();
 
         for (int matchNumber : targetMatches) {
             // 既にWONかどうかチェック
@@ -406,9 +408,14 @@ public class WaitlistPromotionService {
             }
             practiceParticipantRepository.save(participant);
 
-            // 参加通知 + 枠状況通知
-            lineNotificationService.sendSameDayJoinNotification(session, matchNumber, playerName, playerId);
-            lineNotificationService.sendSameDayVacancyUpdateNotification(session, matchNumber, playerName, playerId);
+            joinedMatches.add(matchNumber);
+
+            // 参加登録後の空き枠数を計算（save後なので+1された状態）
+            int currentWonCount = currentWon.size() + 1; // 今登録した分を加算
+            int vacancies = Math.max(0, capacity - currentWonCount);
+            if (vacancies > 0) {
+                vacanciesByMatch.put(matchNumber, vacancies);
+            }
 
             joinedCount++;
             log.info("Same-day join all: player {} ({}) joined session {} match {}",
@@ -416,6 +423,15 @@ public class WaitlistPromotionService {
         }
 
         if (joinedCount > 0) {
+            // 参加通知をセッション単位でまとめて送信
+            lineNotificationService.sendConsolidatedSameDayJoinNotification(session, joinedMatches, playerName, playerId);
+
+            // 空き枠通知をセッション単位でまとめて送信
+            if (!vacanciesByMatch.isEmpty()) {
+                lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, playerId);
+                lineNotificationService.sendConsolidatedAdminVacancyNotification(session, vacanciesByMatch);
+            }
+
             densukeSyncService.triggerWriteAsync();
         }
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
@@ -1,0 +1,162 @@
+package com.karuta.matchtracker.service;
+
+import com.karuta.matchtracker.entity.*;
+import com.karuta.matchtracker.repository.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LineNotificationService 統合参加通知テスト")
+class LineNotificationServiceConsolidatedJoinTest {
+
+    @Mock
+    private LineChannelRepository lineChannelRepository;
+    @Mock
+    private LineChannelAssignmentRepository lineChannelAssignmentRepository;
+    @Mock
+    private LineNotificationPreferenceRepository lineNotificationPreferenceRepository;
+    @Mock
+    private LineMessageLogService lineMessageLogService;
+    @Mock
+    private LineMessagingService lineMessagingService;
+    @Mock
+    private PracticeSessionRepository practiceSessionRepository;
+    @Mock
+    private PracticeParticipantRepository practiceParticipantRepository;
+    @Mock
+    private PlayerOrganizationRepository playerOrganizationRepository;
+    @Mock
+    private PlayerRepository playerRepository;
+    @Mock
+    private LotteryQueryService lotteryQueryService;
+    @Mock
+    private VenueRepository venueRepository;
+
+    @Spy
+    @InjectMocks
+    private LineNotificationService lineNotificationService;
+
+    private PracticeSession createSession() {
+        return PracticeSession.builder()
+                .id(100L).sessionDate(LocalDate.of(2026, 4, 20))
+                .capacity(6).totalMatches(3).organizationId(1L).build();
+    }
+
+    @Nested
+    @DisplayName("sendConsolidatedSameDayJoinNotification")
+    class SendConsolidatedSameDayJoinNotificationTests {
+
+        @Test
+        @DisplayName("複数試合の受信者を重複排除し、本人を除外して通知する")
+        void recipientDeduplicationAndSelfExclusion() {
+            PracticeSession session = createSession();
+
+            // 1試合目のWON: player10, player20（参加者本人）
+            PracticeParticipant won1a = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(1).status(ParticipantStatus.WON).build();
+            PracticeParticipant won1b = PracticeParticipant.builder()
+                    .id(2L).sessionId(100L).playerId(20L).matchNumber(1).status(ParticipantStatus.WON).build();
+            // 2試合目のWON: player10, player30
+            PracticeParticipant won2a = PracticeParticipant.builder()
+                    .id(3L).sessionId(100L).playerId(10L).matchNumber(2).status(ParticipantStatus.WON).build();
+            PracticeParticipant won2b = PracticeParticipant.builder()
+                    .id(4L).sessionId(100L).playerId(30L).matchNumber(2).status(ParticipantStatus.WON).build();
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of(won1a, won1b));
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 2, ParticipantStatus.WON))
+                    .thenReturn(List.of(won2a, won2b));
+
+            // sendToPlayerをスタブ化
+            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
+                    .sendToPlayer(anyLong(), any(), anyString());
+            // 管理者なし
+            when(playerRepository.findByRoleAndActive(Player.Role.SUPER_ADMIN)).thenReturn(List.of());
+            when(playerRepository.findByRoleAndAdminOrganizationIdAndActive(Player.Role.ADMIN, 1L)).thenReturn(List.of());
+
+            // joinedPlayerId=20 で実行
+            lineNotificationService.sendConsolidatedSameDayJoinNotification(session, List.of(1, 2), "参加者", 20L);
+
+            // player10, player30 に通知（player20=本人は除外、player10は重複排除で1回のみ）
+            verify(lineNotificationService).sendToPlayer(eq(10L), eq(LineMessageLog.LineNotificationType.SAME_DAY_CANCEL), anyString());
+            verify(lineNotificationService).sendToPlayer(eq(30L), eq(LineMessageLog.LineNotificationType.SAME_DAY_CANCEL), anyString());
+            verify(lineNotificationService, never()).sendToPlayer(eq(20L), any(), anyString());
+            // 合計2回（重複排除済み）
+            verify(lineNotificationService, times(2)).sendToPlayer(anyLong(), any(), anyString());
+        }
+
+        @Test
+        @DisplayName("試合番号がソートされたメッセージが送信される")
+        void matchNumbersSorted() {
+            PracticeSession session = createSession();
+
+            PracticeParticipant won = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(3).status(ParticipantStatus.WON).build();
+
+            // 3試合目と1試合目にWON参加者（逆順で渡す）
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 3, ParticipantStatus.WON))
+                    .thenReturn(List.of(won));
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of(PracticeParticipant.builder()
+                            .id(2L).sessionId(100L).playerId(10L).matchNumber(1).status(ParticipantStatus.WON).build()));
+
+            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
+                    .sendToPlayer(anyLong(), any(), anyString());
+            when(playerRepository.findByRoleAndActive(Player.Role.SUPER_ADMIN)).thenReturn(List.of());
+            when(playerRepository.findByRoleAndAdminOrganizationIdAndActive(Player.Role.ADMIN, 1L)).thenReturn(List.of());
+
+            // 逆順で渡してもソートされるか
+            lineNotificationService.sendConsolidatedSameDayJoinNotification(session, List.of(3, 1), "テスト太郎", 99L);
+
+            // メッセージが "1,3" の順でソートされていること
+            verify(lineNotificationService).sendToPlayer(eq(10L), eq(LineMessageLog.LineNotificationType.SAME_DAY_CANCEL),
+                    eq("テスト太郎さんが今日の1,3試合目に参加します"));
+        }
+
+        @Test
+        @DisplayName("管理者にも通知が送信される")
+        void adminNotificationSent() {
+            PracticeSession session = createSession();
+
+            PracticeParticipant won = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(1).status(ParticipantStatus.WON).build();
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of(won));
+
+            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
+                    .sendToPlayer(anyLong(), any(), anyString());
+
+            Player admin = Player.builder().id(50L).name("管理者").role(Player.Role.SUPER_ADMIN).build();
+            when(playerRepository.findByRoleAndActive(Player.Role.SUPER_ADMIN)).thenReturn(List.of(admin));
+            when(playerRepository.findByRoleAndAdminOrganizationIdAndActive(Player.Role.ADMIN, 1L)).thenReturn(List.of());
+
+            lineNotificationService.sendConsolidatedSameDayJoinNotification(session, List.of(1), "参加者", 20L);
+
+            // 管理者に通知が送信される
+            verify(lineNotificationService).sendToPlayer(eq(50L), eq(LineMessageLog.LineNotificationType.ADMIN_SAME_DAY_CANCEL), anyString());
+        }
+
+        @Test
+        @DisplayName("参加試合が空リストの場合は何も送信しない")
+        void emptyMatchList() {
+            PracticeSession session = createSession();
+
+            lineNotificationService.sendConsolidatedSameDayJoinNotification(session, List.of(), "参加者", 20L);
+
+            verify(lineNotificationService, never()).sendToPlayer(anyLong(), any(), anyString());
+        }
+    }
+}

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
@@ -11,9 +11,15 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
-import java.util.List;
+import org.mockito.ArgumentCaptor;
 
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -157,6 +163,104 @@ class LineNotificationServiceConsolidatedJoinTest {
             lineNotificationService.sendConsolidatedSameDayJoinNotification(session, List.of(), "参加者", 20L);
 
             verify(lineNotificationService, never()).sendToPlayer(anyLong(), any(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("sendConsolidatedSameDayVacancyNotification - 満枠ケース")
+    class VacancyNotificationFullCapacityTests {
+
+        @Test
+        @DisplayName("全試合満枠の場合、CTA文言とボタンが表示されない")
+        @SuppressWarnings("unchecked")
+        void allMatchesFullCapacity_noCTAAndNoButtons() {
+            PracticeSession session = createSession();
+
+            // 全試合の空き枠が0
+            Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
+            vacanciesByMatch.put(1, 0);
+            vacanciesByMatch.put(2, 0);
+
+            // 1試合目・2試合目ともにWON参加者なし → 全メンバーが送信対象
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 2, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            // 団体メンバー
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            // sendFlexToPlayerをスタブ化し、Flexペイロードをキャプチャ
+            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
+                    .sendFlexToPlayer(anyLong(), any(), anyString(), any());
+
+            lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
+
+            ArgumentCaptor<Map<String, Object>> flexCaptor = ArgumentCaptor.forClass(Map.class);
+            verify(lineNotificationService).sendFlexToPlayer(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), anyString(), flexCaptor.capture());
+
+            Map<String, Object> flex = flexCaptor.getValue();
+            Map<String, Object> body = (Map<String, Object>) flex.get("body");
+            List<Object> bodyContents = (List<Object>) body.get("contents");
+
+            // CTA文言「参加希望の場合はボタンを押してください」が含まれないこと
+            boolean hasCTA = bodyContents.stream()
+                    .filter(c -> c instanceof Map)
+                    .map(c -> (Map<String, Object>) c)
+                    .anyMatch(c -> "参加希望の場合はボタンを押してください".equals(c.get("text")));
+            assertFalse(hasCTA, "満枠時にCTA文言が表示されてはいけない");
+
+            // フッター（ボタン）がないこと
+            assertNull(flex.get("footer"), "満枠時にフッターが表示されてはいけない");
+        }
+
+        @Test
+        @DisplayName("一部空きありの場合、CTA文言とボタンが表示される")
+        @SuppressWarnings("unchecked")
+        void someMatchesAvailable_showsCTAAndButtons() {
+            PracticeSession session = createSession();
+
+            // 1試合目は空きあり、2試合目は満枠
+            Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
+            vacanciesByMatch.put(1, 2);
+            vacanciesByMatch.put(2, 0);
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 2, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
+                    .sendFlexToPlayer(anyLong(), any(), anyString(), any());
+
+            lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
+
+            ArgumentCaptor<Map<String, Object>> flexCaptor = ArgumentCaptor.forClass(Map.class);
+            verify(lineNotificationService).sendFlexToPlayer(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), anyString(), flexCaptor.capture());
+
+            Map<String, Object> flex = flexCaptor.getValue();
+            Map<String, Object> body = (Map<String, Object>) flex.get("body");
+            List<Object> bodyContents = (List<Object>) body.get("contents");
+
+            // CTA文言が含まれること
+            boolean hasCTA = bodyContents.stream()
+                    .filter(c -> c instanceof Map)
+                    .map(c -> (Map<String, Object>) c)
+                    .anyMatch(c -> "参加希望の場合はボタンを押してください".equals(c.get("text")));
+            assertTrue(hasCTA, "空きがある場合はCTA文言が表示されるべき");
+
+            // フッター（ボタン）があること
+            assertNotNull(flex.get("footer"), "空きがある場合はフッターが表示されるべき");
         }
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -496,6 +497,7 @@ class WaitlistPromotionServiceTest {
                 verify(practiceParticipantRepository).save(any(PracticeParticipant.class));
                 verify(lineNotificationService).sendSameDayJoinNotification(eq(session), eq(1), eq("参加者"), eq(20L));
                 verify(lineNotificationService).sendSameDayVacancyUpdateNotification(eq(session), eq(1), eq("参加者"), eq(20L));
+                verify(lineNotificationService).sendConsolidatedAdminVacancyNotification(eq(session), anyMap());
             }
         }
 
@@ -577,6 +579,9 @@ class WaitlistPromotionServiceTest {
 
                 assertThat(result).isEqualTo(3);
                 verify(practiceParticipantRepository, times(3)).save(any(PracticeParticipant.class));
+                verify(lineNotificationService).sendConsolidatedSameDayJoinNotification(eq(session), eq(List.of(1, 2, 3)), eq("参加者"), eq(20L));
+                verify(lineNotificationService).sendConsolidatedSameDayVacancyNotification(eq(session), anyMap(), eq(20L));
+                verify(lineNotificationService).sendConsolidatedAdminVacancyNotification(eq(session), anyMap());
                 verify(densukeSyncService).triggerWriteAsync();
             }
         }


### PR DESCRIPTION
## Summary
- `handleSameDayJoinAll` でループ内の個別通知呼び出し（`sendSameDayJoinNotification` / `sendSameDayVacancyUpdateNotification`）を削除
- ループ後にセッション単位で統合送信（`sendConsolidatedSameDayJoinNotification` / `sendConsolidatedSameDayVacancyNotification`）に変更
- 参加通知テキストも「〇〇さんが今日の1,2,3試合目に参加します」の形でまとめて1通に

## Bug
Fixes #402

## Test plan
- [ ] 空き枠がある練習セッション（複数試合）で「すべての試合に参加」を実行し、LINE通知が1通にまとまることを確認
- [ ] 単一試合の参加（handleSameDayJoin）は従来通り個別通知されることを確認
- [ ] 管理者通知も統合送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)