### PR TITLE
feat: 会場拡張前に隣室予約ステップを必須化

### DIFF
--- a/database/add_reservation_confirmed_at.sql
+++ b/database/add_reservation_confirmed_at.sql
@@ -1,0 +1,3 @@
+-- 隣室予約確認日時カラムを追加
+-- 予約ステップ完了時にタイムスタンプがセットされ、expand-venue実行時にサーバー側で検証される
+ALTER TABLE practice_sessions ADD COLUMN IF NOT EXISTS reservation_confirmed_at TIMESTAMP;

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -257,7 +257,6 @@ Entity Layer (JPA Entity)
 | end_time | TIME | | 終了時刻 |
 | capacity | INT | | 定員（抽選判定に使用） |
 | reservation_confirmed_at | DATETIME | | 隣室予約確認日時（NULLは未確認） |
-| reservation_confirmed_by | BIGINT | | 隣室予約確認者ID |
 | organization_id | BIGINT | NOT NULL, FK | 団体ID（organizations.id） |
 | created_by | BIGINT | NOT NULL | 登録者ID |
 | updated_by | BIGINT | NOT NULL | 更新者ID |
@@ -2365,7 +2364,7 @@ Entity Layer (JPA Entity)
 7. POST /api/practice-sessions/{id}/confirm-reservation
    ↓
 [バックエンド: AdjacentRoomService.confirmReservation()]
-8. reservation_confirmed_at, reservation_confirmed_by をセット
+8. reservation_confirmed_at をセット（確認者は updated_by で記録）
    ↓
 9. レスポンス: 200 OK + 更新後のセッション情報
    ↓
@@ -2388,7 +2387,7 @@ Entity Layer (JPA Entity)
 
 | 対象 | 変更内容 |
 |------|---------|
-| `practice_sessions` テーブル | `reservation_confirmed_at`, `reservation_confirmed_by` カラム追加 |
+| `practice_sessions` テーブル | `reservation_confirmed_at` カラム追加 |
 | `AdjacentRoomService` | `confirmReservation()`, `expandVenue()` メソッド追加 |
 | `PracticeSessionController` | `POST /{id}/confirm-reservation`, `POST /{id}/expand-venue` エンドポイント追加（ADMIN+） |
 | `PracticeList.jsx` | 隣室予約→予約完了報告→会場拡張の3段階UIフロー |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -256,6 +256,8 @@ Entity Layer (JPA Entity)
 | start_time | TIME | | 開始時刻 |
 | end_time | TIME | | 終了時刻 |
 | capacity | INT | | 定員（抽選判定に使用） |
+| reservation_confirmed_at | DATETIME | | 隣室予約確認日時（NULLは未確認） |
+| reservation_confirmed_by | BIGINT | | 隣室予約確認者ID |
 | organization_id | BIGINT | NOT NULL, FK | 団体ID（organizations.id） |
 | created_by | BIGINT | NOT NULL | 登録者ID |
 | updated_by | BIGINT | NOT NULL | 更新者ID |
@@ -2339,6 +2341,57 @@ Entity Layer (JPA Entity)
 | `LineNotificationType` enum | `MENTOR_COMMENT` 追加 |
 | `line_notification_preferences` テーブル | `mentor_comment` カラム追加（DEFAULT TRUE） |
 | `line_message_log` CHECK制約 | `MENTOR_COMMENT` 追加 |
+
+### 7.7 隣室予約→会場拡張フロー
+
+```
+[ユーザー操作（ADMIN+）]
+1. 練習日詳細モーダルで隣室が「空き」の場合、「隣室を予約」ボタンを表示
+   ↓
+2. 「隣室を予約」ボタンクリック
+   ↓
+[フロントエンド: PracticeList.jsx]
+3. kaderuAPI.openReserve() でかでる2・7の予約画面を開く
+   ↓
+4a. 成功時 → 「予約完了を報告」ボタンを表示（manual_pending状態）
+4b. DISABLED時 → 同じく「予約完了を報告」ボタンを表示（手動予約を案内）
+   ↓
+[ユーザー操作]
+5. かでる2・7サイトで予約を完了
+   ↓
+6. 「予約完了を報告」ボタンクリック
+   ↓
+[フロントエンド]
+7. POST /api/practice-sessions/{id}/confirm-reservation
+   ↓
+[バックエンド: AdjacentRoomService.confirmReservation()]
+8. reservation_confirmed_at, reservation_confirmed_by をセット
+   ↓
+9. レスポンス: 200 OK + 更新後のセッション情報
+   ↓
+[フロントエンド]
+10. 「会場を拡張」ボタンを表示（reservationReady = true）
+   ↓
+[ユーザー操作]
+11. 「会場を拡張」ボタンクリック → 確認ダイアログ
+   ↓
+[フロントエンド]
+12. POST /api/practice-sessions/{id}/expand-venue
+   ↓
+[バックエンド: AdjacentRoomService.expandVenue()]
+13. 会場を拡張後会場に変更、定員を更新
+   ↓
+14. レスポンス: 200 OK + 更新後のセッション情報
+```
+
+**変更対象テーブル・コード**:
+
+| 対象 | 変更内容 |
+|------|---------|
+| `practice_sessions` テーブル | `reservation_confirmed_at`, `reservation_confirmed_by` カラム追加 |
+| `AdjacentRoomService` | `confirmReservation()`, `expandVenue()` メソッド追加 |
+| `PracticeSessionController` | `POST /{id}/confirm-reservation`, `POST /{id}/expand-venue` エンドポイント追加（ADMIN+） |
+| `PracticeList.jsx` | 隣室予約→予約完了報告→会場拡張の3段階UIフロー |
 
 ---
 

