### PR TITLE
feat: 会場拡張時のキャンセル待ち昇格をOFFERED（応答期限なし）に変更

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2445,9 +2445,9 @@ Entity Layer (JPA Entity)
 [バックエンド: AdjacentRoomService.expandVenue()]
 13. 会場を拡張後会場に変更、定員を更新
    ↓
-14. WAITLISTED・OFFERED状態の参加者を全員WONに繰り上げ
-   - WAITLISTED → WON（waitlistNumber をクリア）
-   - OFFERED → WON（waitlistNumber, offeredAt, offerDeadline, respondedAt をクリア）
+14. WAITLISTED→OFFERED（応答期限なし）、既存OFFEREDの応答期限をクリア
+   - WAITLISTED → OFFERED（waitlistNumber をクリア、offeredAt=現在時刻、offerDeadline=null）
+   - OFFERED → offerDeadline をnullにクリア（ステータス・offeredAt等はそのまま）
    - dirty=true をセット（伝助同期対象にする）
    - 対象が0件の場合は saveAll をスキップ
    ↓

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1675,7 +1675,7 @@ UNIQUE制約: (player_id, organization_id)
 | POST | `/date/{date}/matches/{num}/participants/{pid}` | ADMIN+ | 参加者追加 |
 | DELETE | `/{sid}/matches/{num}/participants/{pid}` | ADMIN+ | 参加者削除 |
 | POST | `/{id}/confirm-reservation` | ADMIN+ | 隣室予約完了を記録（`reservation_confirmed_at` をセット） |
-| POST | `/{id}/expand-venue` | ADMIN+ | 会場を隣室と合わせた大部屋に拡張（予約確認済みが前提）。拡張時にWAITLISTED・OFFERED状態の参加者を全員WONに繰り上げ（OFFEREDはオファー関連フィールドもクリア） |
+| POST | `/{id}/expand-venue` | ADMIN+ | 会場を隣室と合わせた大部屋に拡張（予約確認済みが前提）。拡張時にWAITLISTED→OFFERED（応答期限なし）、既存OFFEREDの応答期限をクリア |
 
 ### 7.7 伝助連携 (`/api/practice-sessions`)
 

