### PR TITLE
fix: 応答期限が過去のオファー発行を防止し、期限切れ無限ループを修正

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
@@ -532,6 +532,14 @@ public class WaitlistPromotionService {
         // OFFEREDに変更し、応答期限を設定
         LocalDateTime deadline = lotteryDeadlineHelper.calculateOfferDeadline(sessionDate);
 
+        // 応答期限が既に過ぎている場合はオファーを発行しない
+        // （当日12:00以降は SameDayConfirmationScheduler による当日補充フローに移行する）
+        if (deadline.isBefore(JstDateTimeUtil.now())) {
+            log.info("Skip promotion for session {} match {}: offer deadline {} is already past",
+                    sessionId, matchNumber, deadline);
+            return Optional.empty();
+        }
+
         Integer oldWaitlistNumber = next.getWaitlistNumber();
 
         next.setStatus(ParticipantStatus.OFFERED);

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
@@ -531,10 +531,11 @@ public class WaitlistPromotionService {
 
         // OFFEREDに変更し、応答期限を設定
         LocalDateTime deadline = lotteryDeadlineHelper.calculateOfferDeadline(sessionDate);
+        LocalDateTime now = JstDateTimeUtil.now();
 
         // 応答期限が既に過ぎている場合はオファーを発行しない
         // （当日12:00以降は SameDayConfirmationScheduler による当日補充フローに移行する）
-        if (deadline.isBefore(JstDateTimeUtil.now())) {
+        if (!deadline.isAfter(now)) {
             log.info("Skip promotion for session {} match {}: offer deadline {} is already past",
                     sessionId, matchNumber, deadline);
             return Optional.empty();
@@ -544,7 +545,7 @@ public class WaitlistPromotionService {
 
         next.setStatus(ParticipantStatus.OFFERED);
         next.setDirty(true);
-        next.setOfferedAt(JstDateTimeUtil.now());
+        next.setOfferedAt(now);
         next.setOfferDeadline(deadline);
         practiceParticipantRepository.save(next);
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
@@ -230,6 +230,56 @@ class WaitlistPromotionServiceTest {
         }
 
         @Test
+        @DisplayName("応答期限が既に過ぎている場合はOptional.emptyを返しオファーを発行しない")
+        void promoteNextWaitlisted_deadlineAlreadyPast_returnsEmpty() {
+            PracticeParticipant waitlist1 = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
+                    .status(ParticipantStatus.WAITLISTED).waitlistNumber(1).build();
+            when(practiceParticipantRepository
+                    .findFirstBySessionIdAndMatchNumberAndStatusOrderByWaitlistNumberAsc(
+                            100L, 1, ParticipantStatus.WAITLISTED))
+                    .thenReturn(Optional.of(waitlist1));
+            // 期限を過去に設定
+            when(lotteryDeadlineHelper.calculateOfferDeadline(any()))
+                    .thenReturn(JstDateTimeUtil.now().minusHours(1));
+
+            Optional<PracticeParticipant> promoted = service.promoteNextWaitlisted(
+                    100L, 1, LocalDate.of(2026, 5, 1));
+
+            assertThat(promoted).isEmpty();
+            verify(practiceParticipantRepository, never()).save(any());
+            verify(notificationService, never()).createOfferNotification(any());
+        }
+
+        @Test
+        @DisplayName("応答期限がちょうど現在時刻と同じ場合もオファーを発行しない（境界値）")
+        void promoteNextWaitlisted_deadlineEqualsNow_returnsEmpty() {
+            LocalDateTime fixedNow = LocalDateTime.of(2026, 5, 1, 12, 0, 0);
+            PracticeParticipant waitlist1 = PracticeParticipant.builder()
+                    .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
+                    .status(ParticipantStatus.WAITLISTED).waitlistNumber(1).build();
+
+            try (MockedStatic<JstDateTimeUtil> jstMock = mockStatic(JstDateTimeUtil.class)) {
+                jstMock.when(JstDateTimeUtil::now).thenReturn(fixedNow);
+
+                when(practiceParticipantRepository
+                        .findFirstBySessionIdAndMatchNumberAndStatusOrderByWaitlistNumberAsc(
+                                100L, 1, ParticipantStatus.WAITLISTED))
+                        .thenReturn(Optional.of(waitlist1));
+                // deadline == now（ちょうど同じ時刻）
+                when(lotteryDeadlineHelper.calculateOfferDeadline(any()))
+                        .thenReturn(fixedNow);
+
+                Optional<PracticeParticipant> promoted = service.promoteNextWaitlisted(
+                        100L, 1, LocalDate.of(2026, 5, 1));
+
+                assertThat(promoted).isEmpty();
+                verify(practiceParticipantRepository, never()).save(any());
+                verify(notificationService, never()).createOfferNotification(any());
+            }
+        }
+
+        @Test
         @DisplayName("複数OFFERED存在時に離脱しても番号が重複しない（再採番で整合性維持）")
         void respondToOffer_multipleOffered_renumbersCorrectly() {
             // OFFERED#1 Aさん, OFFERED#2 Bさん, WAITLISTED#3 Cさん


### PR DESCRIPTION
## Summary
- `promoteNextWaitlisted` で `calculateOfferDeadline` が返す応答期限が現在時刻より前の場合、オファーを発行せず `Optional.empty()` を返すガードを追加
- 当日12:00以降にキャンセル待ち繰り上げが発火すると、オファー期限が常に過去（当日12:00）となり、OfferExpirySchedulerとの間で5分ごとの無限ループが発生していたバグを修正

## Root Cause
`LotteryDeadlineHelper.calculateOfferDeadline()` が当日セッションに対して `sessionDate.atTime(12, 0)` を固定で返すが、12:00以降に呼ばれると過去の時刻になる。`promoteNextWaitlisted` にはこのチェックがなく、即期限切れのOFFEREDレコードが作成され続けていた。

## Test plan
- [x] WaitlistPromotionServiceTest パス
- [x] OfferExpirySchedulerTest パス
- [x] LotteryServiceTest パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)