--- a/docs/SCREEN_LIST.md
+++ b/docs/SCREEN_LIST.md
@@ -53,7 +53,7 @@
 
 | # | パス | ページコンポーネント | 主要子コンポーネント | 権限 | 説明 |
 |---|------|---------------------|---------------------|------|------|
-| 13 | `/practice` | `PracticeList.jsx` | `PlayerChip`, `MatchParticipantsEditModal` | ALL | 練習日程一覧（月別カレンダー表示）。同一日に複数団体のセッションがある場合はカレンダーセルに団体ごとに表示。ADMIN+は「抽選結果を通知」ボタンでアプリ内+LINE通知を一括送信可能 |
+| 13 | `/practice` | `PracticeList.jsx` | `PlayerChip`, `MatchParticipantsEditModal` | ALL | 練習日程一覧（月別カレンダー表示）。同一日に複数団体のセッションがある場合はカレンダーセルに団体ごとに表示。ADMIN+は「抽選結果を通知」ボタンでアプリ内+LINE通知を一括送信可能。ADMIN+は隣室が空きの場合「隣室を予約」→「予約完了を報告」→「会場を拡張」の3段階操作で会場拡張が可能 |
 | 14 | `/practice/new` | `PracticeForm.jsx` | 会場セレクタ、日付ピッカー | SUPER_ADMIN | 練習日程作成 |
 | 15 | `/practice/:id` | `PracticeDetail.jsx` | — | ALL | 練習日程詳細 |
 | 16 | `/practice/:id/edit` | `PracticeForm.jsx` | 会場セレクタ、日付ピッカー | SUPER_ADMIN | 練習日程編集 |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1173,7 +1173,6 @@ venues ──< venue_match_schedules (venueId)
 | end_time | TIME | — | 終了時刻 |
 | capacity | INT | — | 定員 |
 | reservation_confirmed_at | TIMESTAMP | — | 隣室予約確認日時（NULLは未確認） |
-| reservation_confirmed_by | BIGINT | — | 隣室予約確認者ID |
 | organization_id | BIGINT | NOT NULL, FK | 団体ID（organizations.id） |
 | created_by | BIGINT | NOT NULL | — |
 | updated_by | BIGINT | NOT NULL | — |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1172,6 +1172,8 @@ venues ──< venue_match_schedules (venueId)
 | start_time | TIME | — | 開始時刻 |
 | end_time | TIME | — | 終了時刻 |
 | capacity | INT | — | 定員 |
+| reservation_confirmed_at | TIMESTAMP | — | 隣室予約確認日時（NULLは未確認） |
+| reservation_confirmed_by | BIGINT | — | 隣室予約確認者ID |
 | organization_id | BIGINT | NOT NULL, FK | 団体ID（organizations.id） |
 | created_by | BIGINT | NOT NULL | — |
 | updated_by | BIGINT | NOT NULL | — |
@@ -1593,6 +1595,8 @@ UNIQUE制約: (player_id, organization_id)
 | PUT | `/{sid}/matches/{num}/participants` | SUPER_ADMIN | 試合別参加者設定 |
 | POST | `/date/{date}/matches/{num}/participants/{pid}` | ADMIN+ | 参加者追加 |
 | DELETE | `/{sid}/matches/{num}/participants/{pid}` | ADMIN+ | 参加者削除 |
+| POST | `/{id}/confirm-reservation` | ADMIN+ | 隣室予約完了を記録（`reservation_confirmed_at` をセット） |
+| POST | `/{id}/expand-venue` | ADMIN+ | 会場を隣室と合わせた大部屋に拡張（予約確認済みが前提） |
 
 ### 7.7 伝助連携 (`/api/practice-sessions`)
 

--- a/karuta-tracker-ui/src/api/kaderu.js
+++ b/karuta-tracker-ui/src/api/kaderu.js
@@ -1,0 +1,10 @@
+import apiClient from './client.js';
+
+const kaderuAPI = {
+  openReserve: (roomName, date, slotIndex = 2) =>
+    apiClient.post('/kaderu/open-reserve', null, {
+      params: { roomName, date, slotIndex },
+    }),
+};
+
+export default kaderuAPI;

