### PR TITLE
fix: 隣室空き状況取得失敗時の練習セッション表示エラーを修正

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/scheduler/AdjacentRoomNotificationScheduler.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/scheduler/AdjacentRoomNotificationScheduler.java
@@ -110,7 +110,15 @@ public class AdjacentRoomNotificationScheduler {
         // 残りが負の場合は0に補正
         if (remaining < 0) remaining = 0;
 
-        // 通知済みレコードを先に原子的に確保（一意制約で並列実行時の重複を防止）
+        // 隣室の空き状況を取得（DB障害時は "不明"(available=false) が返りリトライ可能な状態を維持）
+        AdjacentRoomStatusDto adjacentRoom = adjacentRoomService
+                .getAdjacentRoomAvailability(session.getVenueId(), session.getSessionDate());
+        if (adjacentRoom == null || !adjacentRoom.getAvailable()) {
+            return 0;
+        }
+
+        // 通知済みレコードを原子的に確保（一意制約で並列実行時の重複を防止）
+        // ※ 隣室確認後に保存することで、DB障害時に通知未送信なのに通知済みになる問題を防ぐ
         try {
             adjacentRoomNotificationRepository.save(AdjacentRoomNotification.builder()
                     .sessionId(session.getId())
@@ -121,13 +129,6 @@ public class AdjacentRoomNotificationScheduler {
             // 既に他のインスタンスが通知済み → スキップ
             log.debug("Adjacent room notification already sent for session {} (remaining={})",
                     session.getId(), remaining);
-            return 0;
-        }
-
-        // 隣室の空き状況を取得
-        AdjacentRoomStatusDto adjacentRoom = adjacentRoomService
-                .getAdjacentRoomAvailability(session.getVenueId(), session.getSessionDate());
-        if (adjacentRoom == null || !adjacentRoom.getAvailable()) {
             return 0;
         }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
@@ -46,11 +46,15 @@ public class AdjacentRoomService {
         String adjacentRoomName = AdjacentRoomConfig.getAdjacentRoomName(venueId);
         String status = "不明";
 
-        // DBキャッシュから隣室の空き状況を取得
-        var cache = roomAvailabilityCacheRepository
-                .findByRoomNameAndTargetDateAndTimeSlot(adjacentRoomName, date, TIME_SLOT_EVENING);
-        if (cache.isPresent()) {
-            status = cache.get().getStatus();
+        // DBキャッシュから隣室の空き状況を取得（テーブル未作成等のDB障害時はステータス「不明」で継続）
+        try {
+            var cache = roomAvailabilityCacheRepository
+                    .findByRoomNameAndTargetDateAndTimeSlot(adjacentRoomName, date, TIME_SLOT_EVENING);
+            if (cache.isPresent()) {
+                status = cache.get().getStatus();
+            }
+        } catch (Exception e) {
+            log.warn("隣室空き状況の取得に失敗しました（venueId={}, date={}）: {}", venueId, date, e.getMessage());
         }
 
         return AdjacentRoomStatusDto.builder()

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
@@ -11,6 +11,7 @@ import com.karuta.matchtracker.repository.RoomAvailabilityCacheRepository;
 import com.karuta.matchtracker.repository.VenueRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,8 +54,8 @@ public class AdjacentRoomService {
             if (cache.isPresent()) {
                 status = cache.get().getStatus();
             }
-        } catch (Exception e) {
-            log.warn("隣室空き状況の取得に失敗しました（venueId={}, date={}）: {}", venueId, date, e.getMessage());
+        } catch (DataAccessException e) {
+            log.warn("隣室空き状況の取得に失敗しました（venueId={}, date={}）: {}", venueId, date, e.getMessage(), e);
         }
 
         return AdjacentRoomStatusDto.builder()

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -38,7 +39,7 @@ public class AdjacentRoomService {
      * @param date 対象日付
      * @return 隣室の空き状況DTO（かでる和室でない場合はnull）
      */
-    @Transactional(readOnly = true)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public AdjacentRoomStatusDto getAdjacentRoomAvailability(Long venueId, LocalDate date) {
         if (!AdjacentRoomConfig.isKaderuRoom(venueId)) {
             return null;

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/integration/AdjacentRoomIntegrationTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/integration/AdjacentRoomIntegrationTest.java
@@ -1,52 +1,83 @@
 package com.karuta.matchtracker.integration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.karuta.matchtracker.repository.RoomAvailabilityCacheRepository;
+import com.karuta.matchtracker.config.TestContainersConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDate;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
- * AdjacentRoomServiceのトランザクション境界を通る統合テスト
+ * AdjacentRoomServiceのトランザクション境界を通る統合テスト（実DB検証）
  *
- * PracticeSessionService(@Transactional readOnly=true) から
- * AdjacentRoomService(@Transactional propagation=NOT_SUPPORTED) を呼び出す際、
- * DB障害時でも外側トランザクションに影響せず正常応答できることを検証する。
+ * room_availability_cache テーブルを一時的にリネームして実際のDataAccessExceptionを発生させ、
+ * PracticeSessionService(@Transactional readOnly=true) →
+ *   AdjacentRoomService(@Transactional propagation=NOT_SUPPORTED)
+ * のAOP境界を通る呼び出しで、外側トランザクションに影響しないことを検証する。
+ *
+ * NOT_SUPPORTEDを外すとinner DataAccessExceptionがouter transactionをrollback-onlyに
+ * マークするため500となり、このテストが失敗する。
+ *
+ * ※ テーブルリネームはトランザクション外で即コミットされる必要があるため、
+ *   BaseIntegrationTestの@Transactionalを継承せず独自にセットアップする。
  */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestContainersConfig.class)
+@ActiveProfiles("test")
 @DisplayName("隣室空き状況 統合テスト（トランザクション境界検証）")
-class AdjacentRoomIntegrationTest extends BaseIntegrationTest {
+class AdjacentRoomIntegrationTest {
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private MockMvc mockMvc;
 
-    @MockitoBean
-    private RoomAvailabilityCacheRepository roomAvailabilityCacheRepository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute(
+            "TRUNCATE TABLE matches, player_profiles, practice_participants, practice_sessions, " +
+            "match_pairings, venue_match_schedules, venues, player_organizations, players, organizations RESTART IDENTITY CASCADE"
+        );
+        jdbcTemplate.execute(
+            "INSERT INTO organizations (id, code, name, color, deadline_type, created_at, updated_at) " +
+            "VALUES (1, 'wasura', 'わすらもち会', '#16a34a', 'SAME_DAY', NOW(), NOW()) " +
+            "ON CONFLICT (id) DO NOTHING"
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        // テーブルがリネームされていた場合は復元する
+        try {
+            jdbcTemplate.execute("ALTER TABLE room_availability_cache_bak RENAME TO room_availability_cache");
+        } catch (Exception ignored) {
+            // リネームされていなかった場合は無視
+        }
+        jdbcTemplate.execute(
+            "TRUNCATE TABLE practice_sessions, venues, organizations RESTART IDENTITY CASCADE"
+        );
+    }
 
     @Test
-    @DisplayName("DB障害時でも練習日詳細APIは200で応答し、隣室ステータスは「不明」になる")
-    void getSessionDetail_whenCacheDbFails_returnsOkWithUnknownStatus() throws Exception {
-        // RoomAvailabilityCacheRepository が DataAccessException をスローするように設定
-        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot(
-                anyString(), any(LocalDate.class), anyString()))
-                .thenThrow(new DataAccessResourceFailureException(
-                        "relation \"room_availability_cache\" does not exist"));
-
+    @DisplayName("実DBでキャッシュテーブルが存在しない場合、APIは200で応答しステータスは「不明」")
+    void getSessionDetail_whenCacheTableMissing_returnsOkWithUnknownStatus() throws Exception {
         // Venue（かでる和室 id=3）を準備
         jdbcTemplate.execute(
                 "INSERT INTO venues (id, name, default_match_count, capacity, created_at, updated_at) " +
                 "VALUES (3, 'すずらん', 7, 14, NOW(), NOW()) ON CONFLICT (id) DO NOTHING");
 
-        // 練習セッションを直接DBに投入（APIのPOSTだとenrichment内でmockが呼ばれるため）
+        // 練習セッションを直接DBに投入
         jdbcTemplate.execute(
                 "INSERT INTO practice_sessions " +
                 "(session_date, total_matches, venue_id, organization_id, created_by, updated_by, created_at, updated_at) " +
@@ -54,10 +85,14 @@ class AdjacentRoomIntegrationTest extends BaseIntegrationTest {
         Long sessionId = jdbcTemplate.queryForObject(
                 "SELECT id FROM practice_sessions WHERE session_date = '2026-05-01'", Long.class);
 
+        // room_availability_cache テーブルをリネームして実DBエラーを発生させる
+        jdbcTemplate.execute("ALTER TABLE room_availability_cache RENAME TO room_availability_cache_bak");
+
         // 練習日詳細APIを呼び出し
-        // PracticeSessionService(@Transactional readOnly=true) →
-        //   AdjacentRoomService.getAdjacentRoomAvailability(@Transactional NOT_SUPPORTED)
-        // のAOP境界を通る呼び出しで、DB障害が外側トランザクションに影響しないことを検証
+        // @Transactional(propagation=NOT_SUPPORTED) が有効なら:
+        //   inner query は outer transaction の外で実行 → DataAccessException はキャッチされ "不明" で応答
+        // NOT_SUPPORTED を外すと:
+        //   inner DataAccessException が PostgreSQL の outer transaction を abort 状態にし 500 エラーになる
         mockMvc.perform(get("/api/practice-sessions/" + sessionId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(sessionId))

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/integration/AdjacentRoomIntegrationTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/integration/AdjacentRoomIntegrationTest.java
@@ -1,0 +1,68 @@
+package com.karuta.matchtracker.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.karuta.matchtracker.repository.RoomAvailabilityCacheRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.dao.DataAccessResourceFailureException;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * AdjacentRoomServiceのトランザクション境界を通る統合テスト
+ *
+ * PracticeSessionService(@Transactional readOnly=true) から
+ * AdjacentRoomService(@Transactional propagation=NOT_SUPPORTED) を呼び出す際、
+ * DB障害時でも外側トランザクションに影響せず正常応答できることを検証する。
+ */
+@DisplayName("隣室空き状況 統合テスト（トランザクション境界検証）")
+class AdjacentRoomIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private RoomAvailabilityCacheRepository roomAvailabilityCacheRepository;
+
+    @Test
+    @DisplayName("DB障害時でも練習日詳細APIは200で応答し、隣室ステータスは「不明」になる")
+    void getSessionDetail_whenCacheDbFails_returnsOkWithUnknownStatus() throws Exception {
+        // RoomAvailabilityCacheRepository が DataAccessException をスローするように設定
+        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot(
+                anyString(), any(LocalDate.class), anyString()))
+                .thenThrow(new DataAccessResourceFailureException(
+                        "relation \"room_availability_cache\" does not exist"));
+
+        // Venue（かでる和室 id=3）を準備
+        jdbcTemplate.execute(
+                "INSERT INTO venues (id, name, default_match_count, capacity, created_at, updated_at) " +
+                "VALUES (3, 'すずらん', 7, 14, NOW(), NOW()) ON CONFLICT (id) DO NOTHING");
+
+        // 練習セッションを直接DBに投入（APIのPOSTだとenrichment内でmockが呼ばれるため）
+        jdbcTemplate.execute(
+                "INSERT INTO practice_sessions " +
+                "(session_date, total_matches, venue_id, organization_id, created_by, updated_by, created_at, updated_at) " +
+                "VALUES ('2026-05-01', 7, 3, 1, 1, 1, NOW(), NOW())");
+        Long sessionId = jdbcTemplate.queryForObject(
+                "SELECT id FROM practice_sessions WHERE session_date = '2026-05-01'", Long.class);
+
+        // 練習日詳細APIを呼び出し
+        // PracticeSessionService(@Transactional readOnly=true) →
+        //   AdjacentRoomService.getAdjacentRoomAvailability(@Transactional NOT_SUPPORTED)
+        // のAOP境界を通る呼び出しで、DB障害が外側トランザクションに影響しないことを検証
+        mockMvc.perform(get("/api/practice-sessions/" + sessionId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(sessionId))
+                .andExpect(jsonPath("$.adjacentRoomStatus").exists())
+                .andExpect(jsonPath("$.adjacentRoomStatus.status").value("不明"))
+                .andExpect(jsonPath("$.adjacentRoomStatus.available").value(false));
+    }
+}

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/scheduler/AdjacentRoomNotificationSchedulerTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/scheduler/AdjacentRoomNotificationSchedulerTest.java
@@ -114,6 +114,13 @@ class AdjacentRoomNotificationSchedulerTest {
         when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(1L, 1, ParticipantStatus.PENDING))
                 .thenReturn(0L);
 
+        // 隣室は空き（通知レコード保存に到達する条件）
+        AdjacentRoomStatusDto status = AdjacentRoomStatusDto.builder()
+                .adjacentRoomName("はまなす").status("○").available(true)
+                .expandedVenueId(7L).expandedVenueName("すずらん・はまなす").expandedCapacity(24)
+                .build();
+        when(adjacentRoomService.getAdjacentRoomAvailability(3L, session.getSessionDate())).thenReturn(status);
+
         // 残り3人で既に通知済み → save時に一意制約違反
         when(adjacentRoomNotificationRepository.save(any())).thenThrow(new DataIntegrityViolationException("duplicate"));
 
@@ -140,6 +147,8 @@ class AdjacentRoomNotificationSchedulerTest {
         scheduler.checkCapacityAndNotify();
 
         verify(notificationService, never()).createAndPush(any(), any(), any(), any(), any(), any(), any(), any());
+        // 隣室が空いていない場合は通知レコードも保存しない（リトライ可能な状態を維持）
+        verify(adjacentRoomNotificationRepository, never()).save(any());
     }
 
     @Test

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.dao.DataAccessResourceFailureException;
+
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -82,6 +84,21 @@ class AdjacentRoomServiceTest {
         assertNotNull(result);
         assertEquals("不明", result.getStatus());
         assertFalse(result.getAvailable());
+    }
+
+    @Test
+    @DisplayName("DB障害時はステータス「不明」でフォールバックする")
+    void getAdjacentRoomAvailability_dbError() {
+        LocalDate date = LocalDate.of(2026, 4, 12);
+        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))
+                .thenThrow(new DataAccessResourceFailureException("relation \"room_availability_cache\" does not exist"));
+
+        AdjacentRoomStatusDto result = adjacentRoomService.getAdjacentRoomAvailability(3L, date);
+
+        assertNotNull(result);
+        assertEquals("不明", result.getStatus());
+        assertFalse(result.getAvailable());
+        assertEquals("はまなす", result.getAdjacentRoomName());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `AdjacentRoomService.getAdjacentRoomAvailability()` でのDBアクセスにtry-catchを追加
- テーブル未作成等のDB障害時もステータス「不明」で安全に継続し、練習セッション表示が壊れないようにした
- 本番DBへの `room_availability_cache` / `adjacent_room_notifications` テーブル作成は手動実行済み

## Bug
Fixes #407

## Test plan
- [ ] /practice 画面で試合がある日を押下し、試合データが表示されることを確認
- [ ] 隣室空き状況が「不明」として表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)