--- a/karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx
+++ b/karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx
@@ -68,14 +68,16 @@ export default function WaitlistStatus() {
                     <span className={`px-2 py-1 rounded text-xs font-bold ${statusInfo.color}`}>
                       {statusInfo.text}
                     </span>
-                    <div className="text-sm text-gray-500 mt-1">
-                      待ち番号: {entry.waitlistNumber}番
-                    </div>
+                    {entry.waitlistNumber != null && (
+                      <div className="text-sm text-gray-500 mt-1">
+                        待ち番号: {entry.waitlistNumber}番
+                      </div>
+                    )}
                   </div>
                 </div>
-                {entry.status === 'OFFERED' && entry.offerDeadline && (
+                {entry.status === 'OFFERED' && (
                   <div className="mt-2 p-2 bg-blue-50 rounded text-sm text-blue-700">
-                    応答期限: {new Date(entry.offerDeadline).toLocaleString('ja-JP')}
+                    応答期限: {entry.offerDeadline ? new Date(entry.offerDeadline).toLocaleString('ja-JP') : '期限なし'}
                     <a href={`/lottery/offer-response?id=${entry.participantId}`}
                       className="ml-2 font-bold underline">応答する</a>
                   </div>

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.karuta.matchtracker.util.JstDateTimeUtil;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -142,23 +143,22 @@ public class AdjacentRoomService {
         log.info("Expanded venue for session {}: venueId {} -> {}, capacity -> {}",
                 sessionId, currentVenueId, expandedVenueId, expandedVenue.getCapacity());
 
-        // キャンセル待ち・オファー中の参加者を全員WONに繰り上げ
+        // キャンセル待ち→OFFERED（応答期限なし）、既存OFFERED→応答期限をクリア
+        LocalDateTime now = JstDateTimeUtil.now();
         List<PracticeParticipant> waitlisted = practiceParticipantRepository
                 .findBySessionIdAndStatus(sessionId, ParticipantStatus.WAITLISTED);
         List<PracticeParticipant> offered = practiceParticipantRepository
                 .findBySessionIdAndStatus(sessionId, ParticipantStatus.OFFERED);
 
         for (PracticeParticipant p : waitlisted) {
-            p.setStatus(ParticipantStatus.WON);
+            p.setStatus(ParticipantStatus.OFFERED);
             p.setWaitlistNumber(null);
+            p.setOfferedAt(now);
+            p.setOfferDeadline(null);
             p.setDirty(true);
         }
         for (PracticeParticipant p : offered) {
-            p.setStatus(ParticipantStatus.WON);
-            p.setWaitlistNumber(null);
-            p.setOfferedAt(null);
             p.setOfferDeadline(null);
-            p.setRespondedAt(null);
             p.setDirty(true);
         }
 
@@ -166,7 +166,7 @@ public class AdjacentRoomService {
         promoted.addAll(offered);
         if (!promoted.isEmpty()) {
             practiceParticipantRepository.saveAll(promoted);
-            log.info("Promoted {} participants (waitlisted={}, offered={}) to WON for session {}",
+            log.info("Promoted {} participants (waitlisted={}, offered={}) to OFFERED for session {}",
                     promoted.size(), waitlisted.size(), offered.size(), sessionId);
         }
     }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
@@ -171,7 +171,7 @@ class AdjacentRoomServiceTest {
     }
 
     @Test
-    @DisplayName("会場拡張 - WAITLISTEDがWONに繰り上げられる")
+    @DisplayName("会場拡張 - WAITLISTEDがOFFEREDに繰り上げられる（応答期限なし）")
     void expandVenue_promotesWaitlisted() {
         LocalDate date = LocalDate.of(2026, 4, 12);
         PracticeSession session = PracticeSession.builder()
@@ -200,16 +200,20 @@ class AdjacentRoomServiceTest {
 
         adjacentRoomService.expandVenue(1L, 100L);
 
-        assertEquals(ParticipantStatus.WON, w1.getStatus());
+        assertEquals(ParticipantStatus.OFFERED, w1.getStatus());
         assertNull(w1.getWaitlistNumber());
+        assertNotNull(w1.getOfferedAt());
+        assertNull(w1.getOfferDeadline());
         assertTrue(w1.isDirty());
-        assertEquals(ParticipantStatus.WON, w2.getStatus());
+        assertEquals(ParticipantStatus.OFFERED, w2.getStatus());
         assertNull(w2.getWaitlistNumber());
+        assertNotNull(w2.getOfferedAt());
+        assertNull(w2.getOfferDeadline());
         verify(practiceParticipantRepository).saveAll(anyList());
     }
 
     @Test
-    @DisplayName("会場拡張 - OFFEREDがWONに繰り上げられ、オファー関連フィールドがクリアされる")
+    @DisplayName("会場拡張 - OFFEREDの応答期限がクリアされる")
     void expandVenue_promotesOffered() {
         LocalDate date = LocalDate.of(2026, 4, 12);
         PracticeSession session = PracticeSession.builder()
@@ -238,11 +242,9 @@ class AdjacentRoomServiceTest {
 
         adjacentRoomService.expandVenue(1L, 100L);
 
-        assertEquals(ParticipantStatus.WON, offered.getStatus());
-        assertNull(offered.getWaitlistNumber());
-        assertNull(offered.getOfferedAt());
+        assertEquals(ParticipantStatus.OFFERED, offered.getStatus());
+        assertNotNull(offered.getOfferedAt()); // 元のofferedAtは維持される
         assertNull(offered.getOfferDeadline());
-        assertNull(offered.getRespondedAt());
         assertTrue(offered.isDirty());
         verify(practiceParticipantRepository).saveAll(anyList());
     }


### PR DESCRIPTION
## Summary
- 会場拡張時、WAITLISTED参加者をWONではなくOFFERED（offerDeadline=null）に変更
- 既存OFFERED参加者の応答期限（offerDeadline）もnullにクリア
- offerDeadline=nullのためOfferExpirySchedulerの期限切れ判定には引っかからず安全

## Test plan
- [x] AdjacentRoomServiceTest 全5テスト通過
- [ ] 手動テスト: 会場拡張後、WAITLISTED→OFFEREDになることを確認
- [ ] 手動テスト: 既存OFFEREDのofferDeadlineがnullになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)