### PR TITLE
fix: 当日キャンセル通知の繰り返し送信を防止

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
@@ -13,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.karuta.matchtracker.dto.AdminWaitlistNotificationData;
 import com.karuta.matchtracker.dto.ExpireOfferResult;
@@ -222,7 +224,21 @@ public class WaitlistPromotionService {
             log.info("Same-day after-noon cancel: triggering vacancy recruitment for session {} match {}",
                     session.getId(), participant.getMatchNumber());
 
-            handleSameDayCancelAndRecruit(participant, session);
+            // LINE通知はトランザクションコミット後に送信する。
+            // importFromDensuke 等の @Transactional メソッド内で呼ばれた場合、
+            // 後続処理のロールバックで CANCELLED が巻き戻っても通知だけ送信済みになる問題を防ぐ。
+            final PracticeParticipant cancelledParticipant = participant;
+            final PracticeSession cancelledSession = session;
+            if (TransactionSynchronizationManager.isActualTransactionActive()) {
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        handleSameDayCancelAndRecruit(cancelledParticipant, cancelledSession);
+                    }
+                });
+            } else {
+                handleSameDayCancelAndRecruit(participant, session);
+            }
             return null; // 当日補充は独自の通知フローを持つ
         }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
@@ -229,7 +229,8 @@ public class WaitlistPromotionService {
             // 後続処理のロールバックで CANCELLED が巻き戻っても通知だけ送信済みになる問題を防ぐ。
             final PracticeParticipant cancelledParticipant = participant;
             final PracticeSession cancelledSession = session;
-            if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            if (TransactionSynchronizationManager.isActualTransactionActive()
+                    && TransactionSynchronizationManager.isSynchronizationActive()) {
                 TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
@@ -35,6 +35,9 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
 @ExtendWith(MockitoExtension.class)
 @DisplayName("WaitlistPromotionService 辞退・復帰テスト")
 class WaitlistPromotionServiceTest {
@@ -316,6 +319,67 @@ class WaitlistPromotionServiceTest {
             // 新フロー通知は送信されないことを検証
             verify(lineNotificationService, never()).sendSameDayCancelNotification(any(), anyInt(), any(), any());
             verify(lineNotificationService, never()).sendSameDayVacancyNotification(any(), anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("トランザクション内ではafterCommitで通知が遅延実行される")
+        void cancelAfterNoon_defersNotificationToAfterCommit() {
+            PracticeParticipant participant = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
+                    .status(ParticipantStatus.WON).build();
+            PracticeSession session = PracticeSession.builder()
+                    .id(100L).sessionDate(LocalDate.of(2026, 4, 15)).capacity(6).build();
+
+            when(practiceParticipantRepository.findById(1L)).thenReturn(Optional.of(participant));
+            when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+            when(lotteryDeadlineHelper.isAfterSameDayNoon(session.getSessionDate())).thenReturn(true);
+
+            try (MockedStatic<TransactionSynchronizationManager> txMock =
+                         mockStatic(TransactionSynchronizationManager.class)) {
+                txMock.when(TransactionSynchronizationManager::isActualTransactionActive).thenReturn(true);
+                txMock.when(TransactionSynchronizationManager::isSynchronizationActive).thenReturn(true);
+
+                service.cancelParticipation(1L, "HEALTH", null);
+
+                // afterCommit に登録されたため、この時点では通知未送信
+                verify(lineNotificationService, never()).sendSameDayCancelNotification(any(), anyInt(), any(), any());
+                verify(lineNotificationService, never()).sendSameDayVacancyNotification(any(), anyInt(), any());
+                // registerSynchronization が呼ばれたことを検証
+                txMock.verify(() -> TransactionSynchronizationManager.registerSynchronization(
+                        any(TransactionSynchronization.class)));
+            }
+        }
+
+        @Test
+        @DisplayName("トランザクション外では即座に通知が送信される")
+        void cancelAfterNoon_sendsImmediatelyOutsideTransaction() {
+            PracticeParticipant participant = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
+                    .status(ParticipantStatus.WON).build();
+            PracticeSession session = PracticeSession.builder()
+                    .id(100L).sessionDate(LocalDate.of(2026, 4, 15)).capacity(6).build();
+            Player player = Player.builder().id(10L).name("テスト選手").build();
+
+            when(practiceParticipantRepository.findById(1L)).thenReturn(Optional.of(participant));
+            when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+            when(lotteryDeadlineHelper.isAfterSameDayNoon(session.getSessionDate())).thenReturn(true);
+            when(playerRepository.findById(10L)).thenReturn(Optional.of(player));
+
+            try (MockedStatic<TransactionSynchronizationManager> txMock =
+                         mockStatic(TransactionSynchronizationManager.class)) {
+                txMock.when(TransactionSynchronizationManager::isActualTransactionActive).thenReturn(false);
+
+                service.cancelParticipation(1L, "HEALTH", null);
+
+                // トランザクション外なので即座に通知が送信される
+                verify(lineNotificationService).sendSameDayCancelNotification(
+                        eq(session), eq(1), eq("テスト選手"), eq(10L));
+                verify(lineNotificationService).sendSameDayVacancyNotification(
+                        eq(session), eq(1), eq(10L));
+                // registerSynchronization は呼ばれない
+                txMock.verify(() -> TransactionSynchronizationManager.registerSynchronization(
+                        any(TransactionSynchronization.class)), never());
+            }
         }
     }
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -348,6 +349,80 @@ class WaitlistPromotionServiceTest {
                 txMock.verify(() -> TransactionSynchronizationManager.registerSynchronization(
                         any(TransactionSynchronization.class)));
             }
+        }
+
+        @Test
+        @DisplayName("afterCommitコールバック実行時に通知が実際に送信される")
+        void cancelAfterNoon_afterCommitTriggersNotification() {
+            PracticeParticipant participant = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
+                    .status(ParticipantStatus.WON).build();
+            PracticeSession session = PracticeSession.builder()
+                    .id(100L).sessionDate(LocalDate.of(2026, 4, 15)).capacity(6).build();
+            Player player = Player.builder().id(10L).name("テスト選手").build();
+
+            when(practiceParticipantRepository.findById(1L)).thenReturn(Optional.of(participant));
+            when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+            when(lotteryDeadlineHelper.isAfterSameDayNoon(session.getSessionDate())).thenReturn(true);
+            when(playerRepository.findById(10L)).thenReturn(Optional.of(player));
+
+            ArgumentCaptor<TransactionSynchronization> syncCaptor =
+                    ArgumentCaptor.forClass(TransactionSynchronization.class);
+
+            try (MockedStatic<TransactionSynchronizationManager> txMock =
+                         mockStatic(TransactionSynchronizationManager.class)) {
+                txMock.when(TransactionSynchronizationManager::isActualTransactionActive).thenReturn(true);
+                txMock.when(TransactionSynchronizationManager::isSynchronizationActive).thenReturn(true);
+
+                service.cancelParticipation(1L, "HEALTH", null);
+
+                // 登録されたコールバックをキャプチャ
+                txMock.verify(() ->
+                        TransactionSynchronizationManager.registerSynchronization(syncCaptor.capture()));
+            }
+
+            // afterCommit() を手動実行 → 通知が送信されることを検証
+            syncCaptor.getValue().afterCommit();
+
+            verify(lineNotificationService).sendSameDayCancelNotification(
+                    eq(session), eq(1), eq("テスト選手"), eq(10L));
+            verify(lineNotificationService).sendSameDayVacancyNotification(
+                    eq(session), eq(1), eq(10L));
+        }
+
+        @Test
+        @DisplayName("ロールバック時はafterCommitが呼ばれず通知は送信されない")
+        void cancelAfterNoon_rollbackDoesNotTriggerNotification() {
+            PracticeParticipant participant = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
+                    .status(ParticipantStatus.WON).build();
+            PracticeSession session = PracticeSession.builder()
+                    .id(100L).sessionDate(LocalDate.of(2026, 4, 15)).capacity(6).build();
+
+            when(practiceParticipantRepository.findById(1L)).thenReturn(Optional.of(participant));
+            when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+            when(lotteryDeadlineHelper.isAfterSameDayNoon(session.getSessionDate())).thenReturn(true);
+
+            ArgumentCaptor<TransactionSynchronization> syncCaptor =
+                    ArgumentCaptor.forClass(TransactionSynchronization.class);
+
+            try (MockedStatic<TransactionSynchronizationManager> txMock =
+                         mockStatic(TransactionSynchronizationManager.class)) {
+                txMock.when(TransactionSynchronizationManager::isActualTransactionActive).thenReturn(true);
+                txMock.when(TransactionSynchronizationManager::isSynchronizationActive).thenReturn(true);
+
+                service.cancelParticipation(1L, "HEALTH", null);
+
+                txMock.verify(() ->
+                        TransactionSynchronizationManager.registerSynchronization(syncCaptor.capture()));
+            }
+
+            // afterCompletion(ROLLED_BACK) → afterCommit は呼ばれないことをシミュレート
+            syncCaptor.getValue().afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            // 通知は送信されないことを検証
+            verify(lineNotificationService, never()).sendSameDayCancelNotification(any(), anyInt(), any(), any());
+            verify(lineNotificationService, never()).sendSameDayVacancyNotification(any(), anyInt(), any());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- 当日12:00以降キャンセル時のLINE通知送信を `afterCommit` コールバックに変更
- トランザクションロールバック時に通知が送信されないよう修正
- トランザクション外からの呼び出し時は従来通り即座に送信（フォールバック）

## Bug
Fixes #421

伝助で×に変更した際、DensukeSyncScheduler（5分間隔）のインポートトランザクション内で `handleSameDayCancelAndRecruit` が呼ばれ、LINE通知が即送信される。後続処理エラーでトランザクションがロールバックするとステータスがWONに戻り、5分後に再度同じキャンセルが検知されて通知が無限ループしていた。

## Test plan
- [ ] 当日12:00以降にアプリからキャンセル → キャンセル通知・空き枠通知が1回だけ送信されることを確認
- [ ] 伝助で×に変更 → 次回の伝助同期でキャンセル通知が1回だけ送信されることを確認
- [ ] 通知が5分おきに繰り返されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)