### PR TITLE
feat: コメントスレッドをLINE風チャットUIに改修

### DIFF
--- a/docs/features/mentor-feedback/fix-implementation-plan.md
+++ b/docs/features/mentor-feedback/fix-implementation-plan.md
@@ -1,0 +1,52 @@
+---
+status: completed
+---
+# メンターフィードバック コメントUI改修 実装手順書
+
+## 実装タスク
+
+### タスク1: MatchCommentThread を LINE風チャットUIに改修
+- [x] 完了
+- **概要:** コメントスレッドコンポーネントのレイアウト・入力欄・操作体系をLINE風に全面改修する。1ファイル内の変更で完結する。
+- **変更対象ファイル:**
+  - `karuta-tracker-ui/src/pages/matches/MatchCommentThread.jsx` — 以下の4点を改修
+    1. コンテナをflex column + 固定高さに変更し、メッセージエリアの独立スクロール + 入力欄下部固定を実現
+    2. `<input type="text">` を `<textarea>` に変更し、自動リサイズ（最大4行）を実装
+    3. Enter送信 / Shift+Enter改行のキーハンドリングを追加
+    4. メッセージエリアの背景色をチャット風ベージュ (`#f0ebe4`) に変更
+- **依存タスク:** なし
+- **対応Issue:** #413
+
+#### 実装詳細
+
+**1. レイアウト変更**
+- 外側コンテナ: `p-4` → `flex flex-col h-[28rem]`（padding除去、flex column化）
+- ヘッダー部: `<h3>` を `p-3 border-b` の独立divに分離
+- エラー表示: ヘッダー直下に配置
+- メッセージエリア: `max-h-96 overflow-y-auto mb-4` → `flex-1 overflow-y-auto min-h-0 p-4 bg-[#f0ebe4]`
+- 入力フォーム: `p-3 border-t` の独立divで包む
+
+**2. textarea自動リサイズ**
+- `textareaRef = useRef(null)` を追加
+- onChange時:
+  ```
+  textarea.style.height = 'auto';
+  textarea.style.height = Math.min(textarea.scrollHeight, 96) + 'px';
+  ```
+- 送信成功後に `textarea.style.height = 'auto'` でリセット
+
+**3. Enter送信 / Shift+Enter改行**
+- onKeyDownハンドラ:
+  ```
+  if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+    e.preventDefault();
+    handleSubmit(e);
+  }
+  ```
+- `isComposing` チェックでIME変換確定時のEnterを無視（日本語入力対応）
+
+**4. 背景色**
+- メッセージエリアに `bg-[#f0ebe4]` を適用
+
+## 実装順序
+1. タスク1（単一タスク、依存なし）

