### PR TITLE
fix: 空き枠通知(SAME_DAY_VACANCY)の重複送信を防止

### DIFF
--- a/database/add_line_message_log_dedupe_key.sql
+++ b/database/add_line_message_log_dedupe_key.sql
@@ -5,3 +5,9 @@ ALTER TABLE line_message_log ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(100);
 
 CREATE INDEX IF NOT EXISTS idx_lml_dedupe
     ON line_message_log (player_id, notification_type, dedupe_key, sent_at);
+
+-- Partial unique index: prevent duplicate SUCCESS logs for the same player+type+dedupeKey per day.
+-- Acts as a DB-level safety net against race conditions in concurrent duplicate checks.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_lml_dedupe_daily_unique
+    ON line_message_log (player_id, notification_type, dedupe_key, (sent_at::date))
+    WHERE status = 'SUCCESS' AND dedupe_key IS NOT NULL;

--- a/database/add_line_message_log_dedupe_key.sql
+++ b/database/add_line_message_log_dedupe_key.sql
@@ -6,9 +6,11 @@ ALTER TABLE line_message_log ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(100);
 CREATE INDEX IF NOT EXISTS idx_lml_dedupe
     ON line_message_log (player_id, notification_type, dedupe_key, sent_at);
 
--- Partial unique index: prevent duplicate SUCCESS logs for the same player+type+dedupeKey per day.
+-- Partial unique index: prevent duplicate SUCCESS/RESERVED logs for the same player+type+dedupeKey per day.
 -- Acts as a DB-level safety net against race conditions in concurrent duplicate checks.
+-- RESERVED is included to prevent concurrent processes from both acquiring send rights.
 -- NOTE: sent_at is stored in JST (via JstDateTimeUtil.now()), so sent_at::date yields the JST date.
-CREATE UNIQUE INDEX IF NOT EXISTS idx_lml_dedupe_daily_unique
+DROP INDEX IF EXISTS idx_lml_dedupe_daily_unique;
+CREATE UNIQUE INDEX idx_lml_dedupe_daily_unique
     ON line_message_log (player_id, notification_type, dedupe_key, (sent_at::date))
-    WHERE status = 'SUCCESS' AND dedupe_key IS NOT NULL;
+    WHERE status IN ('SUCCESS', 'RESERVED') AND dedupe_key IS NOT NULL;

--- a/database/add_line_message_log_dedupe_key.sql
+++ b/database/add_line_message_log_dedupe_key.sql
@@ -1,0 +1,7 @@
+-- Add dedupe_key column to line_message_log for session-level duplicate prevention.
+-- Without this column, the duplicate check only considers player+type+date,
+-- which suppresses notifications for different sessions on the same day.
+ALTER TABLE line_message_log ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(100);
+
+CREATE INDEX IF NOT EXISTS idx_lml_dedupe
+    ON line_message_log (player_id, notification_type, dedupe_key, sent_at);

--- a/database/add_line_message_log_dedupe_key.sql
+++ b/database/add_line_message_log_dedupe_key.sql
@@ -8,6 +8,7 @@ CREATE INDEX IF NOT EXISTS idx_lml_dedupe
 
 -- Partial unique index: prevent duplicate SUCCESS logs for the same player+type+dedupeKey per day.
 -- Acts as a DB-level safety net against race conditions in concurrent duplicate checks.
+-- NOTE: sent_at is stored in JST (via JstDateTimeUtil.now()), so sent_at::date yields the JST date.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_lml_dedupe_daily_unique
     ON line_message_log (player_id, notification_type, dedupe_key, (sent_at::date))
     WHERE status = 'SUCCESS' AND dedupe_key IS NOT NULL;

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -667,14 +667,28 @@ Entity Layer (JPA Entity)
 | player_id | BIGINT | NOT NULL, FK → players.id | プレイヤーID |
 | notification_type | VARCHAR(30) | NOT NULL | 通知種別 |
 | message_content | TEXT | NOT NULL | 送信メッセージ内容 |
-| status | VARCHAR(20) | NOT NULL | SUCCESS / FAILED / SKIPPED |
+| status | VARCHAR(20) | NOT NULL | SUCCESS / FAILED / SKIPPED / RESERVED |
 | error_message | TEXT | | 失敗時のエラー内容 |
+| dedupe_key | VARCHAR(100) | | 重複排除キー（セッションID等） |
 | sent_at | DATETIME | NOT NULL | 送信日時 |
 
 **インデックス**:
 - `idx_lml_channel` (line_channel_id)
 - `idx_lml_player` (player_id)
 - `idx_lml_type_sent` (notification_type, sent_at)
+- `idx_lml_dedupe` (player_id, notification_type, dedupe_key, sent_at)
+- `idx_lml_dedupe_daily_unique` (player_id, notification_type, dedupe_key, sent_at::date) WHERE status IN ('SUCCESS', 'RESERVED') — 部分ユニーク制約
+
+**重複送信防止フロー（原子的送信権確保方式）:**
+1. `tryAcquireSendRight`: dedupeKey付きで `RESERVED` ステータスのログをINSERT（ON CONFLICT DO NOTHING）
+2. LINE APIで送信実行
+3. 成功時: `markReservationSucceeded` で RESERVED → SUCCESS に更新
+4. 失敗時: `markReservationFailed` で RESERVED → FAILED に更新（次回リトライ可能）
+5. クラッシュ時: RESERVED が残るが SUCCESS ではないため、通知欠落を防止
+
+**dedupeKeyの粒度:**
+- 試合単位通知（sendSameDayVacancyNotification）: `sessionId:matchNumber`
+- セッション統合通知（sendConsolidatedSameDayVacancyNotification）: `sessionId`
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -684,7 +684,7 @@ Entity Layer (JPA Entity)
 2. LINE APIで送信実行
 3. 成功時: `markReservationSucceeded` で RESERVED → SUCCESS に更新
 4. 失敗時: `markReservationFailed` で RESERVED → FAILED に更新（次回リトライ可能）
-5. クラッシュ時: RESERVED が残るが SUCCESS ではないため、通知欠落を防止
+5. クラッシュ時: RESERVED が残留するため、次回送信前に `releaseStaleReservations` で10分超過のRESERVEDをFAILEDに解放し、再送信を可能にする
 
 **dedupeKeyの粒度:**
 - 試合単位通知（sendSameDayVacancyNotification）: `sessionId:matchNumber`

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1456,9 +1456,14 @@ UNIQUE制約: (player_id, organization_id)
 | player_id | BIGINT | NOT NULL, FK | players.id |
 | notification_type | VARCHAR(30) | NOT NULL | 通知種別 |
 | message_content | TEXT | NOT NULL | メッセージ内容 |
-| status | VARCHAR(20) | NOT NULL | SUCCESS/FAILED/SKIPPED |
+| status | VARCHAR(20) | NOT NULL | SUCCESS/FAILED/SKIPPED/RESERVED |
 | error_message | TEXT | — | エラー内容 |
+| dedupe_key | VARCHAR(100) | — | 重複排除キー（セッションID等） |
 | sent_at | TIMESTAMP | NOT NULL | 送信日時 |
+
+部分ユニーク制約: `(player_id, notification_type, dedupe_key, sent_at::date) WHERE status IN ('SUCCESS', 'RESERVED')` — 同一プレイヤー・通知種別・dedupeKeyの当日重複を防止
+
+**重複送信防止方式:** RESERVED → SUCCESS の2段階ステータス遷移により、送信権の原子的確保とクラッシュ耐性を両立。dedupeKeyは試合単位通知では `sessionId:matchNumber`、セッション統合通知では `sessionId` を使用。
 
 #### mentor_relationships
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/config/DataInitializer.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/config/DataInitializer.java
@@ -8,10 +8,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
- * アプリケーション起動時に初期データを投入する
+ * アプリケーション起動時に初期データを投入・検証する
  */
 @Component
 @RequiredArgsConstructor
@@ -19,10 +20,12 @@ import org.springframework.stereotype.Component;
 public class DataInitializer implements ApplicationRunner {
 
     private final LineNotificationScheduleSettingRepository scheduleSettingRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     @Override
     public void run(ApplicationArguments args) {
         initScheduleSettings();
+        validateDedupeIndex();
     }
 
     private void initScheduleSettings() {
@@ -38,5 +41,42 @@ public class DataInitializer implements ApplicationRunner {
                 log.info("初期スケジュール設定を作成しました: {}", type);
             }
         }
+    }
+
+    /**
+     * tryAcquireSendRight が依存する部分ユニークインデックス (idx_lml_dedupe_daily_unique) の存在を検証する。
+     * Hibernate ddl-auto=update ではこのインデックスは自動作成されないため、
+     * 存在しなければ自動作成を試み、それでも失敗した場合はfail-fastする。
+     */
+    private void validateDedupeIndex() {
+        try {
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_lml_dedupe_daily_unique'",
+                    Integer.class);
+            if (count != null && count > 0) {
+                log.info("dedupe インデックス検証OK: idx_lml_dedupe_daily_unique が存在します");
+                return;
+            }
+            log.warn("必須インデックス idx_lml_dedupe_daily_unique が未検出。自動作成を試みます...");
+            ensureDedupeKeyColumn();
+            jdbcTemplate.execute(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS idx_lml_dedupe_daily_unique "
+                    + "ON line_message_log (player_id, notification_type, dedupe_key, (sent_at::date)) "
+                    + "WHERE status IN ('SUCCESS', 'RESERVED') AND dedupe_key IS NOT NULL");
+            log.info("idx_lml_dedupe_daily_unique を自動作成しました");
+        } catch (Exception e) {
+            log.error("dedupe インデックスの検証/作成に失敗しました: {}", e.getMessage());
+            throw new IllegalStateException(
+                    "必須インデックス idx_lml_dedupe_daily_unique の作成に失敗しました。"
+                    + " database/add_line_message_log_dedupe_key.sql を手動で実行してください。", e);
+        }
+    }
+
+    private void ensureDedupeKeyColumn() {
+        jdbcTemplate.execute(
+                "ALTER TABLE line_message_log ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(100)");
+        jdbcTemplate.execute(
+                "CREATE INDEX IF NOT EXISTS idx_lml_dedupe "
+                + "ON line_message_log (player_id, notification_type, dedupe_key, sent_at)");
     }
 }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineMessageLog.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineMessageLog.java