--- a/karuta-tracker-ui/src/api/practices.js
+++ b/karuta-tracker-ui/src/api/practices.js
@@ -103,6 +103,10 @@ export const practiceAPI = {
   getDensukeWriteStatus: (organizationId) =>
     apiClient.get('/practice-sessions/densuke-write-status', { params: { organizationId } }),
 
+  // 隣室予約完了を記録
+  confirmReservation: (sessionId) =>
+    apiClient.post(`/practice-sessions/${sessionId}/confirm-reservation`),
+
   // 会場を拡張（隣室と合わせた大部屋に変更）
   expandVenue: (sessionId) =>
     apiClient.post(`/practice-sessions/${sessionId}/expand-venue`),

--- a/karuta-tracker-ui/src/pages/practice/AdjacentRoomFlow.test.jsx
+++ b/karuta-tracker-ui/src/pages/practice/AdjacentRoomFlow.test.jsx
@@ -125,7 +125,7 @@ const openSessionModal = async (user) => {
 };
 
 describe('隣室予約→会場拡張フロー', () => {
-  it('openReserve成功時: 隣室を予約→confirmReservation→会場を拡張ボタン表示', async () => {
+  it('openReserve成功時: 隣室を予約→予約完了を報告ボタン表示→クリック→会場を拡張ボタン表示', async () => {
     kaderuAPI.openReserve.mockResolvedValue({ data: { success: true } });
     practiceAPI.confirmReservation.mockResolvedValue({
       data: { ...sessionWithAdjacentRoom, reservationConfirmedAt: '2026-04-12T10:00:00' },
@@ -138,14 +138,23 @@ describe('隣室予約→会場拡張フロー', () => {
     // 「隣室を予約」ボタンをクリック
     await user.click(screen.getByText('隣室を予約'));
 
-    // openReserve → confirmReservation が呼ばれる
+    // alertが表示され、「予約完了を報告」ボタンが表示される
     await waitFor(() => {
       expect(kaderuAPI.openReserve).toHaveBeenCalledWith('はまなす', '2026-04-12');
-      expect(practiceAPI.confirmReservation).toHaveBeenCalledWith(1);
+      expect(window.alert).toHaveBeenCalledWith(
+        expect.stringContaining('予約画面を開きました')
+      );
+      expect(screen.getByText('予約完了を報告')).toBeInTheDocument();
     });
+    // この時点ではconfirmReservationはまだ呼ばれない
+    expect(practiceAPI.confirmReservation).not.toHaveBeenCalled();
 
-    // 「会場を拡張」ボタンが表示される
+    // 「予約完了を報告」ボタンをクリック
+    await user.click(screen.getByText('予約完了を報告'));
+
+    // confirmReservation が呼ばれ、「会場を拡張」ボタンに変わる
     await waitFor(() => {
+      expect(practiceAPI.confirmReservation).toHaveBeenCalledWith(1);
       expect(screen.getByText('会場を拡張')).toBeInTheDocument();
     });
     expect(screen.queryByText('隣室を予約')).not.toBeInTheDocument();

--- a/karuta-tracker-ui/src/pages/practice/AdjacentRoomFlow.test.jsx
+++ b/karuta-tracker-ui/src/pages/practice/AdjacentRoomFlow.test.jsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// --- Mocks ---
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../../api', () => ({
+  practiceAPI: {
+    getByYearMonth: vi.fn().mockResolvedValue({ data: [] }),
+    getSessionSummaries: vi.fn().mockResolvedValue({ data: [] }),
+    getById: vi.fn(),
+    expandVenue: vi.fn(),
+    confirmReservation: vi.fn(),
+    getPlayerParticipations: vi.fn().mockResolvedValue({ data: {} }),
+    getPlayerParticipationStatus: vi.fn().mockResolvedValue({ data: { participations: {} } }),
+  },
+  lotteryAPI: {},
+}));
+
+vi.mock('../../api/organizations', () => ({
+  organizationAPI: {
+    getAll: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+vi.mock('../../api/kaderu', () => ({
+  default: {
+    openReserve: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/auth', () => ({
+  isSuperAdmin: () => true,
+  isAdmin: () => true,
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    currentPlayer: { id: 1, name: 'テスト管理者', role: 'SUPER_ADMIN' },
+  }),
+}));
+
+vi.mock('../../components/MatchParticipantsEditModal', () => ({
+  default: () => null,
+}));
+vi.mock('../../components/PlayerChip', () => ({
+  default: ({ player }) => <span>{player?.name}</span>,
+}));
+vi.mock('../../components/YearMonthPicker', () => ({
+  default: () => null,
+}));
+vi.mock('../../components/LoadingScreen', () => ({
+  default: () => <div>Loading...</div>,
+}));
+
+import { practiceAPI } from '../../api';
+import kaderuAPI from '../../api/kaderu';
+import PracticeList from './PracticeList';
+
+// セッション詳細データ（隣室空きあり）
+const sessionWithAdjacentRoom = {
+  id: 1,
+  sessionDate: '2026-04-12',
+  totalMatches: 3,
+  venueId: 3,
+  venueName: 'すずらん',
+  capacity: 14,
+  organizationId: 1,
+  participantCount: 10,
+  adjacentRoomStatus: {
+    adjacentRoomName: 'はまなす',
+    status: '○',
+    available: true,
+    expandedVenueId: 7,
+    expandedVenueName: 'すずらん・はまなす',
+    expandedCapacity: 24,
+  },
+  reservationConfirmedAt: null,
+  matchParticipants: {},
+};
+
+// サマリーデータ
+const sessionSummary = {
+  id: 1,
+  sessionDate: '2026-04-12',
+  totalMatches: 3,
+  venueName: 'すずらん',
+  participantCount: 10,
+  organizationId: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // カレンダーに表示されるセッション
+  practiceAPI.getSessionSummaries.mockResolvedValue({ data: [sessionSummary] });
+  practiceAPI.getByYearMonth.mockResolvedValue({ data: [sessionSummary] });
+  // モーダル用の詳細データ
+  practiceAPI.getById.mockResolvedValue({ data: sessionWithAdjacentRoom });
+  // happy-domでは window.alert/confirm が未定義のため直接設定
+  window.alert = vi.fn();
+  window.confirm = vi.fn().mockReturnValue(true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/**
+ * カレンダーの日付をクリックしてモーダルを開くヘルパー
+ */
+const openSessionModal = async (user) => {
+  // カレンダーの12日をクリック
+  const dayCell = await screen.findByText('12');
+  await user.click(dayCell);
+  // モーダルが開くのを待つ
+  await waitFor(() => {
+    expect(screen.getByText('隣室を予約')).toBeInTheDocument();
+  });
+};
+
+describe('隣室予約→会場拡張フロー', () => {
+  it('openReserve成功時: 隣室を予約→confirmReservation→会場を拡張ボタン表示', async () => {
+    kaderuAPI.openReserve.mockResolvedValue({ data: { success: true } });
+    practiceAPI.confirmReservation.mockResolvedValue({
+      data: { ...sessionWithAdjacentRoom, reservationConfirmedAt: '2026-04-12T10:00:00' },
+    });
+
+    const user = userEvent.setup();
+    render(<PracticeList />);
+    await openSessionModal(user);
+
+    // 「隣室を予約」ボタンをクリック
+    await user.click(screen.getByText('隣室を予約'));
+
+    // openReserve → confirmReservation が呼ばれる
+    await waitFor(() => {
+      expect(kaderuAPI.openReserve).toHaveBeenCalledWith('はまなす', '2026-04-12');
+      expect(practiceAPI.confirmReservation).toHaveBeenCalledWith(1);
+    });
+
+    // 「会場を拡張」ボタンが表示される
+    await waitFor(() => {
+      expect(screen.getByText('会場を拡張')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('隣室を予約')).not.toBeInTheDocument();
+  });
+
+  it('DISABLED時: 隣室を予約→予約完了を報告ボタン表示→クリック→会場を拡張ボタン表示', async () => {
+    kaderuAPI.openReserve.mockRejectedValue({
+      response: { data: { errorCode: 'DISABLED' } },
+    });
+    practiceAPI.confirmReservation.mockResolvedValue({
+      data: { ...sessionWithAdjacentRoom, reservationConfirmedAt: '2026-04-12T10:00:00' },
+    });
+
+    const user = userEvent.setup();
+    render(<PracticeList />);
+    await openSessionModal(user);
+
+    // 「隣室を予約」ボタンをクリック
+    await user.click(screen.getByText('隣室を予約'));
+
+    // alertが表示され、「予約完了を報告」ボタンが表示される
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith(
+        expect.stringContaining('自動予約機能は現在利用できません')
+      );
+      expect(screen.getByText('予約完了を報告')).toBeInTheDocument();
+    });
+    // この時点ではconfirmReservationはまだ呼ばれない
+    expect(practiceAPI.confirmReservation).not.toHaveBeenCalled();
+
+    // 「予約完了を報告」ボタンをクリック
+    await user.click(screen.getByText('予約完了を報告'));
+
+    // confirmReservation が呼ばれ、「会場を拡張」ボタンに変わる
+    await waitFor(() => {
+      expect(practiceAPI.confirmReservation).toHaveBeenCalledWith(1);
+      expect(screen.getByText('会場を拡張')).toBeInTheDocument();
+    });
+  });
+
+  it('その他エラー時: エラーメッセージが表示され、隣室を予約ボタンのまま', async () => {
+    kaderuAPI.openReserve.mockRejectedValue({
+      response: { data: { message: 'サーバーエラー' } },
+    });
+
+    const user = userEvent.setup();
+    render(<PracticeList />);
+    await openSessionModal(user);
+
+    // 「隣室を予約」ボタンをクリック
+    await user.click(screen.getByText('隣室を予約'));
+
+    // エラーalertが表示される
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith(
+        expect.stringContaining('サーバーエラー')
+      );
+    });
+
+    // ボタンは「隣室を予約」のまま
+    expect(screen.getByText('隣室を予約')).toBeInTheDocument();
+    expect(screen.queryByText('会場を拡張')).not.toBeInTheDocument();
+    expect(screen.queryByText('予約完了を報告')).not.toBeInTheDocument();
+  });
+
+  it('ページリロード時: reservationConfirmedAtがある場合は会場を拡張ボタンが表示される', async () => {
+    // getByIdが予約確認済みデータを返す
+    practiceAPI.getById.mockResolvedValue({
+      data: { ...sessionWithAdjacentRoom, reservationConfirmedAt: '2026-04-12T10:00:00' },
+    });
+
+    const user = userEvent.setup();
+    render(<PracticeList />);
+
+    // カレンダーの12日をクリック
+    const dayCell = await screen.findByText('12');
+    await user.click(dayCell);
+
+    // 初期表示から「会場を拡張」ボタンが表示されている（予約確認済みのため）
+    await waitFor(() => {
+      expect(screen.getByText('会場を拡張')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('隣室を予約')).not.toBeInTheDocument();
+  });
+});

--- a/karuta-tracker-ui/src/pages/practice/PracticeList.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeList.jsx
@@ -220,6 +220,10 @@ const PracticeList = () => {
         // 個別に詳細取得（試合別参加者を含むエンリッチメント済みデータ）
         const response = await practiceAPI.getById(session.id);
         setSelectedSession(response.data);
+        // サーバー側の予約確認状態を復元
+        if (response.data.reservationConfirmedAt) {
+          setReservationReady(prev => ({ ...prev, [session.id]: true }));
+        }
         // 全試合をデフォルトで開いた状態にする
         if (response.data.matchParticipants) {
           const allExpanded = {};
@@ -251,20 +255,32 @@ const PracticeList = () => {
     setReservationLoading(true);
     try {
       await kaderuAPI.openReserve(adjacentRoomName, sessionDate);
+      // サーバー側に予約確認を記録
+      await practiceAPI.confirmReservation(sessionId);
       setReservationReady(prev => ({ ...prev, [sessionId]: true }));
       alert('予約画面を開きました。利用目的を入力し予約を完了してください。\n予約完了後に「会場を拡張」ボタンを押してください。');
     } catch (err) {
       const errorCode = err.response?.data?.errorCode;
       if (errorCode === 'DISABLED') {
-        const confirmed = window.confirm(
-          '自動予約機能は現在利用できません。\nかでる2・7のサイトで直接予約を行ってください。\n\n予約が完了しましたか？'
-        );
-        if (confirmed) {
-          setReservationReady(prev => ({ ...prev, [sessionId]: true }));
-        }
+        alert('自動予約機能は現在利用できません。\nかでる2・7のサイトで直接予約を行ってください。\n予約完了後に「予約完了を報告」ボタンを押してください。');
+        setReservationReady(prev => ({ ...prev, [sessionId]: 'manual_pending' }));
       } else {
         alert('予約画面の表示に失敗しました: ' + (err.response?.data?.message || err.message));
       }
+    } finally {
+      setReservationLoading(false);
+    }
+  };
+
+  // 手動予約完了を報告（DISABLED時の明示的な確認フロー）
+  const handleManualReservationConfirm = async (sessionId) => {
+    setReservationLoading(true);
+    try {
+      await practiceAPI.confirmReservation(sessionId);
+      setReservationReady(prev => ({ ...prev, [sessionId]: true }));
+    } catch (err) {
+      console.error('Error confirming reservation:', err);
+      alert('予約完了の記録に失敗しました');
     } finally {
       setReservationLoading(false);
     }
@@ -578,7 +594,7 @@ const PracticeList = () => {
                             : '利用不可'}
                         </span>
                         {selectedSession.adjacentRoomStatus.available && (isSuperAdmin(currentPlayer) || isAdmin(currentPlayer)) && (
-                          reservationReady[selectedSession.id] ? (
+                          reservationReady[selectedSession.id] === true ? (
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
@@ -587,6 +603,17 @@ const PracticeList = () => {
                               className="text-xs px-2 py-0.5 bg-[#4a6b5a] text-white rounded hover:bg-[#3d5a4b] transition-colors"
                             >
                               会場を拡張
+                            </button>
+                          ) : reservationReady[selectedSession.id] === 'manual_pending' ? (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleManualReservationConfirm(selectedSession.id);
+                              }}
+                              disabled={reservationLoading}
+                              className="text-xs px-2 py-0.5 bg-amber-600 text-white rounded hover:bg-amber-700 transition-colors disabled:opacity-50"
+                            >
+                              {reservationLoading ? '処理中...' : '予約完了を報告'}
                             </button>
                           ) : (
                             <button

--- a/karuta-tracker-ui/src/pages/practice/PracticeList.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeList.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { practiceAPI, lotteryAPI } from '../../api';
 import { organizationAPI } from '../../api/organizations';
+import kaderuAPI from '../../api/kaderu';
 import { isSuperAdmin, isAdmin } from '../../utils/auth';
 import { X, ChevronLeft, ChevronRight, CalendarCheck, RotateCcw, XCircle, Bell } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
@@ -30,6 +31,8 @@ const PracticeList = () => {
   const [editingMatchNumber, setEditingMatchNumber] = useState(null); // 編集中の試合番号
   const [showYearMonthPicker, setShowYearMonthPicker] = useState(false); // 年月ピッカー表示
   const [orgMap, setOrgMap] = useState({}); // 団体ID → 団体情報マップ
+  const [reservationReady, setReservationReady] = useState({}); // 隣室予約済みフラグ {sessionId: true}
+  const [reservationLoading, setReservationLoading] = useState(false); // 予約処理中フラグ
 
   // StrictMode重複呼び出し防止用
   const fetchingRef = useRef(false);
@@ -243,7 +246,31 @@ const PracticeList = () => {
     setExpandedMatches({}); // アコーディオンの状態をリセット
   };
 
-  // 会場拡張
+  // 隣室を予約（かでる2・7の予約画面を開く）
+  const handleReserveAdjacentRoom = async (sessionId, adjacentRoomName, sessionDate) => {
+    setReservationLoading(true);
+    try {
+      await kaderuAPI.openReserve(adjacentRoomName, sessionDate);
+      setReservationReady(prev => ({ ...prev, [sessionId]: true }));
+      alert('予約画面を開きました。利用目的を入力し予約を完了してください。\n予約完了後に「会場を拡張」ボタンを押してください。');
+    } catch (err) {
+      const errorCode = err.response?.data?.errorCode;
+      if (errorCode === 'DISABLED') {
+        const confirmed = window.confirm(
+          '自動予約機能は現在利用できません。\nかでる2・7のサイトで直接予約を行ってください。\n\n予約が完了しましたか？'
+        );
+        if (confirmed) {
+          setReservationReady(prev => ({ ...prev, [sessionId]: true }));
+        }
+      } else {
+        alert('予約画面の表示に失敗しました: ' + (err.response?.data?.message || err.message));
+      }
+    } finally {
+      setReservationLoading(false);
+    }
+  };
+
+  // 会場拡張（予約完了後にDBを更新）
   const handleExpandVenue = async (sessionId, venueName, adjacentRoomStatus) => {
     const confirmed = window.confirm(
       `${venueName}を${adjacentRoomStatus.expandedVenueName}に拡張しますか？\n定員が${selectedSession.capacity}→${adjacentRoomStatus.expandedCapacity}に変更されます`
@@ -252,7 +279,11 @@ const PracticeList = () => {
     try {
       const response = await practiceAPI.expandVenue(sessionId);
       setSelectedSession(response.data);
-      // セッション一覧も更新
+      setReservationReady(prev => {
+        const next = { ...prev };
+        delete next[sessionId];
+        return next;
+      });
       fetchSessions();
     } catch (err) {
       console.error('Error expanding venue:', err);
@@ -547,15 +578,32 @@ const PracticeList = () => {
                             : '利用不可'}
                         </span>
                         {selectedSession.adjacentRoomStatus.available && (isSuperAdmin(currentPlayer) || isAdmin(currentPlayer)) && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleExpandVenue(selectedSession.id, selectedSession.venueName, selectedSession.adjacentRoomStatus);
-                            }}
-                            className="text-xs px-2 py-0.5 bg-[#4a6b5a] text-white rounded hover:bg-[#3d5a4b] transition-colors"
-                          >
-                            会場を拡張
-                          </button>
+                          reservationReady[selectedSession.id] ? (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleExpandVenue(selectedSession.id, selectedSession.venueName, selectedSession.adjacentRoomStatus);
+                              }}
+                              className="text-xs px-2 py-0.5 bg-[#4a6b5a] text-white rounded hover:bg-[#3d5a4b] transition-colors"
+                            >
+                              会場を拡張
+                            </button>
+                          ) : (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleReserveAdjacentRoom(
+                                  selectedSession.id,
+                                  selectedSession.adjacentRoomStatus.adjacentRoomName,
+                                  selectedSession.sessionDate
+                                );
+                              }}
+                              disabled={reservationLoading}
+                              className="text-xs px-2 py-0.5 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors disabled:opacity-50"
+                            >
+                              {reservationLoading ? '処理中...' : '隣室を予約'}
+                            </button>
+                          )
                         )}
                       </div>
                     )}

--- a/karuta-tracker-ui/src/pages/practice/PracticeList.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeList.jsx
@@ -255,10 +255,9 @@ const PracticeList = () => {
     setReservationLoading(true);
     try {
       await kaderuAPI.openReserve(adjacentRoomName, sessionDate);
-      // サーバー側に予約確認を記録
-      await practiceAPI.confirmReservation(sessionId);
-      setReservationReady(prev => ({ ...prev, [sessionId]: true }));
-      alert('予約画面を開きました。利用目的を入力し予約を完了してください。\n予約完了後に「会場を拡張」ボタンを押してください。');
+      // 予約画面を開いただけでは確認済みにしない。ユーザーが予約完了を明示的に報告するまで待機
+      setReservationReady(prev => ({ ...prev, [sessionId]: 'manual_pending' }));
+      alert('予約画面を開きました。利用目的を入力し予約を完了してください。\n予約完了後に「予約完了を報告」ボタンを押してください。');
     } catch (err) {
       const errorCode = err.response?.data?.errorCode;
       if (errorCode === 'DISABLED') {

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/PracticeSessionController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/PracticeSessionController.java
@@ -422,6 +422,28 @@ public class PracticeSessionController {
     }
 
     /**
+     * 隣室予約完了を記録する
+     *
+     * @param id セッションID
+     * @return 更新後のセッション情報
+     */
+    @PostMapping("/{id}/confirm-reservation")
+    @RequireRole({Role.SUPER_ADMIN, Role.ADMIN})
+    public ResponseEntity<PracticeSessionDto> confirmReservation(
+            @PathVariable Long id,
+            HttpServletRequest httpRequest) {
+        log.info("POST /api/practice-sessions/{}/confirm-reservation", id);
+        String role = (String) httpRequest.getAttribute("currentUserRole");
+        Long adminOrgId = (Long) httpRequest.getAttribute("adminOrganizationId");
+        practiceSessionService.checkAdminScope(id, role, adminOrgId);
+
+        Long currentUserId = (Long) httpRequest.getAttribute("currentUserId");
+        adjacentRoomService.confirmReservation(id, currentUserId);
+        PracticeSessionDto updatedSession = practiceSessionService.findById(id);
+        return ResponseEntity.ok(updatedSession);
+    }
+
+    /**
      * 会場を拡張（隣室と合わせた大部屋に変更）
      *
      * @param id セッションID

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/PracticeSessionDto.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/PracticeSessionDto.java
@@ -48,6 +48,9 @@ public class PracticeSessionDto {
     // 隣室空き状況
     private AdjacentRoomStatusDto adjacentRoomStatus;
 
+    // 隣室予約確認日時
+    private LocalDateTime reservationConfirmedAt;
+
     // 抽選関連フィールド
     private Boolean lotteryExecuted;  // 抽選実行済みか
     private java.util.Map<Integer, MatchLotteryInfo> matchLotteryInfo;  // 試合番号ごとの抽選情報
@@ -98,6 +101,7 @@ public class PracticeSessionDto {
                 .updatedBy(session.getUpdatedBy())
                 .createdAt(session.getCreatedAt())
                 .updatedAt(session.getUpdatedAt())
+                .reservationConfirmedAt(session.getReservationConfirmedAt())
                 .build();
     }
 }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/PracticeSession.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/PracticeSession.java
@@ -102,6 +102,12 @@ public class PracticeSession {
     private LocalDateTime updatedAt;
 
     /**
+     * 隣室予約確認日時（予約ステップ完了時にセットされる）
+     */
+    @Column(name = "reservation_confirmed_at")
+    private LocalDateTime reservationConfirmedAt;
+
+    /**
      * エンティティ保存前の処理
      */
     @PrePersist

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.karuta.matchtracker.util.JstDateTimeUtil;
+
 import java.time.LocalDate;
 
 /**
@@ -70,6 +72,30 @@ public class AdjacentRoomService {
     }
 
     /**
+     * 隣室予約完了を記録する
+     *
+     * @param sessionId セッションID
+     * @param currentUserId 操作ユーザーID
+     */
+    @Transactional
+    public void confirmReservation(Long sessionId, Long currentUserId) {
+        PracticeSession session = practiceSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResourceNotFoundException("PracticeSession", sessionId));
+
+        Long currentVenueId = session.getVenueId();
+        if (!AdjacentRoomConfig.isKaderuRoom(currentVenueId)) {
+            throw new IllegalStateException("この会場は隣室予約の対象外です");
+        }
+
+        session.setReservationConfirmedAt(JstDateTimeUtil.now());
+        session.setUpdatedBy(currentUserId);
+        practiceSessionRepository.save(session);
+
+        log.info("Reservation confirmed for session {}: venueId={}, confirmedBy={}",
+                sessionId, currentVenueId, currentUserId);
+    }
+
+    /**
      * 会場を拡張する（隣室と合わせた大部屋に変更）
      *
      * @param sessionId セッションID
@@ -83,6 +109,11 @@ public class AdjacentRoomService {
         Long currentVenueId = session.getVenueId();
         if (!AdjacentRoomConfig.isKaderuRoom(currentVenueId)) {
             throw new IllegalStateException("この会場は拡張できません");
+        }
+
+        // 予約ステップの完了をサーバー側で検証
+        if (session.getReservationConfirmedAt() == null) {
+            throw new IllegalStateException("隣室の予約が確認されていません。先に予約を完了してください");
         }
 
         // 隣室の空き状況をサーバー側で再検証
@@ -99,6 +130,7 @@ public class AdjacentRoomService {
 
         session.setVenueId(expandedVenueId);
         session.setCapacity(expandedVenue.getCapacity());
+        session.setReservationConfirmedAt(null); // 予約確認状態をクリア
         session.setUpdatedBy(currentUserId);
         practiceSessionRepository.save(session);
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/PracticeSessionControllerTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/PracticeSessionControllerTest.java
@@ -250,6 +250,52 @@ class PracticeSessionControllerTest {
         verify(practiceSessionService).updateTotalMatches(1L, -1);
     }
 
+    // ========== 隣室予約確認 ==========
+
+    @Test
+    @DisplayName("POST /api/practice-sessions/{id}/confirm-reservation - ADMIN成功")
+    void testConfirmReservation() throws Exception {
+        // Given
+        doNothing().when(adjacentRoomService).confirmReservation(eq(1L), any());
+        when(practiceSessionService.findById(1L)).thenReturn(testSessionDto);
+
+        // When & Then
+        mockMvc.perform(post("/api/practice-sessions/1/confirm-reservation")
+                        .header("X-User-Role", "ADMIN").header("X-User-Id", "1")
+                        .header("X-Admin-Organization-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1));
+
+        verify(adjacentRoomService).confirmReservation(eq(1L), any());
+    }
+
+    @Test
+    @DisplayName("POST /api/practice-sessions/{id}/confirm-reservation - PLAYERロールは403")
+    void testConfirmReservationPlayerForbidden() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/practice-sessions/1/confirm-reservation")
+                        .header("X-User-Role", "PLAYER").header("X-User-Id", "1"))
+                .andExpect(status().isForbidden());
+
+        verify(adjacentRoomService, never()).confirmReservation(any(), any());
+    }
+
+    @Test
+    @DisplayName("POST /api/practice-sessions/{id}/confirm-reservation - サービス例外時は400")
+    void testConfirmReservationServiceException() throws Exception {
+        // Given
+        doThrow(new IllegalStateException("かでる2・7の部屋ではないため、予約確認できません"))
+                .when(adjacentRoomService).confirmReservation(eq(1L), any());
+
+        // When & Then
+        mockMvc.perform(post("/api/practice-sessions/1/confirm-reservation")
+                        .header("X-User-Role", "ADMIN").header("X-User-Id", "1")
+                        .header("X-Admin-Organization-Id", "1"))
+                .andExpect(status().isBadRequest());
+
+        verify(adjacentRoomService).confirmReservation(eq(1L), any());
+    }
+
     // ========== 会場拡張 ==========
 
     @Test

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
@@ -108,11 +108,37 @@ class AdjacentRoomServiceTest {
     }
 
     @Test
-    @DisplayName("会場拡張 - 正常系")
+    @DisplayName("予約確認 - 正常系")
+    void confirmReservation_success() {
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).venueId(3L).capacity(14).build();
+        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
+        when(practiceSessionRepository.save(any())).thenReturn(session);
+
+        adjacentRoomService.confirmReservation(1L, 100L);
+
+        assertNotNull(session.getReservationConfirmedAt());
+        assertEquals(100L, session.getUpdatedBy());
+        verify(practiceSessionRepository).save(session);
+    }
+
+    @Test
+    @DisplayName("予約確認 - かでる和室でないVenueはエラー")
+    void confirmReservation_nonKaderu() {
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).venueId(1L).capacity(20).build();
+        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
+
+        assertThrows(IllegalStateException.class, () -> adjacentRoomService.confirmReservation(1L, 100L));
+    }
+
+    @Test
+    @DisplayName("会場拡張 - 正常系（予約確認済み）")
     void expandVenue_success() {
         LocalDate date = LocalDate.of(2026, 4, 12);
         PracticeSession session = PracticeSession.builder()
-                .id(1L).venueId(3L).capacity(14).sessionDate(date).build();
+                .id(1L).venueId(3L).capacity(14).sessionDate(date)
+                .reservationConfirmedAt(java.time.LocalDateTime.of(2026, 4, 12, 10, 0)).build();
         Venue expandedVenue = Venue.builder().id(7L).name("すずらん・はまなす").capacity(24).build();
         RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
                 .roomName("はまなす").targetDate(date).timeSlot("evening").status("○").build();
@@ -128,7 +154,23 @@ class AdjacentRoomServiceTest {
         assertEquals(7L, session.getVenueId());
         assertEquals(24, session.getCapacity());
         assertEquals(100L, session.getUpdatedBy());
+        assertNull(session.getReservationConfirmedAt()); // 拡張後にクリアされる
         verify(practiceSessionRepository).save(session);
+    }
+
+    @Test
+    @DisplayName("会場拡張 - 予約未確認の場合はエラー")
+    void expandVenue_reservationNotConfirmed() {
+        LocalDate date = LocalDate.of(2026, 4, 12);
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).venueId(3L).capacity(14).sessionDate(date)
+                .reservationConfirmedAt(null).build();
+        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> adjacentRoomService.expandVenue(1L, 100L));
+        assertEquals("隣室の予約が確認されていません。先に予約を完了してください", ex.getMessage());
+        verify(practiceSessionRepository, never()).save(any());
     }
 
     @Test
@@ -154,7 +196,8 @@ class AdjacentRoomServiceTest {
     void expandVenue_adjacentRoomNotAvailable() {
         LocalDate date = LocalDate.of(2026, 4, 12);
         PracticeSession session = PracticeSession.builder()
-                .id(1L).venueId(3L).capacity(14).sessionDate(date).build();
+                .id(1L).venueId(3L).capacity(14).sessionDate(date)
+                .reservationConfirmedAt(java.time.LocalDateTime.of(2026, 4, 12, 10, 0)).build();
         RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
                 .roomName("はまなす").targetDate(date).timeSlot("evening").status("×").build();
 
@@ -173,7 +216,8 @@ class AdjacentRoomServiceTest {
     void expandVenue_adjacentRoomUnknown() {
         LocalDate date = LocalDate.of(2026, 4, 12);
         PracticeSession session = PracticeSession.builder()
-                .id(1L).venueId(3L).capacity(14).sessionDate(date).build();
+                .id(1L).venueId(3L).capacity(14).sessionDate(date)
+                .reservationConfirmedAt(java.time.LocalDateTime.of(2026, 4, 12, 10, 0)).build();
 
         when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
         when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))


### PR DESCRIPTION
## Summary
- 「会場を拡張」ボタンの前に「隣室を予約」ステップを追加
- 予約完了後にのみ「会場を拡張」ボタンが表示されるよう変更
- かでる予約機能無効時（本番環境）は手動予約の確認ダイアログで対応

## Test plan
- [ ] 隣室空きのセッションで「隣室を予約」ボタンが表示されることを確認
- [ ] 「隣室を予約」クリック後に「会場を拡張」ボタンに切り替わることを確認
- [ ] kaderu無効環境で確認ダイアログが表示されることを確認
- [ ] 「会場を拡張」で従来通りDB更新されることを確認
- [ ] 一般PLAYERにはボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)