--- a/docs/features/mentor-feedback/fix-requirements.md
+++ b/docs/features/mentor-feedback/fix-requirements.md
@@ -1,0 +1,107 @@
+---
+status: completed
+audit_source: ユーザー直接リクエスト
+selected_items: [1, 2, 3, 4]
+---
+# メンターフィードバック コメントUI改修 要件定義書
+
+## 1. 改修概要
+
+- **対象機能**: メンター・メンティー間コメントスレッド（MatchCommentThread）
+- **改修の背景**: 現在のコメントUIは通常のフォーム配置であり、ページスクロール時に入力欄が画面外に消える、入力が1行固定で改行できない等、チャットアプリとしてのUXに課題がある。LINEのようなチャットUIに改修し、メッセージのやり取りをより直感的にする。
+- **改修スコープ**: フロントエンドUIのみ（バックエンド・API・DBへの変更なし）
+
+## 2. 改修内容
+
+### 2.1 レイアウトをチャットウィンドウ型に変更
+- **現状の問題**: コメント一覧（`max-h-96 overflow-y-auto`）と入力フォームが通常フロー配置。ページ全体をスクロールすると入力欄が画面外に消え、文字を打ちながら過去メッセージを確認できない。
+- **修正方針**: コンテナを `flex flex-col` + 固定高さに変更。メッセージエリアを `flex-1 overflow-y-auto min-h-0` で独立スクロール可能にし、入力フォームをコンテナ下部に固定する。
+- **修正後のあるべき姿**: 入力欄が常にコメントセクション下部に表示され、メッセージ履歴だけが独立してスクロールする（LINE風）。
+
+### 2.2 入力欄を複数行対応（自動リサイズ）に変更
+- **現状の問題**: `<input type="text">` で1行固定。長文や改行付きコメントが入力しにくい。
+- **修正方針**: `<textarea>` に変更し、入力内容に応じて自動的に高さを拡張する。最大高さ（約4行分）に達したらtextarea内でスクロール。
+- **修正後のあるべき姿**: 入力するたびにテキストエリアが自然に広がり、LINEの入力欄と同じ挙動になる。
+
+### 2.3 送信・改行の操作をLINE準拠に変更
+- **現状の問題**: Enterキーでフォーム送信。改行を入力する手段がない。
+- **修正方針**: Enterで送信、Shift+Enterで改行に変更。
+- **修正後のあるべき姿**: LINEと同じ操作感で、Enterで即送信、改行したい場合はShift+Enterを使用。
+
+### 2.4 メッセージエリアの背景をチャット風に変更
+- **現状の問題**: 白背景でチャットアプリらしさがない。
+- **修正方針**: メッセージエリアに薄いベージュ系の背景色を適用し、チャットウィンドウの雰囲気を出す。
+- **修正後のあるべき姿**: LINEのトーク画面のような背景色でチャット感が向上。
+
+## 3. 技術設計
+
+### 3.1 API変更
+なし
+
+### 3.2 DB変更
+なし
+
+### 3.3 フロントエンド変更
+
+**変更ファイル**: `karuta-tracker-ui/src/pages/matches/MatchCommentThread.jsx`
+
+#### レイアウト構造の変更
+```
+変更前:
+<div className="bg-white rounded-lg shadow-sm p-4">        // 通常フロー
+  <h3>コメント</h3>
+  <div className="max-h-96 overflow-y-auto">               // 固定max-height
+    {messages}
+  </div>
+  <form>                                                     // フロー配置
+    <input type="text" />
+  </form>
+</div>
+
+変更後:
+<div className="bg-white rounded-lg shadow-sm flex flex-col h-[28rem]">  // flex column + 固定高さ
+  <div className="p-3 border-b">                                          // ヘッダー固定
+    <h3>コメント</h3>
+  </div>
+  <div className="flex-1 overflow-y-auto min-h-0 p-4 bg-[#f0ebe4]">    // 独立スクロール + チャット背景
+    {messages}
+  </div>
+  <div className="p-3 border-t">                                          // 入力欄固定
+    <form>
+      <textarea />  // auto-resize対応
+    </form>
+  </div>
+</div>
+```
+
+#### textarea自動リサイズ
+- `useRef` でtextarea要素を参照
+- `onChange` 時に `scrollHeight` を読み取り `style.height` を動的に設定
+- 最大高さ（96px ≈ 4行）を超えたら内部スクロール
+
+#### Enter送信 / Shift+Enter改行
+- `onKeyDown` で `e.key === 'Enter' && !e.shiftKey` を検知し `handleSubmit` を呼び出す
+- `e.shiftKey` が true の場合はデフォルト動作（改行）を許可
+
+#### 送信後のtextareaリセット
+- 送信成功後に `setNewComment('')` と同時に textarea の `style.height` を初期値にリセット
+
+### 3.4 バックエンド変更
+なし
+
+## 4. 影響範囲
+
+- **変更ファイル**: `MatchCommentThread.jsx` の1ファイルのみ
+- **呼び出し元**: `MatchDetail.jsx` (L281) — propsに変更なし、影響なし
+- **API連携**: リクエスト/レスポンス形式に変更なし
+- **共通コンポーネント**: 使用していないため影響なし
+- **破壊的変更**: なし
+
+## 5. 設計判断の根拠
+
+| 判断 | 理由 |
+|------|------|
+| コンテナ高さを `h-[28rem]` (448px) に固定 | モバイル・デスクトップ両方で適切なチャットウィンドウサイズ。ページ内の他の情報も見える余裕を残す |
+| `<input>` → `<textarea>` + auto-resize | LINEの入力欄と同じ挙動を実現するための標準的な手法 |
+| Enter送信 / Shift+Enter改行 | LINEのPC版と同一の操作体系。ユーザーが期待する動作 |
+| 背景色 `#f0ebe4` | LINEのトーク画面の背景色に近い暖かみのあるベージュ。既存の緑 (`#4a6b5a`) 吹き出しとの相性も良い |