@@ -85,7 +85,8 @@ public class LineMessageLog {
     public enum MessageStatus {
         SUCCESS,
         FAILED,
-        SKIPPED
+        SKIPPED,
+        RESERVED
     }
 
     @PrePersist

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineMessageLog.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineMessageLog.java
@@ -12,7 +12,8 @@ import java.time.LocalDateTime;
 @Table(name = "line_message_log", indexes = {
     @Index(name = "idx_lml_channel", columnList = "line_channel_id"),
     @Index(name = "idx_lml_player", columnList = "player_id"),
-    @Index(name = "idx_lml_type_sent", columnList = "notification_type, sent_at")
+    @Index(name = "idx_lml_type_sent", columnList = "notification_type, sent_at"),
+    @Index(name = "idx_lml_dedupe", columnList = "player_id, notification_type, dedupe_key, sent_at")
 })
 @Getter
 @Setter
@@ -50,6 +51,10 @@ public class LineMessageLog {
     /** 失敗時のエラー内容 */
     @Column(name = "error_message", columnDefinition = "TEXT")
     private String errorMessage;
+
+    /** 重複排除キー（セッションID等、通知コンテキストを識別する値） */
+    @Column(name = "dedupe_key", length = 100)
+    private String dedupeKey;
 
     /** 送信日時 */
     @Column(name = "sent_at", nullable = false)

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
@@ -116,6 +116,21 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
                               @Param("errorMessage") String errorMessage,
                               @Param("sentDate") LocalDate sentDate);
 
+    /**
+     * 指定時刻より古い RESERVED レコードを FAILED に解放する。
+     * プロセス障害等で markReservationSucceeded/Failed が実行されず RESERVED が残留した場合の回復経路。
+     * FAILED に変更することで、次回リトライ時に再度送信権を確保できるようになる。
+     * @return 更新された行数
+     */
+    @Modifying
+    @Query(value = """
+        UPDATE line_message_log
+        SET status = 'FAILED', error_message = 'RESERVED timeout - auto-released'
+        WHERE status = 'RESERVED'
+        AND sent_at < :cutoff
+        """, nativeQuery = true)
+    int releaseStaleReservations(@Param("cutoff") LocalDateTime cutoff);
+
     /** チャネルの当月送信成功数を集計 */
     @Query("""
         SELECT COUNT(l) FROM LineMessageLog l

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
@@ -53,16 +53,17 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
 
     /**
      * 原子的に送信権を確保する（INSERT ... ON CONFLICT DO NOTHING）。
-     * 同一 (player_id, notification_type, dedupe_key, 日付) で SUCCESS ログが存在しない場合のみ挿入に成功する。
+     * RESERVED ステータスで挿入し、送信成功後に markReservationSucceeded で SUCCESS に更新する。
+     * 同一 (player_id, notification_type, dedupe_key, 日付) で SUCCESS または RESERVED ログが存在する場合は挿入されない。
      * sent_at にはサービス層から JstDateTimeUtil.now() を渡し、他のJPA保存経路と時刻基準を統一する。
      * @return 挿入された行数（1=送信権確保成功、0=既に送信済み）
      */
     @Modifying
     @Query(value = """
         INSERT INTO line_message_log (line_channel_id, player_id, notification_type, message_content, status, dedupe_key, sent_at)
-        VALUES (:channelId, :playerId, CAST(:type AS VARCHAR), :message, 'SUCCESS', :dedupeKey, :sentAt)
+        VALUES (:channelId, :playerId, CAST(:type AS VARCHAR), :message, 'RESERVED', :dedupeKey, :sentAt)
         ON CONFLICT (player_id, notification_type, dedupe_key, (sent_at::date))
-        WHERE status = 'SUCCESS' AND dedupe_key IS NOT NULL
+        WHERE status IN ('SUCCESS', 'RESERVED') AND dedupe_key IS NOT NULL
         DO NOTHING
         """, nativeQuery = true)
     int tryAcquireSendRight(@Param("channelId") Long channelId,
@@ -73,8 +74,29 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
                             @Param("sentAt") LocalDateTime sentAt);
 
     /**
+     * 送信成功時に予約レコードのステータスを SUCCESS に更新する。
+     * tryAcquireSendRight で確保した RESERVED レコードを SUCCESS に変更し、
+     * 以降の重複送信を防止する。
+     * sentDate にはサービス層から JstDateTimeUtil.today() を渡し、JST日付基準で照合する。
+     */
+    @Modifying
+    @Query(value = """
+        UPDATE line_message_log
+        SET status = 'SUCCESS'
+        WHERE player_id = :playerId
+        AND notification_type = CAST(:type AS VARCHAR)
+        AND dedupe_key = :dedupeKey
+        AND status = 'RESERVED'
+        AND sent_at::date = :sentDate
+        """, nativeQuery = true)
+    int markReservationSucceeded(@Param("playerId") Long playerId,
+                                 @Param("type") String type,
+                                 @Param("dedupeKey") String dedupeKey,
+                                 @Param("sentDate") LocalDate sentDate);
+
+    /**
      * 送信失敗時に予約レコードのステータスを FAILED に更新する。
-     * tryAcquireSendRight で確保した SUCCESS レコードを FAILED に変更し、
+     * tryAcquireSendRight で確保した RESERVED レコードを FAILED に変更し、
      * 次回のリトライを可能にする。
      * sentDate にはサービス層から JstDateTimeUtil.today() を渡し、JST日付基準で照合する。
      */
@@ -85,7 +107,7 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
         WHERE player_id = :playerId
         AND notification_type = CAST(:type AS VARCHAR)
         AND dedupe_key = :dedupeKey
-        AND status = 'SUCCESS'
+        AND status = 'RESERVED'
         AND sent_at::date = :sentDate
         """, nativeQuery = true)
     int markReservationFailed(@Param("playerId") Long playerId,

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
@@ -3,6 +3,7 @@ package com.karuta.matchtracker.repository;
 import com.karuta.matchtracker.entity.LineMessageLog;
 import com.karuta.matchtracker.entity.LineMessageLog.LineNotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -48,6 +49,45 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
         @Param("dedupeKey") String dedupeKey,
         @Param("since") LocalDateTime since
     );
+
+    /**
+     * 原子的に送信権を確保する（INSERT ... ON CONFLICT DO NOTHING）。
+     * 同一 (player_id, notification_type, dedupe_key, 日付) で SUCCESS ログが存在しない場合のみ挿入に成功する。
+     * @return 挿入された行数（1=送信権確保成功、0=既に送信済み）
+     */
+    @Modifying
+    @Query(value = """
+        INSERT INTO line_message_log (line_channel_id, player_id, notification_type, message_content, status, dedupe_key, sent_at)
+        VALUES (:channelId, :playerId, CAST(:type AS VARCHAR), :message, 'SUCCESS', :dedupeKey, NOW())
+        ON CONFLICT (player_id, notification_type, dedupe_key, (sent_at::date))
+        WHERE status = 'SUCCESS' AND dedupe_key IS NOT NULL
+        DO NOTHING
+        """, nativeQuery = true)
+    int tryAcquireSendRight(@Param("channelId") Long channelId,
+                            @Param("playerId") Long playerId,
+                            @Param("type") String type,
+                            @Param("message") String message,
+                            @Param("dedupeKey") String dedupeKey);
+
+    /**
+     * 送信失敗時に予約レコードのステータスを FAILED に更新する。
+     * tryAcquireSendRight で確保した SUCCESS レコードを FAILED に変更し、
+     * 次回のリトライを可能にする。
+     */
+    @Modifying
+    @Query(value = """
+        UPDATE line_message_log
+        SET status = 'FAILED', error_message = :errorMessage
+        WHERE player_id = :playerId
+        AND notification_type = CAST(:type AS VARCHAR)
+        AND dedupe_key = :dedupeKey
+        AND status = 'SUCCESS'
+        AND sent_at::date = CURRENT_DATE
+        """, nativeQuery = true)
+    int markReservationFailed(@Param("playerId") Long playerId,
+                              @Param("type") String type,
+                              @Param("dedupeKey") String dedupeKey,
+                              @Param("errorMessage") String errorMessage);
 
     /** チャネルの当月送信成功数を集計 */
     @Query("""

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -53,12 +54,13 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
     /**
      * 原子的に送信権を確保する（INSERT ... ON CONFLICT DO NOTHING）。
      * 同一 (player_id, notification_type, dedupe_key, 日付) で SUCCESS ログが存在しない場合のみ挿入に成功する。
+     * sent_at にはサービス層から JstDateTimeUtil.now() を渡し、他のJPA保存経路と時刻基準を統一する。
      * @return 挿入された行数（1=送信権確保成功、0=既に送信済み）
      */
     @Modifying
     @Query(value = """
         INSERT INTO line_message_log (line_channel_id, player_id, notification_type, message_content, status, dedupe_key, sent_at)
-        VALUES (:channelId, :playerId, CAST(:type AS VARCHAR), :message, 'SUCCESS', :dedupeKey, NOW())
+        VALUES (:channelId, :playerId, CAST(:type AS VARCHAR), :message, 'SUCCESS', :dedupeKey, :sentAt)
         ON CONFLICT (player_id, notification_type, dedupe_key, (sent_at::date))
         WHERE status = 'SUCCESS' AND dedupe_key IS NOT NULL
         DO NOTHING
@@ -67,12 +69,14 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
                             @Param("playerId") Long playerId,
                             @Param("type") String type,
                             @Param("message") String message,
-                            @Param("dedupeKey") String dedupeKey);
+                            @Param("dedupeKey") String dedupeKey,
+                            @Param("sentAt") LocalDateTime sentAt);
 
     /**
      * 送信失敗時に予約レコードのステータスを FAILED に更新する。
      * tryAcquireSendRight で確保した SUCCESS レコードを FAILED に変更し、
      * 次回のリトライを可能にする。
+     * sentDate にはサービス層から JstDateTimeUtil.today() を渡し、JST日付基準で照合する。
      */
     @Modifying
     @Query(value = """
@@ -82,12 +86,13 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
         AND notification_type = CAST(:type AS VARCHAR)
         AND dedupe_key = :dedupeKey
         AND status = 'SUCCESS'
-        AND sent_at::date = CURRENT_DATE
+        AND sent_at::date = :sentDate
         """, nativeQuery = true)
     int markReservationFailed(@Param("playerId") Long playerId,
                               @Param("type") String type,
                               @Param("dedupeKey") String dedupeKey,
-                              @Param("errorMessage") String errorMessage);
+                              @Param("errorMessage") String errorMessage,
+                              @Param("sentDate") LocalDate sentDate);
 
     /** チャネルの当月送信成功数を集計 */
     @Query("""

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/LineMessageLogRepository.java
@@ -33,6 +33,22 @@ public interface LineMessageLogRepository extends JpaRepository<LineMessageLog, 
         @Param("since") LocalDateTime since
     );
 
+    /** 重複送信チェック（同一プレイヤー・同一種別・同一dedupeKey・指定期間内） */
+    @Query("""
+        SELECT COUNT(l) > 0 FROM LineMessageLog l
+        WHERE l.playerId = :playerId
+        AND l.notificationType = :type
+        AND l.dedupeKey = :dedupeKey
+        AND l.status = 'SUCCESS'
+        AND l.sentAt >= :since
+        """)
+    boolean existsSuccessfulSinceWithDedupeKey(
+        @Param("playerId") Long playerId,
+        @Param("type") LineNotificationType type,
+        @Param("dedupeKey") String dedupeKey,
+        @Param("since") LocalDateTime since
+    );
+
     /** チャネルの当月送信成功数を集計 */
     @Query("""
         SELECT COUNT(l) FROM LineMessageLog l

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
@@ -26,6 +26,12 @@ public class LineMessageLogService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void save(Long channelId, Long playerId, LineNotificationType type,
                      String message, MessageStatus status, String error) {
+        save(channelId, playerId, type, message, status, error, null);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void save(Long channelId, Long playerId, LineNotificationType type,
+                     String message, MessageStatus status, String error, String dedupeKey) {
         lineMessageLogRepository.save(LineMessageLog.builder()
                 .lineChannelId(channelId)
                 .playerId(playerId)
@@ -33,6 +39,7 @@ public class LineMessageLogService {
                 .messageContent(message)
                 .status(status)
                 .errorMessage(error)
+                .dedupeKey(dedupeKey)
                 .build());
     }
 
@@ -40,6 +47,13 @@ public class LineMessageLogService {
     public boolean existsSuccessfulSince(Long playerId, LineNotificationType type,
                                          LocalDateTime since) {
         return lineMessageLogRepository.existsSuccessfulSince(playerId, type, since);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsSuccessfulSince(Long playerId, LineNotificationType type,
+                                         String dedupeKey, LocalDateTime since) {
+        return lineMessageLogRepository.existsSuccessfulSinceWithDedupeKey(
+                playerId, type, dedupeKey, since);
     }
 }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
@@ -70,8 +70,19 @@ public class LineMessageLogService {
     }
 
     /**
+     * tryAcquireSendRight で確保した予約レコードを SUCCESS に変更する。
+     * RESERVED → SUCCESS への変更により、送信完了を確定し重複送信を防止する。
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markReservationSucceeded(Long playerId, LineNotificationType type,
+                                          String dedupeKey) {
+        lineMessageLogRepository.markReservationSucceeded(
+                playerId, type.name(), dedupeKey, JstDateTimeUtil.today());
+    }
+
+    /**
      * tryAcquireSendRight で確保した予約レコードを FAILED に変更する。
-     * SUCCESS → FAILED への変更により、次回リトライ時に再度送信権を確保できるようになる。
+     * RESERVED → FAILED への変更により、次回リトライ時に再度送信権を確保できるようになる。
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markReservationFailed(Long playerId, LineNotificationType type,

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 /**
  * LINE message log persistence service.
  *
@@ -32,6 +34,12 @@ public class LineMessageLogService {
                 .status(status)
                 .errorMessage(error)
                 .build());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsSuccessfulSince(Long playerId, LineNotificationType type,
+                                         LocalDateTime since) {
+        return lineMessageLogRepository.existsSuccessfulSince(playerId, type, since);
     }
 }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
@@ -55,5 +55,28 @@ public class LineMessageLogService {
         return lineMessageLogRepository.existsSuccessfulSinceWithDedupeKey(
                 playerId, type, dedupeKey, since);
     }
+
+    /**
+     * 原子的に送信権を確保する。
+     * INSERT ... ON CONFLICT DO NOTHING により、同一キーで最初にINSERTできた処理のみがtrueを返す。
+     * これにより並行実行時の二重送信を防止する。
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean tryAcquireSendRight(Long channelId, Long playerId, LineNotificationType type,
+                                       String message, String dedupeKey) {
+        return lineMessageLogRepository.tryAcquireSendRight(
+                channelId, playerId, type.name(), message, dedupeKey) > 0;
+    }
+
+    /**
+     * tryAcquireSendRight で確保した予約レコードを FAILED に変更する。
+     * SUCCESS → FAILED への変更により、次回リトライ時に再度送信権を確保できるようになる。
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markReservationFailed(Long playerId, LineNotificationType type,
+                                      String dedupeKey, String errorMessage) {
+        lineMessageLogRepository.markReservationFailed(
+                playerId, type.name(), dedupeKey, errorMessage);
+    }
 }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
@@ -72,23 +72,35 @@ public class LineMessageLogService {
     /**
      * tryAcquireSendRight で確保した予約レコードを SUCCESS に変更する。
      * RESERVED → SUCCESS への変更により、送信完了を確定し重複送信を防止する。
+     * @return 更新された行数（0の場合は不整合の可能性あり）
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markReservationSucceeded(Long playerId, LineNotificationType type,
-                                          String dedupeKey) {
-        lineMessageLogRepository.markReservationSucceeded(
+    public int markReservationSucceeded(Long playerId, LineNotificationType type,
+                                         String dedupeKey) {
+        return lineMessageLogRepository.markReservationSucceeded(
                 playerId, type.name(), dedupeKey, JstDateTimeUtil.today());
     }
 
     /**
      * tryAcquireSendRight で確保した予約レコードを FAILED に変更する。
      * RESERVED → FAILED への変更により、次回リトライ時に再度送信権を確保できるようになる。
+     * @return 更新された行数（0の場合は不整合の可能性あり）
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markReservationFailed(Long playerId, LineNotificationType type,
+    public int markReservationFailed(Long playerId, LineNotificationType type,
                                       String dedupeKey, String errorMessage) {
-        lineMessageLogRepository.markReservationFailed(
+        return lineMessageLogRepository.markReservationFailed(
                 playerId, type.name(), dedupeKey, errorMessage, JstDateTimeUtil.today());
+    }
+
+    /**
+     * 指定時刻より古い RESERVED レコードを FAILED に解放する。
+     * プロセス障害等で RESERVED が残留した場合の回復経路。
+     * @return 解放された行数
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int releaseStaleReservations(LocalDateTime cutoff) {
+        return lineMessageLogRepository.releaseStaleReservations(cutoff);
     }
 }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineMessageLogService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.karuta.matchtracker.util.JstDateTimeUtil;
 import java.time.LocalDateTime;
 
 /**
@@ -65,7 +66,7 @@ public class LineMessageLogService {
     public boolean tryAcquireSendRight(Long channelId, Long playerId, LineNotificationType type,
                                        String message, String dedupeKey) {
         return lineMessageLogRepository.tryAcquireSendRight(
-                channelId, playerId, type.name(), message, dedupeKey) > 0;
+                channelId, playerId, type.name(), message, dedupeKey, JstDateTimeUtil.now()) > 0;
     }
 
     /**
@@ -76,7 +77,7 @@ public class LineMessageLogService {
     public void markReservationFailed(Long playerId, LineNotificationType type,
                                       String dedupeKey, String errorMessage) {
         lineMessageLogRepository.markReservationFailed(
-                playerId, type.name(), dedupeKey, errorMessage);
+                playerId, type.name(), dedupeKey, errorMessage, JstDateTimeUtil.today());
     }
 }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1057,12 +1057,18 @@ public class LineNotificationService {
      */
     private SendResult handleSendResult(boolean success, LineChannel channel, Long playerId,
                                          LineNotificationType notificationType, String messageForLog) {
+        return handleSendResult(success, channel, playerId, notificationType, messageForLog, null);
+    }
+
+    private SendResult handleSendResult(boolean success, LineChannel channel, Long playerId,
+                                         LineNotificationType notificationType, String messageForLog,
+                                         String dedupeKey) {
         if (success) {
-            logMessage(channel.getId(), playerId, notificationType, messageForLog, MessageStatus.SUCCESS, null);
+            logMessage(channel.getId(), playerId, notificationType, messageForLog, MessageStatus.SUCCESS, null, dedupeKey);
             return SendResult.SUCCESS;
         } else {
             logMessage(channel.getId(), playerId, notificationType, messageForLog,
-                MessageStatus.FAILED, "LINE API送信失敗");
+                MessageStatus.FAILED, "LINE API送信失敗", dedupeKey);
             return SendResult.FAILED;
         }
     }
@@ -1575,12 +1581,13 @@ public class LineNotificationService {
         if (recipientIds.isEmpty()) return;
 
         int sentCount = 0;
-        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+        LocalDateTime todayStart = JstDateTimeUtil.today().atStartOfDay();
+        String dedupeKey = String.valueOf(session.getId());
 
         for (Long playerId : recipientIds) {
-            // 当日中に同じプレイヤーへ送信済みならスキップ
+            // 当日中に同じプレイヤー・同じセッションへ送信済みならスキップ
             if (lineMessageLogService.existsSuccessfulSince(
-                    playerId, LineNotificationType.SAME_DAY_VACANCY, todayStart)) {
+                    playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, todayStart)) {
                 continue;
             }
 
@@ -1606,7 +1613,7 @@ public class LineNotificationService {
                     sessionLabel, playerVacancies, session.getId(), true);
 
             try {
-                sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex);
+                sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex, dedupeKey);
                 sentCount++;
             } catch (Exception e) {
                 log.error("Failed to send consolidated vacancy notification to player {}: {}", playerId, e.getMessage());
@@ -2109,6 +2116,12 @@ public class LineNotificationService {
      */
     public SendResult sendFlexToPlayer(Long playerId, LineNotificationType notificationType,
                                         String altText, Map<String, Object> flexContents) {
+        return sendFlexToPlayer(playerId, notificationType, altText, flexContents, null);
+    }
+
+    public SendResult sendFlexToPlayer(Long playerId, LineNotificationType notificationType,
+                                        String altText, Map<String, Object> flexContents,
+                                        String dedupeKey) {
         ResolvedChannel resolved = resolveChannel(playerId, notificationType, altText);
         if (resolved == null) {
             return SendResult.SKIPPED;
@@ -2117,7 +2130,7 @@ public class LineNotificationService {
         boolean success = lineMessagingService.sendPushFlexMessage(
             resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flexContents);
 
-        return handleSendResult(success, resolved.channel(), playerId, notificationType, altText);
+        return handleSendResult(success, resolved.channel(), playerId, notificationType, altText, dedupeKey);
     }
 
     /**
@@ -2172,8 +2185,13 @@ public class LineNotificationService {
 
     private void logMessage(Long channelId, Long playerId, LineNotificationType type,
                            String message, MessageStatus status, String error) {
+        logMessage(channelId, playerId, type, message, status, error, null);
+    }
+
+    private void logMessage(Long channelId, Long playerId, LineNotificationType type,
+                           String message, MessageStatus status, String error, String dedupeKey) {
         try {
-            lineMessageLogService.save(channelId, playerId, type, message, status, error);
+            lineMessageLogService.save(channelId, playerId, type, message, status, error, dedupeKey);
         } catch (Exception e) {
             log.error("Failed to save LINE message log: {}", e.getMessage());
         }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -70,7 +70,36 @@ public class LineNotificationService {
 
     private static final int MONTHLY_MESSAGE_LIMIT = 200;
     private static final int RESERVED_TIMEOUT_MINUTES = 10;
+    private static final int MARK_SUCCEEDED_MAX_RETRIES = 2;
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("M月d日");
+
+    /**
+     * 送信成功後のステータス更新をリトライ付きで実行する。
+     * markReservationSucceeded が一時的なDB障害で失敗した場合、RESERVED が残留し
+     * releaseStaleReservations により FAILED に変更されると重複送信の原因になるため、
+     * リトライで成功率を高める。
+     */
+    private void markSucceededWithRetry(Long playerId, LineMessageLog.LineNotificationType type,
+                                        String dedupeKey) {
+        Exception lastException = null;
+        for (int attempt = 0; attempt <= MARK_SUCCEEDED_MAX_RETRIES; attempt++) {
+            try {
+                int updated = lineMessageLogService.markReservationSucceeded(playerId, type, dedupeKey);
+                if (updated == 0) {
+                    log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                }
+                return;
+            } catch (Exception e) {
+                lastException = e;
+                if (attempt < MARK_SUCCEEDED_MAX_RETRIES) {
+                    log.warn("markReservationSucceeded リトライ {}/{}: player={}, dedupeKey={}, error={}",
+                            attempt + 1, MARK_SUCCEEDED_MAX_RETRIES, playerId, dedupeKey, e.getMessage());
+                }
+            }
+        }
+        log.error("送信成功後のステータス更新が全リトライで失敗しました（重複送信防止のためFAILEDには変更しません）: player={}, dedupeKey={}, error={}",
+                playerId, dedupeKey, lastException != null ? lastException.getMessage() : "unknown");
+    }
 
     /**
      * セッションのラベルを生成する（例: "4月5日（中央公民館）"）
@@ -1554,20 +1583,11 @@ public class LineNotificationService {
                 failedCount++;
             }
 
-            // 送信成功後のステータス更新は別のtry-catchで行う
+            // 送信成功後のステータス更新（リトライ付き）
             // 送信済みなのにFAILEDに変更すると重複送信の原因になるため、
             // markReservationSucceededが例外を投げてもmarkReservationFailedは呼ばない
             if (sent) {
-                try {
-                    int updated = lineMessageLogService.markReservationSucceeded(
-                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
-                    if (updated == 0) {
-                        log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
-                    }
-                } catch (Exception e) {
-                    log.error("送信成功後のステータス更新に失敗しました（重複送信防止のためFAILEDには変更しません）: player={}, dedupeKey={}, error={}",
-                            playerId, dedupeKey, e.getMessage());
-                }
+                markSucceededWithRetry(playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
             }
         }
 
@@ -1719,20 +1739,11 @@ public class LineNotificationService {
                 failedCount++;
             }
 
-            // 送信成功後のステータス更新は別のtry-catchで行う
+            // 送信成功後のステータス更新（リトライ付き）
             // 送信済みなのにFAILEDに変更すると重複送信の原因になるため、
             // markReservationSucceededが例外を投げてもmarkReservationFailedは呼ばない
             if (sent) {
-                try {
-                    int updated = lineMessageLogService.markReservationSucceeded(
-                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
-                    if (updated == 0) {
-                        log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
-                    }
-                } catch (Exception e) {
-                    log.error("送信成功後のステータス更新に失敗しました（重複送信防止のためFAILEDには変更しません）: player={}, dedupeKey={}, error={}",
-                            playerId, dedupeKey, e.getMessage());
-                }
+                markSucceededWithRetry(playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
             }
         }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -1573,7 +1574,16 @@ public class LineNotificationService {
 
         if (recipientIds.isEmpty()) return;
 
+        int sentCount = 0;
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+
         for (Long playerId : recipientIds) {
+            // 当日中に同じプレイヤーへ送信済みならスキップ
+            if (lineMessageLogService.existsSuccessfulSince(
+                    playerId, LineNotificationType.SAME_DAY_VACANCY, todayStart)) {
+                continue;
+            }
+
             // プレイヤーごとに参加可能な試合のみを抽出
             Map<Integer, Integer> playerVacancies = new LinkedHashMap<>();
             for (Map.Entry<Integer, Integer> entry : vacanciesByMatch.entrySet()) {
@@ -1597,13 +1607,14 @@ public class LineNotificationService {
 
             try {
                 sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex);
+                sentCount++;
             } catch (Exception e) {
                 log.error("Failed to send consolidated vacancy notification to player {}: {}", playerId, e.getMessage());
             }
         }
 
-        log.info("Sent consolidated vacancy notification to {} players for session {} ({} matches)",
-                recipientIds.size(), session.getId(), vacanciesByMatch.size());
+        log.info("Sent consolidated vacancy notification to {} players (skipped {} already notified) for session {} ({} matches)",
+                sentCount, recipientIds.size() - sentCount, session.getId(), vacanciesByMatch.size());
     }
 
     /**

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1503,7 +1503,7 @@ public class LineNotificationService {
         int alreadyNotifiedCount = 0;
         int failedCount = 0;
         int channelSkippedCount = 0;
-        String dedupeKey = String.valueOf(session.getId());
+        String dedupeKey = session.getId() + ":" + matchNumber;
 
         for (Long playerId : recipientIds) {
             // チャネル解決（通知設定OFF・チャネル未リンク等のチェック含む）
@@ -1525,6 +1525,8 @@ public class LineNotificationService {
                 boolean success = lineMessagingService.sendPushFlexMessage(
                         resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flex);
                 if (success) {
+                    lineMessageLogService.markReservationSucceeded(
+                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
                     sentCount++;
                 } else {
                     lineMessageLogService.markReservationFailed(
@@ -1659,6 +1661,8 @@ public class LineNotificationService {
                 boolean success = lineMessagingService.sendPushFlexMessage(
                         resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flex);
                 if (success) {
+                    lineMessageLogService.markReservationSucceeded(
+                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
                     sentCount++;
                 } else {
                     lineMessageLogService.markReservationFailed(

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1500,26 +1500,47 @@ public class LineNotificationService {
         Map<String, Object> flex = buildSameDayVacancyFlex(sessionLabel, matchNumber, vacancies, session.getId(), true);
 
         int sentCount = 0;
-        LocalDateTime todayStart = JstDateTimeUtil.today().atStartOfDay();
+        int alreadyNotifiedCount = 0;
+        int failedCount = 0;
+        int channelSkippedCount = 0;
         String dedupeKey = String.valueOf(session.getId());
 
         for (Long playerId : recipientIds) {
-            // 当日中に同じプレイヤー・同じセッションへ送信済みならスキップ
-            if (lineMessageLogService.existsSuccessfulSince(
-                    playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, todayStart)) {
+            // チャネル解決（通知設定OFF・チャネル未リンク等のチェック含む）
+            ResolvedChannel resolved = resolveChannel(playerId, LineNotificationType.SAME_DAY_VACANCY, altText);
+            if (resolved == null) {
+                channelSkippedCount++;
                 continue;
             }
 
+            // 原子的に送信権を確保（INSERT ... ON CONFLICT DO NOTHING）
+            if (!lineMessageLogService.tryAcquireSendRight(
+                    resolved.channel().getId(), playerId, LineNotificationType.SAME_DAY_VACANCY, altText, dedupeKey)) {
+                alreadyNotifiedCount++;
+                continue;
+            }
+
+            // 送信権を確保できた場合のみ実際に送信
             try {
-                SendResult result = sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex, dedupeKey);
-                if (result == SendResult.SUCCESS) sentCount++;
+                boolean success = lineMessagingService.sendPushFlexMessage(
+                        resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flex);
+                if (success) {
+                    sentCount++;
+                } else {
+                    lineMessageLogService.markReservationFailed(
+                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, "LINE API送信失敗");
+                    failedCount++;
+                }
             } catch (Exception e) {
                 log.error("Failed to send vacancy notification to player {}: {}", playerId, e.getMessage());
+                lineMessageLogService.markReservationFailed(
+                        playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, e.getMessage());
+                failedCount++;
             }
         }
 
-        log.info("Sent vacancy notification to {} players (skipped {} already notified) for session {} match {} ({} vacancies)",
-                sentCount, recipientIds.size() - sentCount, session.getId(), matchNumber, vacancies);
+        log.info("Sent vacancy notification for session {} match {} ({} vacancies): sent={}, alreadyNotified={}, failed={}, channelSkipped={}",
+                session.getId(), matchNumber, vacancies, sentCount, alreadyNotifiedCount, failedCount, channelSkippedCount);
     }
 
     /**
@@ -1592,16 +1613,12 @@ public class LineNotificationService {
         if (recipientIds.isEmpty()) return;
 
         int sentCount = 0;
-        LocalDateTime todayStart = JstDateTimeUtil.today().atStartOfDay();
+        int alreadyNotifiedCount = 0;
+        int failedCount = 0;
+        int channelSkippedCount = 0;
         String dedupeKey = String.valueOf(session.getId());
 
         for (Long playerId : recipientIds) {
-            // 当日中に同じプレイヤー・同じセッションへ送信済みならスキップ
-            if (lineMessageLogService.existsSuccessfulSince(
-                    playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, todayStart)) {
-                continue;
-            }
-
             // プレイヤーごとに参加可能な試合のみを抽出
             Map<Integer, Integer> playerVacancies = new LinkedHashMap<>();
             for (Map.Entry<Integer, Integer> entry : vacanciesByMatch.entrySet()) {
@@ -1620,19 +1637,44 @@ public class LineNotificationService {
                     .collect(Collectors.joining(", "));
             String altText = String.format("%s 空き枠のお知らせ（%s）", sessionLabel, matchSummary);
 
+            // チャネル解決（通知設定OFF・チャネル未リンク等のチェック含む）
+            ResolvedChannel resolved = resolveChannel(playerId, LineNotificationType.SAME_DAY_VACANCY, altText);
+            if (resolved == null) {
+                channelSkippedCount++;
+                continue;
+            }
+
+            // 原子的に送信権を確保（INSERT ... ON CONFLICT DO NOTHING）
+            if (!lineMessageLogService.tryAcquireSendRight(
+                    resolved.channel().getId(), playerId, LineNotificationType.SAME_DAY_VACANCY, altText, dedupeKey)) {
+                alreadyNotifiedCount++;
+                continue;
+            }
+
             Map<String, Object> flex = buildConsolidatedSameDayVacancyFlex(
                     sessionLabel, playerVacancies, session.getId(), true);
 
+            // 送信権を確保できた場合のみ実際に送信
             try {
-                SendResult result = sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex, dedupeKey);
-                if (result == SendResult.SUCCESS) sentCount++;
+                boolean success = lineMessagingService.sendPushFlexMessage(
+                        resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flex);
+                if (success) {
+                    sentCount++;
+                } else {
+                    lineMessageLogService.markReservationFailed(
+                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, "LINE API送信失敗");
+                    failedCount++;
+                }
             } catch (Exception e) {
                 log.error("Failed to send consolidated vacancy notification to player {}: {}", playerId, e.getMessage());
+                lineMessageLogService.markReservationFailed(
+                        playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, e.getMessage());
+                failedCount++;
             }
         }
 
-        log.info("Sent consolidated vacancy notification to {} players (skipped {} already notified) for session {} ({} matches)",
-                sentCount, recipientIds.size() - sentCount, session.getId(), vacanciesByMatch.size());
+        log.info("Sent consolidated vacancy notification for session {} ({} matches): sent={}, alreadyNotified={}, failed={}, channelSkipped={}",
+                session.getId(), vacanciesByMatch.size(), sentCount, alreadyNotifiedCount, failedCount, channelSkippedCount);
     }
 
     /**

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1499,16 +1499,27 @@ public class LineNotificationService {
         String altText = String.format("%s %d試合目が%d名分空いています", sessionLabel, matchNumber, vacancies);
         Map<String, Object> flex = buildSameDayVacancyFlex(sessionLabel, matchNumber, vacancies, session.getId(), true);
 
+        int sentCount = 0;
+        LocalDateTime todayStart = JstDateTimeUtil.today().atStartOfDay();
+        String dedupeKey = String.valueOf(session.getId());
+
         for (Long playerId : recipientIds) {
+            // 当日中に同じプレイヤー・同じセッションへ送信済みならスキップ
+            if (lineMessageLogService.existsSuccessfulSince(
+                    playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, todayStart)) {
+                continue;
+            }
+
             try {
-                sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex);
+                SendResult result = sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex, dedupeKey);
+                if (result == SendResult.SUCCESS) sentCount++;
             } catch (Exception e) {
                 log.error("Failed to send vacancy notification to player {}: {}", playerId, e.getMessage());
             }
         }
 
-        log.info("Sent vacancy notification to {} players for session {} match {} ({} vacancies)",
-                recipientIds.size(), session.getId(), matchNumber, vacancies);
+        log.info("Sent vacancy notification to {} players (skipped {} already notified) for session {} match {} ({} vacancies)",
+                sentCount, recipientIds.size() - sentCount, session.getId(), matchNumber, vacancies);
     }
 
     /**
@@ -1613,8 +1624,8 @@ public class LineNotificationService {
                     sessionLabel, playerVacancies, session.getId(), true);
 
             try {
-                sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex, dedupeKey);
-                sentCount++;
+                SendResult result = sendFlexToPlayer(playerId, LineNotificationType.SAME_DAY_VACANCY, altText, flex, dedupeKey);
+                if (result == SendResult.SUCCESS) sentCount++;
             } catch (Exception e) {
                 log.error("Failed to send consolidated vacancy notification to player {}: {}", playerId, e.getMessage());
             }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -69,6 +69,7 @@ public class LineNotificationService {
     }
 
     private static final int MONTHLY_MESSAGE_LIMIT = 200;
+    private static final int RESERVED_TIMEOUT_MINUTES = 10;
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("M月d日");
 
     /**
@@ -1468,6 +1469,13 @@ public class LineNotificationService {
      * 当該セッションの非WON参加者（キャンセル本人除く）にFlex Message。
      */
     public void sendSameDayVacancyNotification(PracticeSession session, int matchNumber, Long cancelledPlayerId) {
+        // RESERVED残留の回復: タイムアウトしたRESERVEDをFAILEDに解放
+        int released = lineMessageLogService.releaseStaleReservations(
+                JstDateTimeUtil.now().minusMinutes(RESERVED_TIMEOUT_MINUTES));
+        if (released > 0) {
+            log.warn("Released {} stale RESERVED log entries (timeout={}min)", released, RESERVED_TIMEOUT_MINUTES);
+        }
+
         String sessionLabel = getSessionLabel(session);
 
         // 現在のWON数と定員から空き枠数を計算
@@ -1525,18 +1533,27 @@ public class LineNotificationService {
                 boolean success = lineMessagingService.sendPushFlexMessage(
                         resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flex);
                 if (success) {
-                    lineMessageLogService.markReservationSucceeded(
+                    int updated = lineMessageLogService.markReservationSucceeded(
                             playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
+                    if (updated == 0) {
+                        log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                    }
                     sentCount++;
                 } else {
-                    lineMessageLogService.markReservationFailed(
+                    int updated = lineMessageLogService.markReservationFailed(
                             playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, "LINE API送信失敗");
+                    if (updated == 0) {
+                        log.warn("markReservationFailed updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                    }
                     failedCount++;
                 }
             } catch (Exception e) {
                 log.error("Failed to send vacancy notification to player {}: {}", playerId, e.getMessage());
-                lineMessageLogService.markReservationFailed(
+                int updated = lineMessageLogService.markReservationFailed(
                         playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, e.getMessage());
+                if (updated == 0) {
+                    log.warn("markReservationFailed updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                }
                 failedCount++;
             }
         }
@@ -1587,6 +1604,13 @@ public class LineNotificationService {
                                                             Map<Integer, Integer> vacanciesByMatch,
                                                             Long cancelledPlayerId) {
         if (vacanciesByMatch.isEmpty()) return;
+
+        // RESERVED残留の回復: タイムアウトしたRESERVEDをFAILEDに解放
+        int released = lineMessageLogService.releaseStaleReservations(
+                JstDateTimeUtil.now().minusMinutes(RESERVED_TIMEOUT_MINUTES));
+        if (released > 0) {
+            log.warn("Released {} stale RESERVED log entries (timeout={}min)", released, RESERVED_TIMEOUT_MINUTES);
+        }
 
         String sessionLabel = getSessionLabel(session);
 
@@ -1661,18 +1685,27 @@ public class LineNotificationService {
                 boolean success = lineMessagingService.sendPushFlexMessage(
                         resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flex);
                 if (success) {
-                    lineMessageLogService.markReservationSucceeded(
+                    int updated = lineMessageLogService.markReservationSucceeded(
                             playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
+                    if (updated == 0) {
+                        log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                    }
                     sentCount++;
                 } else {
-                    lineMessageLogService.markReservationFailed(
+                    int updated = lineMessageLogService.markReservationFailed(
                             playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, "LINE API送信失敗");
+                    if (updated == 0) {
+                        log.warn("markReservationFailed updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                    }
                     failedCount++;
                 }
             } catch (Exception e) {
                 log.error("Failed to send consolidated vacancy notification to player {}: {}", playerId, e.getMessage());
-                lineMessageLogService.markReservationFailed(
+                int updated = lineMessageLogService.markReservationFailed(
                         playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey, e.getMessage());
+                if (updated == 0) {
+                    log.warn("markReservationFailed updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                }
                 failedCount++;
             }
         }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1529,15 +1529,12 @@ public class LineNotificationService {
             }
 
             // 送信権を確保できた場合のみ実際に送信
+            boolean sent = false;
             try {
                 boolean success = lineMessagingService.sendPushFlexMessage(
                         resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flex);
                 if (success) {
-                    int updated = lineMessageLogService.markReservationSucceeded(
-                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
-                    if (updated == 0) {
-                        log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
-                    }
+                    sent = true;
                     sentCount++;
                 } else {
                     int updated = lineMessageLogService.markReservationFailed(
@@ -1555,6 +1552,22 @@ public class LineNotificationService {
                     log.warn("markReservationFailed updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
                 }
                 failedCount++;
+            }
+
+            // 送信成功後のステータス更新は別のtry-catchで行う
+            // 送信済みなのにFAILEDに変更すると重複送信の原因になるため、
+            // markReservationSucceededが例外を投げてもmarkReservationFailedは呼ばない
+            if (sent) {
+                try {
+                    int updated = lineMessageLogService.markReservationSucceeded(
+                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
+                    if (updated == 0) {
+                        log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                    }
+                } catch (Exception e) {
+                    log.error("送信成功後のステータス更新に失敗しました（重複送信防止のためFAILEDには変更しません）: player={}, dedupeKey={}, error={}",
+                            playerId, dedupeKey, e.getMessage());
+                }
             }
         }
 
@@ -1681,15 +1694,12 @@ public class LineNotificationService {
                     sessionLabel, playerVacancies, session.getId(), true);
 
             // 送信権を確保できた場合のみ実際に送信
+            boolean sent = false;
             try {
                 boolean success = lineMessagingService.sendPushFlexMessage(
                         resolved.channel().getChannelAccessToken(), resolved.assignment().getLineUserId(), altText, flex);
                 if (success) {
-                    int updated = lineMessageLogService.markReservationSucceeded(
-                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
-                    if (updated == 0) {
-                        log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
-                    }
+                    sent = true;
                     sentCount++;
                 } else {
                     int updated = lineMessageLogService.markReservationFailed(
@@ -1707,6 +1717,22 @@ public class LineNotificationService {
                     log.warn("markReservationFailed updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
                 }
                 failedCount++;
+            }
+
+            // 送信成功後のステータス更新は別のtry-catchで行う
+            // 送信済みなのにFAILEDに変更すると重複送信の原因になるため、
+            // markReservationSucceededが例外を投げてもmarkReservationFailedは呼ばない
+            if (sent) {
+                try {
+                    int updated = lineMessageLogService.markReservationSucceeded(
+                            playerId, LineNotificationType.SAME_DAY_VACANCY, dedupeKey);
+                    if (updated == 0) {
+                        log.warn("markReservationSucceeded updated 0 rows: player={}, dedupeKey={}", playerId, dedupeKey);
+                    }
+                } catch (Exception e) {
+                    log.error("送信成功後のステータス更新に失敗しました（重複送信防止のためFAILEDには変更しません）: player={}, dedupeKey={}, error={}",
+                            playerId, dedupeKey, e.getMessage());
+                }
             }
         }
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -49,6 +50,8 @@ class LineNotificationServiceConsolidatedJoinTest {
     private LotteryQueryService lotteryQueryService;
     @Mock
     private VenueRepository venueRepository;
+    @Mock
+    private MentorRelationshipRepository mentorRelationshipRepository;
 
     @Spy
     @InjectMocks
@@ -58,6 +61,25 @@ class LineNotificationServiceConsolidatedJoinTest {
         return PracticeSession.builder()
                 .id(100L).sessionDate(LocalDate.of(2026, 4, 20))
                 .capacity(6).totalMatches(3).organizationId(1L).build();
+    }
+
+    private void setupChannelMocks(Long playerId) {
+        LineChannelAssignment assignment = LineChannelAssignment.builder()
+                .id(1L).lineChannelId(1L).playerId(playerId)
+                .lineUserId("U_" + playerId)
+                .channelType(ChannelType.PLAYER)
+                .status(LineChannelAssignment.AssignmentStatus.LINKED)
+                .build();
+        when(lineChannelAssignmentRepository.findByPlayerIdAndChannelTypeAndStatusIn(
+                eq(playerId), eq(ChannelType.PLAYER), anyList()))
+                .thenReturn(Optional.of(assignment));
+
+        LineChannel channel = LineChannel.builder()
+                .id(1L).channelAccessToken("test-token")
+                .status(LineChannel.ChannelStatus.LINKED)
+                .monthlyMessageCount(0)
+                .build();
+        when(lineChannelRepository.findById(1L)).thenReturn(Optional.of(channel));
     }
 
     @Nested
@@ -186,16 +208,18 @@ class LineNotificationServiceConsolidatedJoinTest {
             when(playerOrganizationRepository.findByOrganizationId(1L))
                     .thenReturn(List.of(member));
 
-            // 同一セッション・同日で送信済み → true
-            when(lineMessageLogService.existsSuccessfulSince(eq(10L),
+            setupChannelMocks(10L);
+
+            // tryAcquireSendRight が false → 同一セッション・同日で送信済み
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), eq(10L),
                     eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
-                    eq("100"), any())).thenReturn(true);
+                    anyString(), eq("100"))).thenReturn(false);
 
             lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
 
-            // スキップされるため sendFlexToPlayer は呼ばれない
-            verify(lineNotificationService, never())
-                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
+            // スキップされるため sendPushFlexMessage は呼ばれない
+            verify(lineMessagingService, never())
+                    .sendPushFlexMessage(anyString(), anyString(), anyString(), any());
         }
 
         @Test
@@ -214,25 +238,29 @@ class LineNotificationServiceConsolidatedJoinTest {
             when(playerOrganizationRepository.findByOrganizationId(1L))
                     .thenReturn(List.of(member));
 
-            // セッション100の送信済みチェック → false（まだ送っていない）
-            when(lineMessageLogService.existsSuccessfulSince(eq(10L),
-                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
-                    eq("100"), any())).thenReturn(false);
+            setupChannelMocks(10L);
 
-            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
-                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
+            // tryAcquireSendRight が true → 未送信、送信権確保成功
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    anyString(), eq("100"))).thenReturn(true);
+
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
 
             lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
 
-            // dedupeKey="100" で sendFlexToPlayer が呼ばれる
-            verify(lineNotificationService).sendFlexToPlayer(eq(10L),
+            // dedupeKey="100" で tryAcquireSendRight が呼ばれる
+            verify(lineMessageLogService).tryAcquireSendRight(anyLong(), eq(10L),
                     eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
-                    anyString(), any(), eq("100"));
+                    anyString(), eq("100"));
+            // 実際に送信が実行される
+            verify(lineMessagingService).sendPushFlexMessage(anyString(), anyString(), anyString(), any());
         }
 
         @Test
-        @DisplayName("dedupeKeyにセッションIDが含まれ、ログに保存される")
-        void dedupeKeyPassedToSendFlexToPlayer() {
+        @DisplayName("dedupeKeyにセッションIDが含まれ、tryAcquireSendRightに渡される")
+        void dedupeKeyPassedToTryAcquireSendRight() {
             PracticeSession session = createSession(); // id=100
 
             Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
@@ -246,20 +274,21 @@ class LineNotificationServiceConsolidatedJoinTest {
             when(playerOrganizationRepository.findByOrganizationId(1L))
                     .thenReturn(List.of(member));
 
-            when(lineMessageLogService.existsSuccessfulSince(eq(10L),
-                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
-                    eq("100"), any())).thenReturn(false);
+            setupChannelMocks(10L);
 
-            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
-                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), anyLong(), any(), anyString(), anyString()))
+                    .thenReturn(true);
+
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
 
             lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
 
-            // 5引数版がdedupeKey="100"で呼ばれたことを確認
+            // dedupeKey="100" で tryAcquireSendRight が呼ばれたことを確認
             ArgumentCaptor<String> dedupeCaptor = ArgumentCaptor.forClass(String.class);
-            verify(lineNotificationService).sendFlexToPlayer(eq(10L),
+            verify(lineMessageLogService).tryAcquireSendRight(anyLong(), eq(10L),
                     eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
-                    anyString(), any(), dedupeCaptor.capture());
+                    anyString(), dedupeCaptor.capture());
             assertEquals("100", dedupeCaptor.getValue());
         }
     }
@@ -291,15 +320,19 @@ class LineNotificationServiceConsolidatedJoinTest {
             when(playerOrganizationRepository.findByOrganizationId(1L))
                     .thenReturn(List.of(member));
 
-            // sendFlexToPlayerをスタブ化し、Flexペイロードをキャプチャ
-            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
-                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), anyLong(), any(), anyString(), anyString()))
+                    .thenReturn(true);
+
+            // sendPushFlexMessage をスタブ化し、Flexペイロードをキャプチャ
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
 
             lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
 
             ArgumentCaptor<Map<String, Object>> flexCaptor = ArgumentCaptor.forClass(Map.class);
-            verify(lineNotificationService).sendFlexToPlayer(eq(10L),
-                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), anyString(), flexCaptor.capture(), any());
+            verify(lineMessagingService).sendPushFlexMessage(anyString(), anyString(), anyString(), flexCaptor.capture());
 
             Map<String, Object> flex = flexCaptor.getValue();
             Map<String, Object> body = (Map<String, Object>) flex.get("body");
@@ -337,14 +370,18 @@ class LineNotificationServiceConsolidatedJoinTest {
             when(playerOrganizationRepository.findByOrganizationId(1L))
                     .thenReturn(List.of(member));
 
-            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
-                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), anyLong(), any(), anyString(), anyString()))
+                    .thenReturn(true);
+
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
 
             lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
 
             ArgumentCaptor<Map<String, Object>> flexCaptor = ArgumentCaptor.forClass(Map.class);
-            verify(lineNotificationService).sendFlexToPlayer(eq(10L),
-                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), anyString(), flexCaptor.capture(), any());
+            verify(lineMessagingService).sendPushFlexMessage(anyString(), anyString(), anyString(), flexCaptor.capture());
 
             Map<String, Object> flex = flexCaptor.getValue();
             Map<String, Object> body = (Map<String, Object>) flex.get("body");

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
@@ -441,6 +441,38 @@ class LineNotificationServiceConsolidatedJoinTest {
 
             verify(lineMessageLogService).releaseStaleReservations(any());
         }
+
+        @Test
+        @DisplayName("送信成功後にmarkReservationSucceededが例外→markReservationFailedは呼ばれない（重複送信防止）")
+        void sendSuccessThenMarkSucceededThrows_doesNotCallMarkFailed() {
+            PracticeSession session = createSession();
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    anyString(), eq("100:1"))).thenReturn(true);
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
+            // markReservationSucceeded が例外を投げる
+            when(lineMessageLogService.markReservationSucceeded(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), eq("100:1")))
+                    .thenThrow(new RuntimeException("DB connection lost"));
+
+            assertDoesNotThrow(() ->
+                    lineNotificationService.sendSameDayVacancyNotification(session, 1, null));
+
+            // markReservationFailed は呼ばれてはいけない（送信済みのためFAILEDにしない）
+            verify(lineMessageLogService, never()).markReservationFailed(anyLong(), any(), anyString(), anyString());
+        }
     }
 
     @Nested
@@ -475,6 +507,39 @@ class LineNotificationServiceConsolidatedJoinTest {
             lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
 
             verify(lineMessageLogService).releaseStaleReservations(any());
+        }
+
+        @Test
+        @DisplayName("送信成功後にmarkReservationSucceededが例外→markReservationFailedは呼ばれない（重複送信防止）")
+        void sendSuccessThenMarkSucceededThrows_doesNotCallMarkFailed() {
+            PracticeSession session = createSession();
+
+            Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
+            vacanciesByMatch.put(1, 2);
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), anyLong(), any(), anyString(), anyString()))
+                    .thenReturn(true);
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
+            // markReservationSucceeded が例外を投げる
+            when(lineMessageLogService.markReservationSucceeded(anyLong(), any(), anyString()))
+                    .thenThrow(new RuntimeException("DB connection lost"));
+
+            assertDoesNotThrow(() ->
+                    lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null));
+
+            // markReservationFailed は呼ばれてはいけない（送信済みのためFAILEDにしない）
+            verify(lineMessageLogService, never()).markReservationFailed(anyLong(), any(), anyString(), anyString());
         }
 
         @Test

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
@@ -294,6 +294,223 @@ class LineNotificationServiceConsolidatedJoinTest {
     }
 
     @Nested
+    @DisplayName("sendSameDayVacancyNotification - 重複防止・障害回復")
+    class SendSameDayVacancyNotificationTests {
+
+        @Test
+        @DisplayName("送信権確保成功→送信成功→markReservationSucceededが呼ばれる")
+        void acquireAndSendSuccess() {
+            PracticeSession session = createSession();
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    anyString(), eq("100:1"))).thenReturn(true);
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
+            when(lineMessageLogService.markReservationSucceeded(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), eq("100:1"))).thenReturn(1);
+
+            lineNotificationService.sendSameDayVacancyNotification(session, 1, null);
+
+            verify(lineMessageLogService).markReservationSucceeded(10L,
+                    LineMessageLog.LineNotificationType.SAME_DAY_VACANCY, "100:1");
+        }
+
+        @Test
+        @DisplayName("送信権確保失敗→スキップ（送信されない）")
+        void acquireFailedSkips() {
+            PracticeSession session = createSession();
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    anyString(), eq("100:1"))).thenReturn(false);
+
+            lineNotificationService.sendSameDayVacancyNotification(session, 1, null);
+
+            verify(lineMessagingService, never())
+                    .sendPushFlexMessage(anyString(), anyString(), anyString(), any());
+            verify(lineMessageLogService, never())
+                    .markReservationSucceeded(anyLong(), any(), anyString());
+        }
+
+        @Test
+        @DisplayName("送信失敗→markReservationFailedが呼ばれる")
+        void sendFailureCallsMarkFailed() {
+            PracticeSession session = createSession();
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    anyString(), eq("100:1"))).thenReturn(true);
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(false);
+            when(lineMessageLogService.markReservationFailed(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    eq("100:1"), anyString())).thenReturn(1);
+
+            lineNotificationService.sendSameDayVacancyNotification(session, 1, null);
+
+            verify(lineMessageLogService).markReservationFailed(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    eq("100:1"), eq("LINE API送信失敗"));
+        }
+
+        @Test
+        @DisplayName("送信例外→markReservationFailedが呼ばれる")
+        void sendExceptionCallsMarkFailed() {
+            PracticeSession session = createSession();
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    anyString(), eq("100:1"))).thenReturn(true);
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenThrow(new RuntimeException("Network error"));
+            when(lineMessageLogService.markReservationFailed(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    eq("100:1"), anyString())).thenReturn(1);
+
+            lineNotificationService.sendSameDayVacancyNotification(session, 1, null);
+
+            verify(lineMessageLogService).markReservationFailed(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    eq("100:1"), eq("Network error"));
+        }
+
+        @Test
+        @DisplayName("送信前にreleaseStaleReservationsが呼ばれる")
+        void releaseStaleReservationsCalledBeforeSend() {
+            PracticeSession session = createSession();
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.releaseStaleReservations(any())).thenReturn(2);
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), anyLong(), any(), anyString(), anyString()))
+                    .thenReturn(true);
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
+            when(lineMessageLogService.markReservationSucceeded(anyLong(), any(), anyString())).thenReturn(1);
+
+            lineNotificationService.sendSameDayVacancyNotification(session, 1, null);
+
+            verify(lineMessageLogService).releaseStaleReservations(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("sendConsolidatedSameDayVacancyNotification - RESERVED残留回復")
+    class ConsolidatedVacancyStaleReservationTests {
+
+        @Test
+        @DisplayName("送信前にreleaseStaleReservationsが呼ばれる")
+        void releaseStaleReservationsCalledBeforeSend() {
+            PracticeSession session = createSession();
+
+            Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
+            vacanciesByMatch.put(1, 2);
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.releaseStaleReservations(any())).thenReturn(1);
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), anyLong(), any(), anyString(), anyString()))
+                    .thenReturn(true);
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
+            when(lineMessageLogService.markReservationSucceeded(anyLong(), any(), anyString())).thenReturn(1);
+
+            lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
+
+            verify(lineMessageLogService).releaseStaleReservations(any());
+        }
+
+        @Test
+        @DisplayName("markReservationSucceededが0件更新でも送信成功としてカウントされる（ログ出力のみ）")
+        void markSucceededZeroUpdateStillCountsAsSent() {
+            PracticeSession session = createSession();
+
+            Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
+            vacanciesByMatch.put(1, 2);
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            setupChannelMocks(10L);
+
+            when(lineMessageLogService.tryAcquireSendRight(anyLong(), anyLong(), any(), anyString(), anyString()))
+                    .thenReturn(true);
+            when(lineMessagingService.sendPushFlexMessage(anyString(), anyString(), anyString(), any()))
+                    .thenReturn(true);
+            // markReservationSucceeded が 0 を返す（不整合ケース）
+            when(lineMessageLogService.markReservationSucceeded(anyLong(), any(), anyString())).thenReturn(0);
+
+            // 例外が発生しないこと（ログ出力のみ）
+            assertDoesNotThrow(() ->
+                    lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null));
+
+            verify(lineMessageLogService).markReservationSucceeded(anyLong(), any(), anyString());
+        }
+    }
+
+    @Nested
     @DisplayName("sendConsolidatedSameDayVacancyNotification - 満枠ケース")
     class VacancyNotificationFullCapacityTests {
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LineNotificationServiceConsolidatedJoinTest.java
@@ -167,6 +167,104 @@ class LineNotificationServiceConsolidatedJoinTest {
     }
 
     @Nested
+    @DisplayName("sendConsolidatedSameDayVacancyNotification - 重複防止")
+    class VacancyNotificationDedupeTests {
+
+        @Test
+        @DisplayName("同一セッション・同日で送信済みの場合はスキップされる")
+        void sameSessionSameDaySkipped() {
+            PracticeSession session = createSession();
+
+            Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
+            vacanciesByMatch.put(1, 2);
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            // 同一セッション・同日で送信済み → true
+            when(lineMessageLogService.existsSuccessfulSince(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    eq("100"), any())).thenReturn(true);
+
+            lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
+
+            // スキップされるため sendFlexToPlayer は呼ばれない
+            verify(lineNotificationService, never())
+                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
+        }
+
+        @Test
+        @DisplayName("別セッションの場合は送信される（セッション単位のdedupeKey）")
+        void differentSessionNotSkipped() {
+            PracticeSession session = createSession(); // id=100
+
+            Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
+            vacanciesByMatch.put(1, 2);
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            // セッション100の送信済みチェック → false（まだ送っていない）
+            when(lineMessageLogService.existsSuccessfulSince(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    eq("100"), any())).thenReturn(false);
+
+            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
+                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
+
+            lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
+
+            // dedupeKey="100" で sendFlexToPlayer が呼ばれる
+            verify(lineNotificationService).sendFlexToPlayer(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    anyString(), any(), eq("100"));
+        }
+
+        @Test
+        @DisplayName("dedupeKeyにセッションIDが含まれ、ログに保存される")
+        void dedupeKeyPassedToSendFlexToPlayer() {
+            PracticeSession session = createSession(); // id=100
+
+            Map<Integer, Integer> vacanciesByMatch = new LinkedHashMap<>();
+            vacanciesByMatch.put(1, 3);
+
+            when(practiceParticipantRepository.findBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                    .thenReturn(List.of());
+
+            PlayerOrganization member = PlayerOrganization.builder()
+                    .playerId(10L).organizationId(1L).build();
+            when(playerOrganizationRepository.findByOrganizationId(1L))
+                    .thenReturn(List.of(member));
+
+            when(lineMessageLogService.existsSuccessfulSince(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    eq("100"), any())).thenReturn(false);
+
+            doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
+                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
+
+            lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
+
+            // 5引数版がdedupeKey="100"で呼ばれたことを確認
+            ArgumentCaptor<String> dedupeCaptor = ArgumentCaptor.forClass(String.class);
+            verify(lineNotificationService).sendFlexToPlayer(eq(10L),
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY),
+                    anyString(), any(), dedupeCaptor.capture());
+            assertEquals("100", dedupeCaptor.getValue());
+        }
+    }
+
+    @Nested
     @DisplayName("sendConsolidatedSameDayVacancyNotification - 満枠ケース")
     class VacancyNotificationFullCapacityTests {
 
@@ -195,13 +293,13 @@ class LineNotificationServiceConsolidatedJoinTest {
 
             // sendFlexToPlayerをスタブ化し、Flexペイロードをキャプチャ
             doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
-                    .sendFlexToPlayer(anyLong(), any(), anyString(), any());
+                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
 
             lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
 
             ArgumentCaptor<Map<String, Object>> flexCaptor = ArgumentCaptor.forClass(Map.class);
             verify(lineNotificationService).sendFlexToPlayer(eq(10L),
-                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), anyString(), flexCaptor.capture());
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), anyString(), flexCaptor.capture(), any());
 
             Map<String, Object> flex = flexCaptor.getValue();
             Map<String, Object> body = (Map<String, Object>) flex.get("body");
