### PR TITLE
feat: 会場拡張時にキャンセル待ち参加者を全員WONに繰り上げ

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2445,7 +2445,13 @@ Entity Layer (JPA Entity)
 [バックエンド: AdjacentRoomService.expandVenue()]
 13. 会場を拡張後会場に変更、定員を更新
    ↓
-14. レスポンス: 200 OK + 更新後のセッション情報
+14. WAITLISTED・OFFERED状態の参加者を全員WONに繰り上げ
+   - WAITLISTED → WON（waitlistNumber をクリア）
+   - OFFERED → WON（waitlistNumber, offeredAt, offerDeadline, respondedAt をクリア）
+   - dirty=true をセット（伝助同期対象にする）
+   - 対象が0件の場合は saveAll をスキップ
+   ↓
+15. レスポンス: 200 OK + 更新後のセッション情報
 ```
 
 **変更対象テーブル・コード**:

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1675,7 +1675,7 @@ UNIQUE制約: (player_id, organization_id)
 | POST | `/date/{date}/matches/{num}/participants/{pid}` | ADMIN+ | 参加者追加 |
 | DELETE | `/{sid}/matches/{num}/participants/{pid}` | ADMIN+ | 参加者削除 |
 | POST | `/{id}/confirm-reservation` | ADMIN+ | 隣室予約完了を記録（`reservation_confirmed_at` をセット） |
-| POST | `/{id}/expand-venue` | ADMIN+ | 会場を隣室と合わせた大部屋に拡張（予約確認済みが前提） |
+| POST | `/{id}/expand-venue` | ADMIN+ | 会場を隣室と合わせた大部屋に拡張（予約確認済みが前提）。拡張時にWAITLISTED・OFFERED状態の参加者を全員WONに繰り上げ（OFFEREDはオファー関連フィールドもクリア） |
 
 ### 7.7 伝助連携 (`/api/practice-sessions`)
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
@@ -2,10 +2,13 @@ package com.karuta.matchtracker.service;
 
 import com.karuta.matchtracker.config.AdjacentRoomConfig;
 import com.karuta.matchtracker.dto.AdjacentRoomStatusDto;
+import com.karuta.matchtracker.entity.ParticipantStatus;
+import com.karuta.matchtracker.entity.PracticeParticipant;
 import com.karuta.matchtracker.entity.PracticeSession;
 import com.karuta.matchtracker.entity.RoomAvailabilityCache;
 import com.karuta.matchtracker.entity.Venue;
 import com.karuta.matchtracker.exception.ResourceNotFoundException;
+import com.karuta.matchtracker.repository.PracticeParticipantRepository;
 import com.karuta.matchtracker.repository.PracticeSessionRepository;
 import com.karuta.matchtracker.repository.RoomAvailabilityCacheRepository;
 import com.karuta.matchtracker.repository.VenueRepository;
@@ -19,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.karuta.matchtracker.util.JstDateTimeUtil;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * 隣室空き確認・会場拡張サービス
@@ -29,6 +33,7 @@ import java.time.LocalDate;
 public class AdjacentRoomService {
 
     private final RoomAvailabilityCacheRepository roomAvailabilityCacheRepository;
+    private final PracticeParticipantRepository practiceParticipantRepository;
     private final PracticeSessionRepository practiceSessionRepository;
     private final VenueRepository venueRepository;
 
@@ -136,5 +141,18 @@ public class AdjacentRoomService {
 
         log.info("Expanded venue for session {}: venueId {} -> {}, capacity -> {}",
                 sessionId, currentVenueId, expandedVenueId, expandedVenue.getCapacity());
+
+        // キャンセル待ちの参加者を全員WONに繰り上げ
+        List<PracticeParticipant> waitlisted = practiceParticipantRepository
+                .findBySessionIdAndStatus(sessionId, ParticipantStatus.WAITLISTED);
+        for (PracticeParticipant p : waitlisted) {
+            p.setStatus(ParticipantStatus.WON);
+            p.setWaitlistNumber(null);
+            p.setDirty(true);
+        }
+        if (!waitlisted.isEmpty()) {
+            practiceParticipantRepository.saveAll(waitlisted);
+            log.info("Promoted {} waitlisted participants to WON for session {}", waitlisted.size(), sessionId);
+        }
     }
 }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
@@ -142,17 +142,32 @@ public class AdjacentRoomService {
         log.info("Expanded venue for session {}: venueId {} -> {}, capacity -> {}",
                 sessionId, currentVenueId, expandedVenueId, expandedVenue.getCapacity());
 
-        // キャンセル待ちの参加者を全員WONに繰り上げ
+        // キャンセル待ち・オファー中の参加者を全員WONに繰り上げ
         List<PracticeParticipant> waitlisted = practiceParticipantRepository
                 .findBySessionIdAndStatus(sessionId, ParticipantStatus.WAITLISTED);
+        List<PracticeParticipant> offered = practiceParticipantRepository
+                .findBySessionIdAndStatus(sessionId, ParticipantStatus.OFFERED);
+
         for (PracticeParticipant p : waitlisted) {
             p.setStatus(ParticipantStatus.WON);
             p.setWaitlistNumber(null);
             p.setDirty(true);
         }
-        if (!waitlisted.isEmpty()) {
-            practiceParticipantRepository.saveAll(waitlisted);
-            log.info("Promoted {} waitlisted participants to WON for session {}", waitlisted.size(), sessionId);
+        for (PracticeParticipant p : offered) {
+            p.setStatus(ParticipantStatus.WON);
+            p.setWaitlistNumber(null);
+            p.setOfferedAt(null);
+            p.setOfferDeadline(null);
+            p.setRespondedAt(null);
+            p.setDirty(true);
+        }
+
+        List<PracticeParticipant> promoted = new java.util.ArrayList<>(waitlisted);
+        promoted.addAll(offered);
+        if (!promoted.isEmpty()) {
+            practiceParticipantRepository.saveAll(promoted);
+            log.info("Promoted {} participants (waitlisted={}, offered={}) to WON for session {}",
+                    promoted.size(), waitlisted.size(), offered.size(), sessionId);
         }
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
@@ -1,10 +1,13 @@
 package com.karuta.matchtracker.service;
 
 import com.karuta.matchtracker.dto.AdjacentRoomStatusDto;
+import com.karuta.matchtracker.entity.ParticipantStatus;
+import com.karuta.matchtracker.entity.PracticeParticipant;
 import com.karuta.matchtracker.entity.PracticeSession;
 import com.karuta.matchtracker.entity.RoomAvailabilityCache;
 import com.karuta.matchtracker.entity.Venue;
 import com.karuta.matchtracker.exception.ResourceNotFoundException;
+import com.karuta.matchtracker.repository.PracticeParticipantRepository;
 import com.karuta.matchtracker.repository.PracticeSessionRepository;
 import com.karuta.matchtracker.repository.RoomAvailabilityCacheRepository;
 import com.karuta.matchtracker.repository.VenueRepository;
@@ -18,6 +21,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessResourceFailureException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,6 +35,8 @@ class AdjacentRoomServiceTest {
 
     @Mock
     private RoomAvailabilityCacheRepository roomAvailabilityCacheRepository;
+    @Mock
+    private PracticeParticipantRepository practiceParticipantRepository;
     @Mock
     private PracticeSessionRepository practiceSessionRepository;
     @Mock
@@ -148,6 +156,10 @@ class AdjacentRoomServiceTest {
                 .thenReturn(Optional.of(cache));
         when(venueRepository.findById(7L)).thenReturn(Optional.of(expandedVenue));
         when(practiceSessionRepository.save(any())).thenReturn(session);
+        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.WAITLISTED))
+                .thenReturn(Collections.emptyList());
+        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.OFFERED))
+                .thenReturn(Collections.emptyList());
 
         adjacentRoomService.expandVenue(1L, 100L);
 
@@ -156,6 +168,109 @@ class AdjacentRoomServiceTest {
         assertEquals(100L, session.getUpdatedBy());
         assertNull(session.getReservationConfirmedAt()); // 拡張後にクリアされる
         verify(practiceSessionRepository).save(session);
+    }
+
+    @Test
+    @DisplayName("会場拡張 - WAITLISTEDがWONに繰り上げられる")
+    void expandVenue_promotesWaitlisted() {
+        LocalDate date = LocalDate.of(2026, 4, 12);
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).venueId(3L).capacity(14).sessionDate(date)
+                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
+        Venue expandedVenue = Venue.builder().id(7L).name("すずらん・はまなす").capacity(24).build();
+        RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
+                .roomName("はまなす").targetDate(date).timeSlot("evening").status("○").build();
+
+        PracticeParticipant w1 = PracticeParticipant.builder()
+                .id(10L).sessionId(1L).playerId(201L)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(1).build();
+        PracticeParticipant w2 = PracticeParticipant.builder()
+                .id(11L).sessionId(1L).playerId(202L)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(2).build();
+
+        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
+        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))
+                .thenReturn(Optional.of(cache));
+        when(venueRepository.findById(7L)).thenReturn(Optional.of(expandedVenue));
+        when(practiceSessionRepository.save(any())).thenReturn(session);
+        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.WAITLISTED))
+                .thenReturn(List.of(w1, w2));
+        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.OFFERED))
+                .thenReturn(Collections.emptyList());
+
+        adjacentRoomService.expandVenue(1L, 100L);
+
+        assertEquals(ParticipantStatus.WON, w1.getStatus());
+        assertNull(w1.getWaitlistNumber());
+        assertTrue(w1.isDirty());
+        assertEquals(ParticipantStatus.WON, w2.getStatus());
+        assertNull(w2.getWaitlistNumber());
+        verify(practiceParticipantRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("会場拡張 - OFFEREDがWONに繰り上げられ、オファー関連フィールドがクリアされる")
+    void expandVenue_promotesOffered() {
+        LocalDate date = LocalDate.of(2026, 4, 12);
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).venueId(3L).capacity(14).sessionDate(date)
+                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
+        Venue expandedVenue = Venue.builder().id(7L).name("すずらん・はまなす").capacity(24).build();
+        RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
+                .roomName("はまなす").targetDate(date).timeSlot("evening").status("○").build();
+
+        PracticeParticipant offered = PracticeParticipant.builder()
+                .id(12L).sessionId(1L).playerId(203L)
+                .status(ParticipantStatus.OFFERED).waitlistNumber(1)
+                .offeredAt(LocalDateTime.of(2026, 4, 11, 12, 0))
+                .offerDeadline(LocalDateTime.of(2026, 4, 12, 12, 0))
+                .build();
+
+        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
+        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))
+                .thenReturn(Optional.of(cache));
+        when(venueRepository.findById(7L)).thenReturn(Optional.of(expandedVenue));
+        when(practiceSessionRepository.save(any())).thenReturn(session);
+        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.WAITLISTED))
+                .thenReturn(Collections.emptyList());
+        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.OFFERED))
+                .thenReturn(List.of(offered));
+
+        adjacentRoomService.expandVenue(1L, 100L);
+
+        assertEquals(ParticipantStatus.WON, offered.getStatus());
+        assertNull(offered.getWaitlistNumber());
+        assertNull(offered.getOfferedAt());
+        assertNull(offered.getOfferDeadline());
+        assertNull(offered.getRespondedAt());
+        assertTrue(offered.isDirty());
+        verify(practiceParticipantRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("会場拡張 - 昇格対象0件時はsaveAllしない")
+    void expandVenue_noPromotionTarget() {
+        LocalDate date = LocalDate.of(2026, 4, 12);
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).venueId(3L).capacity(14).sessionDate(date)
+                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
+        Venue expandedVenue = Venue.builder().id(7L).name("すずらん・はまなす").capacity(24).build();
+        RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
+                .roomName("はまなす").targetDate(date).timeSlot("evening").status("○").build();
+
+        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
+        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))
+                .thenReturn(Optional.of(cache));
+        when(venueRepository.findById(7L)).thenReturn(Optional.of(expandedVenue));
+        when(practiceSessionRepository.save(any())).thenReturn(session);
+        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.WAITLISTED))
+                .thenReturn(Collections.emptyList());
+        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.OFFERED))
+                .thenReturn(Collections.emptyList());
+
+        adjacentRoomService.expandVenue(1L, 100L);
+
+        verify(practiceParticipantRepository, never()).saveAll(anyList());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 会場拡張（expandVenue）時に、WAITLISTEDの参加者を全員WONに自動繰り上げする処理を追加
- waitlistNumberのクリアとdirtyフラグの設定も実施

## Test plan
- [ ] 会場拡張時にWAITLISTED参加者が全員WONに変更されることを確認
- [ ] waitlistNumberがnullにクリアされることを確認
- [ ] WAITLISTED参加者がいない場合にエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)