### PR TITLE
fix: メンター管理画面で組織がドロップダウンに表示されない

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -816,6 +816,8 @@ Entity Layer (JPA Entity)
   "danRank": "三段",
   "kyuRank": "A級",
   "karutaClub": "東京かるた会",
+  "adminOrganizationId": null,
+  "organizationIds": [1, 3],
   "firstLogin": false,
   "requirePasswordChange": false
 }
@@ -825,6 +827,7 @@ Entity Layer (JPA Entity)
 **説明**: 全アクティブ選手取得
 **権限**: なし
 **レスポンス**: `List<PlayerDto>`
+- 各選手に `organizationIds`（所属団体IDリスト）が含まれる
 
 #### POST /api/players
 **説明**: 選手登録

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -71,7 +71,7 @@
 - **ログイン**: 選手名（`name`）+ パスワードで認証
 - **パスワード**: 平文で保存・比較（プロトタイプ。将来的にBCryptハッシュ化予定）
 - **パスワード変更強制**: `require_password_change` フラグが `true` の場合、ログイン後に `/profile/edit?changePassword=true` へリダイレクトし、パスワード変更を強制する。変更完了後にフラグは自動的に `false` にリセットされる
-- **セッション管理**: ログイン成功時にプレイヤー情報を `localStorage` に保存。トークンは `dummy-token` を使用
+- **セッション管理**: ログイン成功時にプレイヤー情報（`organizationIds` を含む）を `localStorage` に保存。トークンは `dummy-token` を使用
 - **権限チェック**: リクエストヘッダー `X-User-Role` にロールを付与し、バックエンドの `RoleCheckInterceptor` が `@RequireRole` アノテーションで制御
 
 ### 2.3 選手プロパティ
@@ -1501,8 +1501,8 @@ UNIQUE制約: (player_id, organization_id)
 
 | メソッド | パス | 権限 | 説明 |
 |---|---|---|---|
-| POST | `/login` | Public | ログイン |
-| GET | `/` | ALL | 全アクティブ選手取得 |
+| POST | `/login` | Public | ログイン（レスポンスに `organizationIds` を含む） |
+| GET | `/` | ALL | 全アクティブ選手取得（各選手に `organizationIds` を含む） |
 | GET | `/{id}` | ALL | ID指定で取得 |
 | GET | `/search?name=` | ALL | 名前部分一致検索 |
 | GET | `/role/{role}` | ALL | ロール別取得 |