@@ -240,13 +338,13 @@ class LineNotificationServiceConsolidatedJoinTest {
                     .thenReturn(List.of(member));
 
             doReturn(LineNotificationService.SendResult.SKIPPED).when(lineNotificationService)
-                    .sendFlexToPlayer(anyLong(), any(), anyString(), any());
+                    .sendFlexToPlayer(anyLong(), any(), anyString(), any(), any());
 
             lineNotificationService.sendConsolidatedSameDayVacancyNotification(session, vacanciesByMatch, null);
 
             ArgumentCaptor<Map<String, Object>> flexCaptor = ArgumentCaptor.forClass(Map.class);
             verify(lineNotificationService).sendFlexToPlayer(eq(10L),
-                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), anyString(), flexCaptor.capture());
+                    eq(LineMessageLog.LineNotificationType.SAME_DAY_VACANCY), anyString(), flexCaptor.capture(), any());
 
             Map<String, Object> flex = flexCaptor.getValue();
             Map<String, Object> body = (Map<String, Object>) flex.get("body");


### PR DESCRIPTION
## Summary
- `sendConsolidatedSameDayVacancyNotification()` に当日中の重複送信チェックを追加
- `LineMessageLogService` に `existsSuccessfulSince()` メソッドを追加
- 本番DBで player_id=3 に24時間で91件の重複通知を確認済み

## Bug
Fixes #424

## Test plan
- [ ] 空き枠通知が初回のみ送信されることを確認
- [ ] 5分後のDensuke同期で同一プレイヤーに再送されないことを確認
- [ ] 翌日になればリセットされて再度送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)