--- a/karuta-tracker-ui/src/pages/matches/MatchCommentThread.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchCommentThread.jsx
@@ -12,6 +12,7 @@ export default function MatchCommentThread({ matchId, menteeId }) {
   const [editContent, setEditContent] = useState('');
   const [error, setError] = useState(null);
   const bottomRef = useRef(null);
+  const textareaRef = useRef(null);
 
   const fetchComments = async () => {
     try {
@@ -40,6 +41,9 @@ export default function MatchCommentThread({ matchId, menteeId }) {
       setError(null);
       await matchCommentsAPI.createComment(matchId, menteeId, newComment.trim());
       setNewComment('');
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+      }
       await fetchComments();
     } catch (err) {
       setError(err.response?.data?.message || 'コメントの投稿に失敗しました');
@@ -81,21 +85,39 @@ export default function MatchCommentThread({ matchId, menteeId }) {
     return `${month}/${day} ${hours}:${minutes}`;
   };
 
+  const handleInputChange = (e) => {
+    setNewComment(e.target.value);
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = Math.min(textarea.scrollHeight, 96) + 'px';
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
   return (
-    <div className="bg-white rounded-lg shadow-sm p-4">
-      <h3 className="text-base font-semibold text-gray-800 mb-3 flex items-center gap-2">
-        <MessageCircle size={18} className="text-[#4a6b5a]" />
-        コメント
-      </h3>
+    <div className="bg-white rounded-lg shadow-sm flex flex-col h-[28rem]">
+      <div className="p-3 border-b">
+        <h3 className="text-base font-semibold text-gray-800 flex items-center gap-2">
+          <MessageCircle size={18} className="text-[#4a6b5a]" />
+          コメント
+        </h3>
+      </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 p-2 rounded text-sm mb-3">
+        <div className="bg-red-50 border border-red-200 text-red-700 p-2 rounded text-sm mx-3 mt-2">
           {error}
         </div>
       )}
 
       {/* コメント一覧 */}
-      <div className="space-y-3 mb-4 max-h-96 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto min-h-0 p-4 space-y-3 bg-[#f0ebe4]">
         {comments.length === 0 ? (
           <p className="text-gray-400 text-sm text-center py-4">まだコメントはありません</p>
         ) : (
@@ -173,22 +195,27 @@ export default function MatchCommentThread({ matchId, menteeId }) {
       </div>
 
       {/* 投稿フォーム */}
-      <form onSubmit={handleSubmit} className="flex gap-2">
-        <input
-          type="text"
-          value={newComment}
-          onChange={(e) => setNewComment(e.target.value)}
-          placeholder="コメントを入力..."
-          className="flex-1 border border-gray-300 rounded-full px-4 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-[#4a6b5a]"
-        />
-        <button
-          type="submit"
-          disabled={!newComment.trim() || submitting}
-          className="bg-[#4a6b5a] text-white p-2 rounded-full disabled:opacity-50"
-        >
-          <Send size={18} />
-        </button>
-      </form>
+      <div className="p-3 border-t bg-white">
+        <form onSubmit={handleSubmit} className="flex gap-2">
+          <textarea
+            ref={textareaRef}
+            value={newComment}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            placeholder="コメントを入力..."
+            rows={1}
+            className="flex-1 border border-gray-300 rounded-full px-4 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-[#4a6b5a] resize-none overflow-y-auto"
+            style={{ height: 'auto' }}
+          />
+          <button
+            type="submit"
+            disabled={!newComment.trim() || submitting}
+            className="bg-[#4a6b5a] text-white p-2 rounded-full disabled:opacity-50"
+          >
+            <Send size={18} />
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/karuta-tracker-ui/src/pages/matches/MatchCommentThread.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchCommentThread.jsx
@@ -95,7 +95,7 @@ export default function MatchCommentThread({ matchId, menteeId }) {
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !e.repeat) {
       e.preventDefault();
       handleSubmit(e);
     }

--- a/karuta-tracker-ui/src/pages/matches/MatchCommentThread.test.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchCommentThread.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../api/matchComments', () => ({
+  matchCommentsAPI: {
+    getComments: vi.fn().mockResolvedValue({ data: [] }),
+    createComment: vi.fn().mockResolvedValue({ data: {} }),
+    updateComment: vi.fn().mockResolvedValue({ data: {} }),
+    deleteComment: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    currentPlayer: { id: 1, name: 'テスト選手' },
+  }),
+}));
+
+import { matchCommentsAPI } from '../../api/matchComments';
+import MatchCommentThread from './MatchCommentThread';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('MatchCommentThread', () => {
+  const renderComponent = () =>
+    render(<MatchCommentThread matchId={1} menteeId={1} />);
+
+  it('Enterキーでコメントが送信される', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    const textarea = screen.getByPlaceholderText('コメントを入力...');
+    await user.type(textarea, 'テストコメント');
+    await user.keyboard('{Enter}');
+
+    expect(matchCommentsAPI.createComment).toHaveBeenCalledWith(
+      1,
+      1,
+      'テストコメント'
+    );
+  });
+
+  it('Shift+Enterで改行が入力される（送信されない）', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    const textarea = screen.getByPlaceholderText('コメントを入力...');
+    await user.type(textarea, '1行目');
+    await user.keyboard('{Shift>}{Enter}{/Shift}');
+    await user.type(textarea, '2行目');
+
+    expect(matchCommentsAPI.createComment).not.toHaveBeenCalled();
+    expect(textarea.value).toContain('1行目');
+    expect(textarea.value).toContain('2行目');
+  });
+
+  it('送信後に入力欄がクリアされる', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    const textarea = screen.getByPlaceholderText('コメントを入力...');
+    await user.type(textarea, 'テストコメント');
+    await user.keyboard('{Enter}');
+
+    await vi.waitFor(() => {
+      expect(textarea.value).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- コメントスレッド（MatchCommentThread）のレイアウトをflex column+固定高さのチャットウィンドウ型に変更
- メッセージエリアの独立スクロール+入力欄下部固定で、LINE風の操作感を実現
- input→textarea+自動リサイズ（最大4行）で複数行入力に対応
- Enter送信/Shift+Enter改行（日本語IME対応済み）
- メッセージエリアにチャット風ベージュ背景を適用

## Related Issues
https://github.com/poponta2020/match-tracker/issues/412

## Test plan
- [ ] コメントスレッドが固定高さのチャットウィンドウとして表示される
- [ ] メッセージ履歴が独立してスクロールできる
- [ ] 入力欄が常にコメントセクション下部に表示される
- [ ] 複数行入力時にtextareaが自動で高さ拡張される
- [ ] 4行を超えるとtextarea内でスクロールする
- [ ] Enterで送信される
- [ ] Shift+Enterで改行が入力される
- [ ] 日本語IME変換確定時にEnterで誤送信しない
- [ ] 送信後にtextareaの高さがリセットされる
- [ ] メッセージエリアがベージュ背景になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)