--- a/karuta-tracker-ui/src/pages/mentor/MentorManagement.jsx
+++ b/karuta-tracker-ui/src/pages/mentor/MentorManagement.jsx
@@ -38,10 +38,9 @@ export default function MentorManagement() {
       setMyMentees(menteesRes.data);
       setPendingRequests(pendingRes.data);
 
-      // localStorageのcurrentPlayerにorganizationIdsがない場合（デプロイ前ログインユーザー）、
-      // API応答から取得してフォールバックする
+      // API応答の最新データを優先し、localStorage側はフォールバックに留める
       const currentFromApi = playersRes.data.find(p => p.id === currentPlayer.id);
-      const orgIds = currentPlayer.organizationIds || currentFromApi?.organizationIds || [];
+      const orgIds = currentFromApi?.organizationIds ?? currentPlayer.organizationIds ?? [];
       const playerOrgs = orgsRes.data.filter(org => orgIds.includes(org.id));
       setMyOrgs(playerOrgs);
       setAllPlayers(playersRes.data);
@@ -50,7 +49,8 @@ export default function MentorManagement() {
     } finally {
       setLoading(false);
     }
-  }, [currentPlayer.id, currentPlayer.organizationIds]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- organizationIdsは配列参照で毎レンダー変わるため意図的に除外
+  }, [currentPlayer.id]);
 
   useEffect(() => {
     fetchData();

--- a/karuta-tracker-ui/src/pages/mentor/MentorManagement.jsx
+++ b/karuta-tracker-ui/src/pages/mentor/MentorManagement.jsx
@@ -38,9 +38,11 @@ export default function MentorManagement() {
       setMyMentees(menteesRes.data);
       setPendingRequests(pendingRes.data);
 
-      const playerOrgs = orgsRes.data.filter(org =>
-        currentPlayer.organizationIds?.includes(org.id)
-      );
+      // localStorageのcurrentPlayerにorganizationIdsがない場合（デプロイ前ログインユーザー）、
+      // API応答から取得してフォールバックする
+      const currentFromApi = playersRes.data.find(p => p.id === currentPlayer.id);
+      const orgIds = currentPlayer.organizationIds || currentFromApi?.organizationIds || [];
+      const playerOrgs = orgsRes.data.filter(org => orgIds.includes(org.id));
       setMyOrgs(playerOrgs);
       setAllPlayers(playersRes.data);
     } catch (e) {
@@ -48,7 +50,7 @@ export default function MentorManagement() {
     } finally {
       setLoading(false);
     }
-  }, [currentPlayer.organizationIds]);
+  }, [currentPlayer.id, currentPlayer.organizationIds]);
 
   useEffect(() => {
     fetchData();

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/LoginResponse.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/LoginResponse.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 /**
  * ログインレスポンスDTO
  */
@@ -24,13 +26,14 @@ public class LoginResponse {
     private String karutaClub;
     private Player.Role role;
     private Long adminOrganizationId;
+    private List<Long> organizationIds;
     private boolean firstLogin;
     private boolean requirePasswordChange;
 
     /**
      * エンティティからレスポンスへ変換
      */
-    public static LoginResponse fromEntity(Player player, boolean firstLogin) {
+    public static LoginResponse fromEntity(Player player, boolean firstLogin, List<Long> organizationIds) {
         if (player == null) {
             return null;
         }
@@ -44,6 +47,7 @@ public class LoginResponse {
                 .karutaClub(player.getKarutaClub())
                 .role(player.getRole())
                 .adminOrganizationId(player.getAdminOrganizationId())
+                .organizationIds(organizationIds)
                 .firstLogin(firstLogin)
                 .requirePasswordChange(Boolean.TRUE.equals(player.getRequirePasswordChange()))
                 .build();

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/PlayerDto.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/PlayerDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 選手情報のDTO
@@ -27,6 +28,7 @@ public class PlayerDto {
     private String remarks;
     private Player.Role role;
     private Long adminOrganizationId;
+    private List<Long> organizationIds;
     private LocalDateTime lastLoginAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -50,6 +52,32 @@ public class PlayerDto {
                 .remarks(player.getRemarks())
                 .role(player.getRole())
                 .adminOrganizationId(player.getAdminOrganizationId())
+                .lastLoginAt(player.getLastLoginAt())
+                .createdAt(player.getCreatedAt())
+                .updatedAt(player.getUpdatedAt())
+                .deletedAt(player.getDeletedAt())
+                .build();
+    }
+
+    /**
+     * エンティティからDTOへ変換（organizationIds付き）
+     */
+    public static PlayerDto fromEntity(Player player, List<Long> organizationIds) {
+        if (player == null) {
+            return null;
+        }
+        return PlayerDto.builder()
+                .id(player.getId())
+                .name(player.getName())
+                .gender(player.getGender())
+                .dominantHand(player.getDominantHand())
+                .danRank(player.getDanRank())
+                .kyuRank(player.getKyuRank())
+                .karutaClub(player.getKarutaClub())
+                .remarks(player.getRemarks())
+                .role(player.getRole())
+                .adminOrganizationId(player.getAdminOrganizationId())
+                .organizationIds(organizationIds)
                 .lastLoginAt(player.getLastLoginAt())
                 .createdAt(player.getCreatedAt())
                 .updatedAt(player.getUpdatedAt())

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/PlayerOrganizationRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/PlayerOrganizationRepository.java
@@ -11,6 +11,8 @@ public interface PlayerOrganizationRepository extends JpaRepository<PlayerOrgani
 
     List<PlayerOrganization> findByPlayerId(Long playerId);
 
+    List<PlayerOrganization> findByPlayerIdIn(List<Long> playerIds);
+
     List<PlayerOrganization> findByOrganizationId(Long organizationId);
 
     boolean existsByPlayerIdAndOrganizationId(Long playerId, Long organizationId);

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PlayerService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PlayerService.java
@@ -44,8 +44,9 @@ public class PlayerService {
         log.debug("Finding all active players");
         List<Player> players = playerRepository.findAllActiveOrderByName();
 
-        // 全プレイヤーの所属団体IDをバッチ取得（N+1回避）
-        Map<Long, List<Long>> orgIdsByPlayerId = playerOrganizationRepository.findAll().stream()
+        // アクティブ選手のみの所属団体IDをバッチ取得（N+1回避）
+        List<Long> playerIds = players.stream().map(Player::getId).collect(Collectors.toList());
+        Map<Long, List<Long>> orgIdsByPlayerId = playerOrganizationRepository.findByPlayerIdIn(playerIds).stream()
                 .collect(Collectors.groupingBy(
                         PlayerOrganization::getPlayerId,
                         Collectors.mapping(PlayerOrganization::getOrganizationId, Collectors.toList())

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PlayerService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PlayerService.java
@@ -6,8 +6,10 @@ import com.karuta.matchtracker.dto.PlayerCreateRequest;
 import com.karuta.matchtracker.dto.PlayerDto;
 import com.karuta.matchtracker.dto.PlayerUpdateRequest;
 import com.karuta.matchtracker.entity.Player;
+import com.karuta.matchtracker.entity.PlayerOrganization;
 import com.karuta.matchtracker.exception.DuplicateResourceException;
 import com.karuta.matchtracker.exception.ResourceNotFoundException;
+import com.karuta.matchtracker.repository.PlayerOrganizationRepository;
 import com.karuta.matchtracker.repository.PlayerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +22,7 @@ import com.karuta.matchtracker.util.JstDateTimeUtil;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -32,15 +35,24 @@ import java.util.stream.Collectors;
 public class PlayerService {
 
     private final PlayerRepository playerRepository;
+    private final PlayerOrganizationRepository playerOrganizationRepository;
 
     /**
      * 全てのアクティブな選手を取得（名前順）
      */
     public List<PlayerDto> findAllActivePlayers() {
         log.debug("Finding all active players");
-        return playerRepository.findAllActiveOrderByName()
-                .stream()
-                .map(PlayerDto::fromEntity)
+        List<Player> players = playerRepository.findAllActiveOrderByName();
+
+        // 全プレイヤーの所属団体IDをバッチ取得（N+1回避）
+        Map<Long, List<Long>> orgIdsByPlayerId = playerOrganizationRepository.findAll().stream()
+                .collect(Collectors.groupingBy(
+                        PlayerOrganization::getPlayerId,
+                        Collectors.mapping(PlayerOrganization::getOrganizationId, Collectors.toList())
+                ));
+
+        return players.stream()
+                .map(p -> PlayerDto.fromEntity(p, orgIdsByPlayerId.getOrDefault(p.getId(), List.of())))
                 .collect(Collectors.toList());
     }
 
@@ -222,7 +234,12 @@ public class PlayerService {
         player.setLastLoginAt(JstDateTimeUtil.now());
         playerRepository.save(player);
 
+        // ユーザーの参加団体IDリストを取得
+        List<Long> organizationIds = playerOrganizationRepository.findByPlayerId(player.getId()).stream()
+                .map(PlayerOrganization::getOrganizationId)
+                .collect(Collectors.toList());
+
         log.info("Successful login for user: {} (firstLogin: {})", request.getName(), isFirstLogin);
-        return LoginResponse.fromEntity(player, isFirstLogin);
+        return LoginResponse.fromEntity(player, isFirstLogin, organizationIds);
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PlayerServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PlayerServiceTest.java
@@ -4,8 +4,10 @@ import com.karuta.matchtracker.dto.PlayerCreateRequest;
 import com.karuta.matchtracker.dto.PlayerDto;
 import com.karuta.matchtracker.dto.PlayerUpdateRequest;
 import com.karuta.matchtracker.entity.Player;
+import com.karuta.matchtracker.entity.PlayerOrganization;
 import com.karuta.matchtracker.exception.DuplicateResourceException;
 import com.karuta.matchtracker.exception.ResourceNotFoundException;
+import com.karuta.matchtracker.repository.PlayerOrganizationRepository;
 import com.karuta.matchtracker.repository.PlayerRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +37,9 @@ class PlayerServiceTest {
 
     @Mock
     private PlayerRepository playerRepository;
+
+    @Mock
+    private PlayerOrganizationRepository playerOrganizationRepository;
 
     @InjectMocks
     private PlayerService playerService;
@@ -75,14 +80,21 @@ class PlayerServiceTest {
         when(playerRepository.findAllActiveOrderByName())
                 .thenReturn(List.of(testPlayer, player2));
 
+        PlayerOrganization po = PlayerOrganization.builder()
+                .id(1L).playerId(1L).organizationId(10L).build();
+        when(playerOrganizationRepository.findAll()).thenReturn(List.of(po));
+
         // When
         List<PlayerDto> result = playerService.findAllActivePlayers();
 
         // Then
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getName()).isEqualTo("山田太郎");
+        assertThat(result.get(0).getOrganizationIds()).containsExactly(10L);
         assertThat(result.get(1).getName()).isEqualTo("佐藤花子");
+        assertThat(result.get(1).getOrganizationIds()).isEmpty();
         verify(playerRepository).findAllActiveOrderByName();
+        verify(playerOrganizationRepository).findAll();
     }
 
     @Test
@@ -336,6 +348,10 @@ class PlayerServiceTest {
 
         when(playerRepository.findByNameAndActive("山田太郎")).thenReturn(Optional.of(player));
 
+        PlayerOrganization po = PlayerOrganization.builder()
+                .id(1L).playerId(1L).organizationId(10L).build();
+        when(playerOrganizationRepository.findByPlayerId(1L)).thenReturn(List.of(po));
+
         // When
         com.karuta.matchtracker.dto.LoginResponse response = playerService.login(request);
 
@@ -344,7 +360,9 @@ class PlayerServiceTest {
         assertThat(response.getId()).isEqualTo(1L);
         assertThat(response.getName()).isEqualTo("山田太郎");
         assertThat(response.getRole()).isEqualTo(Player.Role.PLAYER);
+        assertThat(response.getOrganizationIds()).containsExactly(10L);
         verify(playerRepository).findByNameAndActive("山田太郎");
+        verify(playerOrganizationRepository).findByPlayerId(1L);
     }
 
     @Test

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PlayerServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PlayerServiceTest.java
@@ -82,7 +82,7 @@ class PlayerServiceTest {
 
         PlayerOrganization po = PlayerOrganization.builder()
                 .id(1L).playerId(1L).organizationId(10L).build();
-        when(playerOrganizationRepository.findAll()).thenReturn(List.of(po));
+        when(playerOrganizationRepository.findByPlayerIdIn(List.of(1L, 2L))).thenReturn(List.of(po));
 
         // When
         List<PlayerDto> result = playerService.findAllActivePlayers();
@@ -94,7 +94,7 @@ class PlayerServiceTest {
         assertThat(result.get(1).getName()).isEqualTo("佐藤花子");
         assertThat(result.get(1).getOrganizationIds()).isEmpty();
         verify(playerRepository).findAllActiveOrderByName();
-        verify(playerOrganizationRepository).findAll();
+        verify(playerOrganizationRepository).findByPlayerIdIn(List.of(1L, 2L));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- LoginResponse / PlayerDto に `organizationIds` フィールドを追加
- PlayerService の `login()` と `findAllActivePlayers()` で organizationIds を取得・セット
- N+1クエリを回避するバッチ取得方式を採用

## Bug
Fixes #410

## Test plan
- [ ] ログイン後、メンター管理画面を開いて「組織を選択」ドロップダウンに所属組織が表示されることを確認
- [ ] 組織を選択後、メンター候補リストに該当組織のプレイヤーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)