### PR TITLE
feat: 伝助ページ自動作成機能 (densuke-page-creator)

### DIFF
--- a/.claude/skills/startapp/SKILL.md
+++ b/.claude/skills/startapp/SKILL.md
@@ -26,7 +26,7 @@ allowed-tools: Bash, Read
 - **重要**: RenderのPostgreSQLに接続するため、以下の環境変数を必ず設定して起動すること
 - 起動コマンド:
 ```bash
-cd c:/Users/popon/match-tracker/karuta-tracker && DB_URL="jdbc:postgresql://dpg-d6t1e77kijhs73er5ug0-a.oregon-postgres.render.com:5432/karuta_tracker_b297" DB_USERNAME="karuta" DB_PASSWORD="b1FgPgpxsqE83Z1sVoRdes2EdxTAKAal" ./gradlew bootRun 2>&1
+cd c:/Users/popon/match-tracker/karuta-tracker && DB_URL="jdbc:postgresql://dpg-d6t1e77kijhs73er5ug0-a.oregon-postgres.render.com:5432/karuta_tracker_b297" DB_USERNAME="karuta" DB_PASSWORD="9wvobIcnZknsLP5owc9bQDKOWHmiekNE" ./gradlew bootRun 2>&1
 ```
 - `run_in_background: true` で起動する
 - 起動完了まで約30〜60秒かかる。30秒後に `curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/players` で確認し、200でなければさらに15秒ごとにリトライ（最大3回）

--- a/claude.md
+++ b/claude.md
@@ -77,7 +77,7 @@ docker-compose -f docker-compose-dev.yml up   # PostgreSQL + アプリ起動
 - バックエンド起動時に以下の環境変数の設定が必須:
   - `DB_URL=jdbc:postgresql://dpg-d6t1e77kijhs73er5ug0-a.oregon-postgres.render.com:5432/karuta_tracker_b297`
   - `DB_USERNAME=karuta`
-  - `DB_PASSWORD=b1FgPgpxsqE83Z1sVoRdes2EdxTAKAal`
+  - `DB_PASSWORD=9wvobIcnZknsLP5owc9bQDKOWHmiekNE`
 - 環境変数なしで起動すると `localhost:5432` に接続しようとして失敗する
 - MySQL 8.0 は CI でのみ使用
 - 論理削除パターン: `deleted_at` カラムで管理

--- a/database/add_densuke_page_created_line_preference.sql
+++ b/database/add_densuke_page_created_line_preference.sql
@@ -1,0 +1,3 @@
+-- LINE 通知設定テーブルに「伝助ページ作成通知」の ON/OFF フラグを追加
+-- 既存レコードは全て TRUE で初期化される
+ALTER TABLE line_notification_preferences ADD COLUMN densuke_page_created BOOLEAN NOT NULL DEFAULT TRUE;

--- a/database/add_densuke_page_created_message_log_check.sql
+++ b/database/add_densuke_page_created_message_log_check.sql
@@ -1,0 +1,22 @@
+-- 伝助ページ作成通知: line_message_log の notification_type CHECK制約に DENSUKE_PAGE_CREATED を追加
+
+ALTER TABLE line_message_log DROP CONSTRAINT IF EXISTS line_message_log_notification_type_check;
+ALTER TABLE line_message_log ADD CONSTRAINT line_message_log_notification_type_check
+    CHECK (notification_type IN (
+        'LOTTERY_RESULT',
+        'WAITLIST_OFFER',
+        'OFFER_EXPIRED',
+        'MATCH_PAIRING',
+        'PRACTICE_REMINDER',
+        'DEADLINE_REMINDER',
+        'ADMIN_WAITLIST_UPDATE',
+        'WAITLIST_POSITION_UPDATE',
+        'SAME_DAY_CONFIRMATION',
+        'SAME_DAY_CANCEL',
+        'SAME_DAY_VACANCY',
+        'ADMIN_SAME_DAY_CONFIRMATION',
+        'ADMIN_SAME_DAY_CANCEL',
+        'MENTOR_COMMENT',
+        'MENTEE_MEMO_UPDATE',
+        'DENSUKE_PAGE_CREATED'
+    ));

--- a/database/add_densuke_sd_column.sql
+++ b/database/add_densuke_sd_column.sql
@@ -1,0 +1,4 @@
+-- densuke_urls に編集用シークレット (sd) カラムを追加
+-- アプリから自動作成した伝助ページのみ値が入る。手動登録URLは NULL のまま。
+-- 将来の編集・削除 API で必要になる可能性があるため保存する。
+ALTER TABLE densuke_urls ADD COLUMN densuke_sd VARCHAR(32);

--- a/database/create_densuke_templates.sql
+++ b/database/create_densuke_templates.sql
@@ -1,0 +1,11 @@
+-- 伝助テンプレート管理テーブル（団体単位）
+-- 団体ごとに1レコード。作成時のタイトル・説明・連絡先メアドのデフォルト値を保持する
+CREATE TABLE densuke_templates (
+  id              BIGSERIAL PRIMARY KEY,
+  organization_id BIGINT NOT NULL UNIQUE REFERENCES organizations(id),
+  title_template  VARCHAR(200) NOT NULL,
+  description     TEXT,
+  contact_email   VARCHAR(255),
+  created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2682,10 +2682,12 @@ Entity Layer (JPA Entity)
 - **伝助ページ自動作成（DensukePageCreateService）**: アプリ側に登録された練習日（`practice_sessions` × `venues` × `venue_match_schedules`）から densuke.biz にページを新規発行
   - エンドポイント: `POST /api/practice-sessions/densuke/create-page`（ADMIN以上）
   - 送信先: `POST https://www.densuke.biz/create`（`/confirm` はスキップ可能、認証不要）
-  - schedule 文字列は `{M}/{D}({曜}) {HH:MM}～{会場名} {N}試合目` 形式で改行区切り（既存 `DensukeScraper` が読める形）
+  - schedule 文字列は「セッションの 1 試合目行は `{M}/{D}({曜}) {会場名} 1試合目`、2 試合目以降は `{N}試合目` のみ」の 2 段形式で改行連結（時刻は含めない）。既存 `DensukeScraper` は `currentDate`/`currentVenue` を前行から引き継ぐため、日付・会場の省略行も正しくパースできる
   - 固定パラメータ: `eventchoice=1`（○△×）、`pw=0`（パスワードなし）
   - レスポンス 302 Location から `cd` と `sd` を抽出、`densuke_urls` に保存
-  - バリデーション: ①既存URL重複、②practice_sessions 0件、③venue_match_schedules 不足、④会場未登録
+  - バリデーション: ①年月範囲（JST 当月〜+2 ヶ月）、②既存URL重複、③practice_sessions 0件、④venue_match_schedules 不足、⑤会場未登録
+  - 排他制御: `densuke_urls` に仮レコードを `saveAndFlush` で先行確保し UNIQUE 制約で同時作成を直列化。ユニーク違反時は 400（「既に登録されています」）を返し densuke.biz への二重 POST を防止
+  - 手動 URL 上書き経路（`saveDensukeUrl`）では `densuke_sd` を明示的に NULL クリアし、自動作成済みレコードの sd が残留しないよう保証
   - 作成成功後、`@TransactionalEventListener(AFTER_COMMIT)` 相当の同期で団体所属 PLAYER ロールメンバー（ADMIN/SUPER_ADMIN 除外）に LINE 通知（`DENSUKE_PAGE_CREATED`）を送信
   - テンプレート: `densuke_templates` テーブルで団体ごとにタイトル・説明・連絡先メアドのデフォルト値を保持。作成ダイアログで編集可能
   - 作成後は既存の `DensukeSyncScheduler` が次回サイクル（最長5分）で新URLを自動取り込み

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -525,11 +525,30 @@ Entity Layer (JPA Entity)
 | month | INT | NOT NULL | 対象月 |
 | url | VARCHAR(500) | NOT NULL | 伝助URL |
 | organization_id | BIGINT | NOT NULL, FK | 団体ID（organizations.id） |
+| densuke_sd | VARCHAR(32) | | 伝助の編集用シークレット (sd)。アプリから自動作成した URL のみ値が入る。手動登録は NULL。将来の編集・削除 API で使用想定 |
 | created_at | DATETIME | NOT NULL | 作成日時 |
 | updated_at | DATETIME | NOT NULL | 更新日時 |
 
 **制約**:
 - UNIQUE (year, month, organization_id)
+
+---
+
+#### densuke_templates（伝助ページ作成テンプレート）
+団体ごとに1レコード保持。伝助ページ自動作成時のタイトル・説明・連絡先メアドのデフォルト値を保存する。
+
+| カラム名 | 型 | 制約 | 説明 |
+|---------|-----|------|------|
+| id | BIGINT | PK, AUTO_INCREMENT | ID |
+| organization_id | BIGINT | NOT NULL, UNIQUE, FK | 団体ID（organizations.id） |
+| title_template | VARCHAR(200) | NOT NULL | タイトルテンプレート（プレースホルダー `{year}`、`{month}`、`{organization_name}` を置換） |
+| description | TEXT | | 伝助イベント説明文 |
+| contact_email | VARCHAR(255) | | 主催者連絡先メアド（伝助の `email` フィールドに送信。控えメールの受信先） |
+| created_at | DATETIME | NOT NULL | 作成日時 |
+| updated_at | DATETIME | NOT NULL | 更新日時 |
+
+**制約**:
+- UNIQUE (organization_id)
 
 ---
 
@@ -2660,6 +2679,16 @@ Entity Layer (JPA Entity)
 - **権限**: ADMINは自団体の伝助URLのみ操作可能。SUPER_ADMINは全団体操作可能
 - **未登録者通知**: ADMINは自団体の未登録者のみ通知。SUPER_ADMINは全団体分を通知
 - **キャッシュ**: `PlayerService.findAllPlayersRaw()` に Caffeine 60秒 TTL を適用（スケジューラーのDB負荷軽減）
+- **伝助ページ自動作成（DensukePageCreateService）**: アプリ側に登録された練習日（`practice_sessions` × `venues` × `venue_match_schedules`）から densuke.biz にページを新規発行
+  - エンドポイント: `POST /api/practice-sessions/densuke/create-page`（ADMIN以上）
+  - 送信先: `POST https://www.densuke.biz/create`（`/confirm` はスキップ可能、認証不要）
+  - schedule 文字列は `{M}/{D}({曜}) {HH:MM}～{会場名} {N}試合目` 形式で改行区切り（既存 `DensukeScraper` が読める形）
+  - 固定パラメータ: `eventchoice=1`（○△×）、`pw=0`（パスワードなし）
+  - レスポンス 302 Location から `cd` と `sd` を抽出、`densuke_urls` に保存
+  - バリデーション: ①既存URL重複、②practice_sessions 0件、③venue_match_schedules 不足、④会場未登録
+  - 作成成功後、`@TransactionalEventListener(AFTER_COMMIT)` 相当の同期で団体所属 PLAYER ロールメンバー（ADMIN/SUPER_ADMIN 除外）に LINE 通知（`DENSUKE_PAGE_CREATED`）を送信
+  - テンプレート: `densuke_templates` テーブルで団体ごとにタイトル・説明・連絡先メアドのデフォルト値を保持。作成ダイアログで編集可能
+  - 作成後は既存の `DensukeSyncScheduler` が次回サイクル（最長5分）で新URLを自動取り込み
 
 #### Google Calendar連携
 - OAuth2アクセストークンベースでGoogle Calendar APIを呼び出し

--- a/docs/SCREEN_LIST.md
+++ b/docs/SCREEN_LIST.md
@@ -149,7 +149,7 @@
 
 | # | パス | ページコンポーネント | 主要子コンポーネント | 権限 | 説明 |
 |---|------|---------------------|---------------------|------|------|
-| 37 | `/admin/densuke` | `DensukeManagement.jsx` | 月ナビゲーション、団体別ブロック（URL入力・同期ボタン・書き込み状況・同期結果・未登録者チェックリスト） | ADMIN+ | 団体別の伝助URL管理・手動同期実行・書き込み状況・未登録者確認・一括登録。ADMINは自団体のみ表示、SUPER_ADMINは全団体を並べて表示。各団体ブロックに団体カラーのアクセント付き |
+| 37 | `/admin/densuke` | `DensukeManagement.jsx` | 月ナビゲーション、団体別ブロック（URL入力・同期ボタン・書き込み状況・同期結果・未登録者チェックリスト・**伝助ページ作成ボタン**・**テンプレート編集ボタン**）、`DensukePageCreateModal`、`DensukeTemplateModal` | ADMIN+ | 団体別の伝助URL管理・手動同期実行・書き込み状況・未登録者確認・一括登録・**伝助ページ自動作成**（アプリの練習日データから densuke.biz にページを新規発行。当月+未来2ヶ月まで作成可能、既に URL 登録済みの月は作成ボタン非表示）・**テンプレート編集**（団体ごとのタイトル・説明・連絡先メアドのデフォルト値、プレースホルダー `{year}` / `{month}` / `{organization_name}` 対応）。ADMINは自団体のみ表示、SUPER_ADMINは全団体を並べて表示。各団体ブロックに団体カラーのアクセント付き |
 
 ---
 
@@ -261,7 +261,9 @@ karuta-tracker-ui/src/
     │   ├── WaitlistStatus.jsx
     │   └── OfferResponse.jsx
     ├── densuke/
-    │   └── DensukeManagement.jsx
+    │   ├── DensukeManagement.jsx
+    │   ├── DensukePageCreateModal.jsx
+    │   └── DensukeTemplateModal.jsx
     ├── line/
     │   ├── LineSettings.jsx
     │   ├── LineChannelAdmin.jsx

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -796,6 +796,50 @@ SUPER_ADMIN のみ操作可能。
 - `writeAllForLotteryConfirmation` で全マッピング済みプレイヤーを対象に書き込む（dirtyフィルタなし）
 - アクティブステータス（WON/WAITLISTED/OFFERED/PENDING）のみ書き戻し、CANCELLED/DECLINED/未登録はスキップ（伝助の既存値を維持）
 
+#### 4.1.7 伝助ページ自動作成（DensukePageCreateService）
+
+アプリ側に登録された練習日データから densuke.biz に出欠ページを**新規発行**する機能。ADMIN 以上が伝助管理画面の「伝助ページ作成」ボタンから手動実行する。
+
+**ユースケース:**
+- 月初に管理者が翌月の練習日を一通り登録し終えたタイミングで、メンバー周知用の伝助ページを 1 クリックで作成
+- 従来は伝助側に手動でページを作成し、日付・会場・試合枠を手入力していたが、アプリのマスタデータ（`practice_sessions` / `venues` / `venue_match_schedules`）をそのまま流用して自動化する
+
+**使い方:**
+1. `/admin/densuke` で対象年月を選択（当月＋未来2ヶ月まで）
+2. 団体カードの「伝助ページ作成」ボタン → 作成モーダル表示
+3. テンプレートから読み込んだタイトル・説明・連絡先メアドを必要に応じて編集
+4. 「作成」ボタンで POST `/api/practice-sessions/densuke/create-page` 実行
+
+**処理フロー:**
+1. バリデーション: 既存URL重複 / 練習日 0 件 / 会場未登録 / `venue_match_schedules` の不足をチェック、いずれかあれば `IllegalStateException`
+2. テンプレート (`densuke_templates`) 取得 + オーバーライド適用 + プレースホルダー置換 (`{year}` / `{month}` / `{organization_name}`)
+3. schedule 文字列組み立て: `{M}/{D}({曜}) {HH:MM}～{会場名} {N}試合目` 形式で練習日×試合枠ぶんを改行連結
+4. densuke.biz に `POST https://www.densuke.biz/create` を送信（UTF-8, `application/x-www-form-urlencoded`, `eventchoice=1` 固定）
+5. 302 レスポンスの `Location` ヘッダーから `cd` と `sd` を正規表現で抽出
+6. `densuke_urls` に新レコードを保存（`url` と `densuke_sd` を含む）
+7. トランザクションコミット後に LINE 通知発火
+
+**通知:**
+- 団体所属 PLAYER ロールのメンバー全員に LINE 通知（`DENSUKE_PAGE_CREATED` 種別）
+- ADMIN / SUPER_ADMIN は通知対象外（作成者なので不要）
+- タイトル: `{month}月の練習日程が出ました`、本文には伝助 URL を含める
+- `line_notification_preferences.densuke_page_created` が `FALSE` のメンバーはスキップ
+- 通知送信失敗は作成 API の成功に影響させない（警告ログのみ）
+
+**テンプレート管理:**
+- `GET / PUT /api/densuke-templates/{organizationId}`（ADMIN以上）
+- 団体ごとに 1 レコード。未登録団体にはデフォルト値（タイトル = `{year}年{month}月 練習出欠`）を返却
+- 伝助管理画面の「テンプレート編集」ボタンからモーダルで編集
+
+**設計上の固定値:**
+- `eventchoice = 1`（○△×）— 既存 `DensukeScraper` の判定ロジック（`col3`=○, `col2`=△）と整合
+- `pw = 0`（パスワードなし）— 運用上パスワード不要
+
+**セキュリティ / 副作用:**
+- densuke.biz への POST は認証不要（匿名作成）
+- `densuke_sd`（編集用シークレット）を保存するが、将来の編集・削除 API 実装時に使用予定
+- 作成後は既存の `DensukeSyncScheduler` が次回サイクル（最長 5 分）で新 URL を自動取り込みし、以降の双方向同期へ合流
+
 **未入力保護:**
 - 伝助上で「未入力」のまま残しているマスをアプリの同期が×に上書きしないよう保護する
 - 通常同期ではdirty行のみ送信し、アプリに未登録のマスは送信しない

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -813,11 +813,13 @@ SUPER_ADMIN のみ操作可能。
 **処理フロー:**
 1. バリデーション: 既存URL重複 / 練習日 0 件 / 会場未登録 / `venue_match_schedules` の不足をチェック、いずれかあれば `IllegalStateException`
 2. テンプレート (`densuke_templates`) 取得 + オーバーライド適用 + プレースホルダー置換 (`{year}` / `{month}` / `{organization_name}`)
-3. schedule 文字列組み立て: `{M}/{D}({曜}) {HH:MM}～{会場名} {N}試合目` 形式で練習日×試合枠ぶんを改行連結
-4. densuke.biz に `POST https://www.densuke.biz/create` を送信（UTF-8, `application/x-www-form-urlencoded`, `eventchoice=1` 固定）
-5. 302 レスポンスの `Location` ヘッダーから `cd` と `sd` を正規表現で抽出
-6. `densuke_urls` に新レコードを保存（`url` と `densuke_sd` を含む）
-7. トランザクションコミット後に LINE 通知発火
+3. schedule 文字列組み立て: 各セッション（日付×会場）の先頭行は `{M}/{D}({曜}) {会場名} 1試合目`、2 試合目以降は `{N}試合目` 単独で改行連結（時刻は含めない）
+4. 年月範囲チェック: JST 基準で当月〜+2 ヶ月以外は `IllegalStateException`（UI の `canCreatePage` と同等の制約を API 側にも適用）
+5. `densuke_urls` に仮レコードを `saveAndFlush` で先行確保（UNIQUE 制約による同時作成の直列化）。ユニーク違反時は「既に登録されています」で 400 を返し、densuke.biz への二重 POST を防止
+6. densuke.biz に `POST https://www.densuke.biz/create` を送信（UTF-8, `application/x-www-form-urlencoded`, `eventchoice=1` 固定）
+7. 302 レスポンスの `Location` ヘッダーから `cd` と `sd` を正規表現で抽出
+8. 仮レコードを実 URL / `sd` で更新
+9. トランザクションコミット後に LINE 通知発火
 
 **通知:**
 - 団体所属 PLAYER ロールのメンバー全員に LINE 通知（`DENSUKE_PAGE_CREATED` 種別）

--- a/docs/features/densuke-page-creator/densuke-form-spec.md
+++ b/docs/features/densuke-page-creator/densuke-form-spec.md
@@ -109,23 +109,23 @@ Java の標準ライブラリ（`java.net.http.HttpClient`, Spring `RestTemplate
 
 つまり、伝助ページ側の各行は**以下のフォーマットで組み立てる必要がある**:
 
-```
-{M}/{D}({曜日}) {HH:MM}～{会場名} {N}試合目
-```
+- 各セッション（= 日付 × 会場）の **1試合目行** は `{M}/{D}({曜日}) {会場名} 1試合目`
+- 同じセッションの **2試合目以降** は `{N}試合目` のみ（`DensukeScraper` は `currentDate` / `currentVenue` を前行から引き継ぐため、省略しても同期に支障なし）
+- **時刻は含めない**（時刻を混入させると `VENUE_PATTERN` が会場名として時刻込み文字列を拾い、同期時に会場解決が崩れるため）
 
-**具体例（1日3試合の場合）:**
+**具体例（1日3試合 × 2日）:**
 ```
-4/20(月) 17:20～すずらん 1試合目
-4/20(月) 18:45～すずらん 2試合目
-4/20(月) 20:10～すずらん 3試合目
-4/22(水) 17:20～はまなす 1試合目
-4/22(水) 18:45～はまなす 2試合目
+4/20(月) すずらん 1試合目
+2試合目
+3試合目
+4/22(水) はまなす 1試合目
+2試合目
 ```
 
 ### アプリ側の実装方針
-- 対象月の `practice_sessions` を全件取得
+- 対象月の `practice_sessions` を `session_date ASC` で取得
 - 各セッションについて、`total_matches`（未設定時は `venues.default_match_count`）の回数ループ
-- 試合ごとに `venue_match_schedules` の `start_time` を時刻として使う
+- 試合時刻の整合チェックは `venue_match_schedules` に全試合分のレコードがあるかで判定（時刻自体は densuke には送信しない）
 - 曜日は Java の `DayOfWeek` から日本語短縮名にマッピング（日/月/火/水/木/金/土）
 - 複数の練習日を改行で連結して `schedule` パラメータに入れる
 
@@ -137,7 +137,7 @@ Java の標準ライブラリ（`java.net.http.HttpClient`, Spring `RestTemplate
 urlenc() { printf '%s' "$1" | od -An -t x1 | tr -d ' \n' | sed 's/../%&/g'; }
 
 EVENTNAME=$(urlenc "2026年5月練習出欠")
-SCHEDULE=$(urlenc $'5/5(火) 17:20～すずらん 1試合目\n5/5(火) 18:45～すずらん 2試合目')
+SCHEDULE=$(urlenc $'5/5(火) すずらん 1試合目\n2試合目')
 EXPLAIN=$(urlenc "5月の練習日程")
 
 curl -X POST \
@@ -218,7 +218,7 @@ String densukeUrl = "https://densuke.biz/list?cd=" + cd;
 
 1. **eventchoice は必ず `1`（○△×）で固定** — 既存 scraper のロジック（`col3`=○, `col2`+△ 判定）と整合
 2. **pw は `0`（パスワードなし）で固定** — 運用上パスワード不要
-3. **日程文字列は `{M}/{D}({曜}) {HH:MM}～{会場} {N}試合目` 厳守** — scraper のパターンに依存
+3. **日程文字列は「1試合目行のみ `{M}/{D}({曜}) {会場} 1試合目`、2試合目以降は `{N}試合目` 単独」の2段形式で組み立てる** — scraper の `VENUE_PATTERN` に時刻が混入するのを避け、`currentDate`/`currentVenue` 引き継ぎに依拠する
 4. **Java からの送信は `URLEncoder.encode(value, UTF_8)` で問題なし** — curl の bug は Java には影響しない
 5. **302 の Location ヘッダーから cd を取得** — `HttpClient` は `redirect(NEVER)` 相当で初期化
 6. **`densuke_urls` テーブルには `cd` と `sd` 両方保存を検討** — sd は将来の編集機能で必要になる可能性

--- a/docs/features/densuke-page-creator/densuke-form-spec.md
+++ b/docs/features/densuke-page-creator/densuke-form-spec.md
@@ -1,0 +1,230 @@
+# densuke.biz 新規ページ作成 API 仕様（タスク1 調査結果）
+
+調査日: 2026-04-17
+調査方法: curl による HTTP リクエスト検証
+テスト作成したイベント: `cd=wAeAQgkBpAAgeMrK`, `sd=inNwg4mqS2.wk` （削除予定）
+
+---
+
+## 1. 画面フロー
+
+```
+[GET  /event]      フォーム表示
+     ↓ 入力
+[POST /confirm]    確認画面（クライアント側バリデーション後に自動送信）
+     ↓ 確認
+[POST /create]     実作成、302 で /complete にリダイレクト
+     ↓ 302
+[GET  /complete?cd=xxx&sd=xxx]  作成完了画面
+     
+以降:
+[GET  /list?cd=xxx]  出欠表ページ（既存 DensukeScraper のターゲット）
+```
+
+**重要:** **/create に直接 POST できる**ことを検証済み。`/confirm` を経由せずとも作成可能。アプリ実装では `/create` を 1 回叩けば完了。
+
+---
+
+## 2. /create エンドポイント仕様
+
+### リクエスト
+- **URL:** `https://www.densuke.biz/create`
+- **Method:** POST
+- **Content-Type:** `application/x-www-form-urlencoded`
+- **認証:** **不要**（匿名作成可能）
+- **Cookie:** 不要（作成時点では未発行）
+
+### 必須ヘッダー（念のため付与推奨）
+- `User-Agent`: 通常のブラウザ UA
+- `Referer`: `https://www.densuke.biz/confirm` または `https://www.densuke.biz/event`
+- `Origin`: `https://www.densuke.biz`
+
+### フォームフィールド
+
+| name | 必須 | 型 | 説明 |
+|---|---|---|---|
+| `eventname` | ✅ | text (max 250) | イベント名 |
+| `schedule` | ✅ | textarea | **候補日程。1行1候補で改行区切り** |
+| `explain` | 任意 | textarea | イベント説明文（出欠登録ページ先頭に表示） |
+| `email` | 任意 | text (max 250) | 主催者メアド（登録内容の控えが送られる）|
+| `pw` | ✅ | radio (0/1) | パスワード設定 0=なし, 1=あり |
+| `password` | 条件付き | text (max 8) | pw=1 のとき必須、英数字8文字以内 |
+| `eventchoice` | ✅ | radio (1/2/3) | 回答選択肢 1=`○△×`, 2=`○×`, 3=`◎○△×` |
+| `postfix` | 任意 | text | 日付末尾に一括追加する文字列（通常空で可）|
+
+### レスポンス
+- **HTTP 302 Found**
+- **Location ヘッダー:** `complete?cd=<CD>&sd=<SD>`
+  - 例: `complete?cd=wAeAQgkBpAAgeMrK&sd=inNwg4mqS2.wk`
+- **Set-Cookie:** `<CD>EDT=<SD>; expires=...; Max-Age=15552000`
+  - Cookie 名は「CD + "EDT"」= 編集用 (Edit) セッション
+  - Max-Age: 180 日
+
+### cd / sd の役割
+- **cd**: 公開用サイトコード（16文字の英数字大小混在）。`/list?cd=xxx` で誰でも出欠表にアクセス可能
+- **sd**: 管理者用シークレット（13文字、英数字+ドット）。編集・削除時に必要
+
+---
+
+## 3. UTF-8 エンコーディングの注意点 ⚠️
+
+Windows Git Bash 環境の curl `--data-urlencode` で**日本語が正しく送信されない問題**が発生した。具体的には、日本語を含むフィールドがサーバー側で「空」として受信される。
+
+**原因（推定）:** Git Bash の curl が --data-urlencode でシェルの codepage 変換をかけるなどで UTF-8 バイト列が崩れる。
+
+**回避策:** 手動で UTF-8 バイト列を `%XX` 形式に変換してから `--data-raw` で送信すれば動作する。
+
+```bash
+# urlenc 関数定義
+urlenc() { printf '%s' "$1" | od -An -t x1 | tr -d ' \n' | sed 's/../%&/g'; }
+
+EVENTNAME=$(urlenc "イベント名")
+curl -X POST --data-raw "eventname=${EVENTNAME}&..." https://www.densuke.biz/create
+```
+
+**Java 実装での影響:**
+Java の標準ライブラリ（`java.net.http.HttpClient`, Spring `RestTemplate`/`WebClient`, Apache HttpClient）は内部で UTF-8 の URL エンコーディングを正しく処理するため、**この問題は Java 実装では発生しない**。`URLEncoder.encode(value, StandardCharsets.UTF_8)` を使えば OK。
+
+---
+
+## 4. 候補日程（schedule）のフォーマット
+
+### 伝助での入力形式（自由書式）
+- 1行 1 候補
+- 改行区切り
+- 例:
+  ```
+  7/27(金) 20:00～
+  7/28(土) 19:00～
+  7/30(月) 20:00～
+  ```
+
+### match-tracker での組み立て要件 ⚠️
+
+既存の [`DensukeScraper.java`](../../karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeScraper.java) は以下の正規表現で日程ラベルをパースする:
+
+- `DATE_PATTERN`: `(\d{1,2})/(\d{1,2})\([^)]+\)` — 月/日(曜)
+- `MATCH_PATTERN`: `(\d+)試合目`
+- `VENUE_PATTERN`: `\([^)]+\)(.+?)[\s\u3000]+\d+試合目` — 曜日の後〜「N試合目」の間を会場名と認識
+
+つまり、伝助ページ側の各行は**以下のフォーマットで組み立てる必要がある**:
+
+```
+{M}/{D}({曜日}) {HH:MM}～{会場名} {N}試合目
+```
+
+**具体例（1日3試合の場合）:**
+```
+4/20(月) 17:20～すずらん 1試合目
+4/20(月) 18:45～すずらん 2試合目
+4/20(月) 20:10～すずらん 3試合目
+4/22(水) 17:20～はまなす 1試合目
+4/22(水) 18:45～はまなす 2試合目
+```
+
+### アプリ側の実装方針
+- 対象月の `practice_sessions` を全件取得
+- 各セッションについて、`total_matches`（未設定時は `venues.default_match_count`）の回数ループ
+- 試合ごとに `venue_match_schedules` の `start_time` を時刻として使う
+- 曜日は Java の `DayOfWeek` から日本語短縮名にマッピング（日/月/火/水/木/金/土）
+- 複数の練習日を改行で連結して `schedule` パラメータに入れる
+
+---
+
+## 5. 動作検証済みの curl コマンド例
+
+```bash
+urlenc() { printf '%s' "$1" | od -An -t x1 | tr -d ' \n' | sed 's/../%&/g'; }
+
+EVENTNAME=$(urlenc "2026年5月練習出欠")
+SCHEDULE=$(urlenc $'5/5(火) 17:20～すずらん 1試合目\n5/5(火) 18:45～すずらん 2試合目')
+EXPLAIN=$(urlenc "5月の練習日程")
+
+curl -X POST \
+  -H 'User-Agent: Mozilla/5.0' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H 'Origin: https://www.densuke.biz' \
+  -H 'Referer: https://www.densuke.biz/confirm' \
+  --data-raw "postfix=&eventname=${EVENTNAME}&schedule=${SCHEDULE}&explain=${EXPLAIN}&email=&pw=0&password=&eventchoice=1" \
+  -i \
+  https://www.densuke.biz/create
+```
+
+**期待レスポンス:**
+```
+HTTP/1.1 302 Found
+Location: complete?cd=<16文字>&sd=<13文字>
+Set-Cookie: <cd>EDT=<sd>; ...
+```
+
+レスポンスボディは空。`cd` は Location ヘッダーからパース。
+
+---
+
+## 6. Java 実装で使うコード骨子（参考）
+
+```java
+// HttpClient でのリクエスト組み立て
+Map<String, String> fields = new LinkedHashMap<>();
+fields.put("postfix", "");
+fields.put("eventname", title);
+fields.put("schedule", scheduleText);  // 改行区切りの日程文字列
+fields.put("explain", description);
+fields.put("email", contactEmail != null ? contactEmail : "");
+fields.put("pw", "0");
+fields.put("password", "");
+fields.put("eventchoice", "1");
+
+String body = fields.entrySet().stream()
+    .map(e -> URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8) + "="
+            + URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8))
+    .collect(Collectors.joining("&"));
+
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("https://www.densuke.biz/create"))
+    .header("Content-Type", "application/x-www-form-urlencoded")
+    .header("User-Agent", "Mozilla/5.0")
+    .header("Origin", "https://www.densuke.biz")
+    .header("Referer", "https://www.densuke.biz/confirm")
+    .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+    .build();
+
+// redirect follow を無効にして 302 Location から cd を取り出す
+HttpResponse<Void> response = client.send(request,
+    HttpResponse.BodyHandlers.discarding());
+
+String location = response.headers().firstValue("Location").orElseThrow();
+// location = "complete?cd=wAeAQgkBpAAgeMrK&sd=inNwg4mqS2.wk"
+
+// cd の抽出
+Matcher m = Pattern.compile("cd=([A-Za-z0-9]+)").matcher(location);
+if (!m.find()) throw new RuntimeException("cd を取得できませんでした");
+String cd = m.group(1);
+String densukeUrl = "https://densuke.biz/list?cd=" + cd;
+```
+
+---
+
+## 7. 未検証事項（将来追加調査）
+
+- **削除 API**: sd を使ってテストイベントを削除する方法（`/delete?cd=xxx&sd=xxx` のような可能性）
+- **編集 API**: 作成後に日程追加・変更する方法（本機能では「作成時に全日程確定」で運用するので不要）
+- **パスワード保護あり**の場合の挙動（本機能では pw=0 固定で問題なし）
+- **eventchoice=2, 3 の場合**のスクレイピング時の違い（既存 scraper は `○/△/×` 判定なので、eventchoice=1 で揃える必要あり）
+
+---
+
+## 8. 設計への反映事項
+
+1. **eventchoice は必ず `1`（○△×）で固定** — 既存 scraper のロジック（`col3`=○, `col2`+△ 判定）と整合
+2. **pw は `0`（パスワードなし）で固定** — 運用上パスワード不要
+3. **日程文字列は `{M}/{D}({曜}) {HH:MM}～{会場} {N}試合目` 厳守** — scraper のパターンに依存
+4. **Java からの送信は `URLEncoder.encode(value, UTF_8)` で問題なし** — curl の bug は Java には影響しない
+5. **302 の Location ヘッダーから cd を取得** — `HttpClient` は `redirect(NEVER)` 相当で初期化
+6. **`densuke_urls` テーブルには `cd` と `sd` 両方保存を検討** — sd は将来の編集機能で必要になる可能性
+
+---
+
+## 9. テストイベントの扱い
+
+今回作成したテストイベント `cd=wAeAQgkBpAAgeMrK` は、伝助サーバー上に残っている。削除方法が判明したら削除すること。URL: https://densuke.biz/list?cd=wAeAQgkBpAAgeMrK

--- a/docs/features/densuke-page-creator/implementation-plan.md
+++ b/docs/features/densuke-page-creator/implementation-plan.md
@@ -1,0 +1,233 @@
+---
+status: completed
+---
+# densuke-page-creator 実装手順書
+
+参照: [requirements.md](./requirements.md)
+親Issue: [#452](https://github.com/poponta2020/match-tracker/issues/452)
+
+## 実装タスク
+
+### タスク1: densuke.biz 新規ページ作成フォームの解析（前提調査）
+- [x] 完了（2026-04-17、結果は densuke-form-spec.md）
+- **概要:** 実装に入る前に densuke.biz 側の仕様を実測する。ユーザー（管理者）が伝助で実際に新規ページを作成する操作を行い、ブラウザの DevTools で通信ログを取得してもらう。得た情報で `requirements.md` の「4.5 未確定事項」を埋める
+- **変更対象ファイル:**
+  - `docs/features/densuke-page-creator/densuke-form-spec.md`(新規) — 解析結果を記録
+  - `docs/features/densuke-page-creator/requirements.md` — 4.5 節を更新
+- **確認項目:**
+  - 新規ページ作成エンドポイント（URL パス、HTTP メソッド）
+  - 作成フォームの必須／任意フィールド名と送信値の仕様
+  - ログイン認証の要否（ユーザー認識では不要）
+  - 作成完了レスポンスから `cd` を取得する方法（Location ヘッダー／本文パース）
+  - 日程行（日付×試合番号×時刻×会場ラベル）の書き込みエンドポイントとフォーム構造
+  - `contact_email`（連絡先メアド）が伝助のどのフィールドに入るか
+- **依存タスク:** なし
+- **対応 Issue:** [#453](https://github.com/poponta2020/match-tracker/issues/453)
+
+### タスク2: densuke_templates テーブル作成
+- [x] 完了（2026-04-17）
+- **追加対応:** densuke_urls に sd カラム追加（タスク1で判明）
+- **概要:** テンプレート保存用の新規テーブル・Entity・Repository を作成
+- **変更対象ファイル:**
+  - `database/create_densuke_templates.sql`(新規) — マイグレーション SQL
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/entity/DensukeTemplate.java`(新規)
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/repository/DensukeTemplateRepository.java`(新規)
+- **依存タスク:** なし
+- **対応 Issue:** [#454](https://github.com/poponta2020/match-tracker/issues/454)
+
+### タスク3: line_notification_preferences への列追加
+- [x] 完了（2026-04-17）
+- **概要:** LINE 通知設定テーブルに `densuke_page_created` 列を追加し、Entity と DTO を更新
+- **変更対象ファイル:**
+  - `database/add_densuke_page_created_line_preference.sql`(新規)
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineNotificationPreference.java` — フィールド追加
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/dto/LineNotificationPreferenceDto.java`(または該当 DTO) — 入出力対応
+- **依存タスク:** なし
+- **対応 Issue:** [#455](https://github.com/poponta2020/match-tracker/issues/455)
+
+### タスク4: LineNotificationType enum に DENSUKE_PAGE_CREATED 追加
+- [x] 完了（2026-04-17）
+- **追加対応:** `LineNotificationService.isLineTypeEnabled()` の switch 式に case 追加
+- **概要:** 通知種別 enum に新規種別を追加
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineNotificationType.java`（または該当 enum 定義ファイル）
+- **依存タスク:** なし
+- **対応 Issue:** [#456](https://github.com/poponta2020/match-tracker/issues/456)
+
+### タスク5: DensukeTemplateService と DTO 実装
+- [x] 完了（2026-04-17）
+- **概要:** テンプレート CRUD のサービス層、入出力 DTO を実装
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeTemplateService.java`(新規)
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukeTemplateDto.java`(新規)
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukeTemplateUpdateRequest.java`(新規)
+- **主要メソッド:**
+  - `getTemplate(orgId)` — テンプレート取得。未登録団体にはデフォルト値返却
+  - `updateTemplate(orgId, request)` — テンプレート更新
+- **依存タスク:** タスク2
+- **対応 Issue:** [#457](https://github.com/poponta2020/match-tracker/issues/457)
+
+### タスク6: LineNotificationService への通知メソッド追加
+- [x] 完了（2026-04-17）
+- **概要:** 伝助ページ作成通知を LINE で送信するメソッドを追加
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java` — `sendDensukePageCreatedNotification(organizationId, year, month, densukeUrl)` 追加
+- **処理:**
+  - 指定団体の PLAYER ロールメンバーを列挙
+  - メッセージ組み立て（`{month}月の練習日程が出ました` + 本文）
+  - `sendToPlayer(playerId, DENSUKE_PAGE_CREATED, message)` を個別に呼ぶ
+  - 送信失敗はログ記録のみで継続
+- **依存タスク:** タスク3, タスク4
+- **対応 Issue:** [#458](https://github.com/poponta2020/match-tracker/issues/458)
+
+### タスク7: DensukePageCreateService 実装（コア）
+- [x] 完了（2026-04-17）
+- **概要:** 伝助ページ作成の中核ロジック
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java`(新規)
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukePageCreateRequest.java`(新規)
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukePageCreateResponse.java`(新規)
+- **処理フロー:**
+  1. バリデーション（practice_sessions 0件、venue_match_schedules 不整合、densuke_urls 既存）
+  2. テンプレート解決（プレースホルダー置換、overrides 適用）
+  3. densuke.biz に新規ページ作成 POST（タスク1 の調査結果に基づく）
+  4. 日程行書き込み（日付×試合×時刻×会場）
+  5. densuke_urls にレコード保存
+  6. `@TransactionalEventListener(phase = AFTER_COMMIT)` で LINE 通知発火
+- **依存タスク:** タスク1, タスク2, タスク6
+- **対応 Issue:** [#459](https://github.com/poponta2020/match-tracker/issues/459)
+
+### タスク8: DensukeTemplateController 実装
+- [x] 完了（2026-04-17）
+- **概要:** テンプレート CRUD API エンドポイント
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/controller/DensukeTemplateController.java`(新規)
+- **エンドポイント:**
+  - `GET /api/densuke-templates/{organizationId}`
+  - `PUT /api/densuke-templates/{organizationId}`
+  - 権限: `@RequireRole({ADMIN, SUPER_ADMIN})`
+- **依存タスク:** タスク5
+- **対応 Issue:** [#460](https://github.com/poponta2020/match-tracker/issues/460)
+
+### タスク9: PracticeSessionController にページ作成エンドポイント追加
+- [x] 完了（2026-04-17）
+- **概要:** 伝助ページ作成の API エンドポイントを既存 Controller に追加
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/controller/PracticeSessionController.java` — `POST /densuke/create-page` 追加
+- **エンドポイント:**
+  - `POST /api/practice-sessions/densuke/create-page`
+  - 権限: `@RequireRole({ADMIN, SUPER_ADMIN})`
+- **依存タスク:** タスク7
+- **対応 Issue:** [#461](https://github.com/poponta2020/match-tracker/issues/461)
+
+### タスク10: バックエンドテスト追加
+- [x] 完了（2026-04-17）
+- **概要:** Service / Controller の単体テスト追加
+- **変更対象ファイル:**
+  - `karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukePageCreateServiceTest.java`(新規)
+  - `karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeTemplateServiceTest.java`(新規)
+  - `karuta-tracker/src/test/java/com/karuta/matchtracker/controller/DensukeTemplateControllerTest.java`(新規)
+  - `karuta-tracker/src/test/java/com/karuta/matchtracker/controller/PracticeSessionControllerTest.java` — 作成エンドポイントのテスト追加
+- **テスト観点:**
+  - バリデーション失敗ケース（練習日0件、venue_match_schedules 不足、既存 URL）
+  - densuke.biz 通信モックでの正常系・異常系
+  - LINE 通知が呼ばれること／失敗しても作成は成功すること
+  - 権限チェック（PLAYER ロールのアクセス拒否）
+- **依存タスク:** タスク7, タスク8, タスク9
+- **対応 Issue:** [#462](https://github.com/poponta2020/match-tracker/issues/462)
+
+### タスク11: テンプレート編集モーダルのフロントエンド実装
+- [x] 完了（2026-04-17）
+- **概要:** 伝助管理画面の各団体カードにテンプレート編集モーダルを追加（設計変更: 当初想定の OrganizationSettings タブ追加から**モーダル化**に変更 — OrganizationSettings が実態として「所属団体選択画面」で構造が違ったため）
+- **変更対象ファイル:**
+  - `karuta-tracker-ui/src/pages/densuke/DensukeTemplateModal.jsx`(新規) — モーダル本体、プレースホルダープレビュー付き
+  - `karuta-tracker-ui/src/pages/densuke/DensukeManagement.jsx` — 「テンプレート編集」ボタン追加、モーダル起動
+  - `karuta-tracker-ui/src/api/densukeTemplates.js`(新規) — API クライアント
+- **依存タスク:** タスク8
+- **対応 Issue:** [#463](https://github.com/poponta2020/match-tracker/issues/463)
+
+### タスク12: 伝助ページ作成モーダルのフロントエンド実装
+- [x] 完了（2026-04-17）
+- **概要:** 伝助管理画面に作成ボタン＋モーダルを追加
+- **変更対象ファイル:**
+  - `karuta-tracker-ui/src/pages/densuke/DensukePageCreateModal.jsx`(新規) — モーダル本体
+  - `karuta-tracker-ui/src/pages/densuke/DensukeManagement.jsx` — ボタン追加・モーダル起動処理
+  - `karuta-tracker-ui/src/api/practices.js` — `createDensukePage()` 追加
+- **UI 挙動:**
+  - 年月選択は現在月＋未来 2 ヶ月まで
+  - 作成中: スピナー表示、ボタン無効化
+  - 成功: トースト表示＋モーダル閉じ＋カード更新
+  - 失敗: モーダル内エラー表示、リトライ可能
+  - 既存 URL がある月は作成ボタン非表示
+- **依存タスク:** タスク9
+- **対応 Issue:** [#464](https://github.com/poponta2020/match-tracker/issues/464)
+
+### タスク13: LINE 通知設定画面への ON/OFF トグル追加
+- [x] 完了（2026-04-17）
+- **概要:** 既存の LINE 通知設定画面に伝助ページ作成通知の ON/OFF を追加
+- **変更対象ファイル:**
+  - LINE 通知設定画面（既存） — トグル追加（ファイルパスは画面調査後に確定）
+  - 関連 API クライアント — 設定項目の入出力対応
+- **依存タスク:** タスク3
+- **対応 Issue:** [#465](https://github.com/poponta2020/match-tracker/issues/465)
+
+### タスク14: E2E 動作確認
+- [ ] 完了
+- **概要:** 開発環境で実動作確認
+- **確認項目:**
+  - 伝助ページが正しく作成される（タスク1 で特定したエンドポイントが機能する）
+  - `densuke_urls` に新レコードが保存される
+  - 指定月の全練習日×試合枠が伝助ページ上に並ぶ
+  - 時刻は `venue_match_schedules` の値が反映される
+  - LINE 通知が対象メンバーに届く（管理者には届かない）
+  - ON/OFF 設定の OFF で通知が抑制される
+  - 既存の `DensukeSyncScheduler` が新 URL を次回サイクルで読み込む
+  - バリデーションエラーケース（0件、不整合、既存 URL）が意図通り動作
+- **依存タスク:** タスク10, タスク11, タスク12, タスク13
+- **対応 Issue:** [#466](https://github.com/poponta2020/match-tracker/issues/466)
+
+### タスク15: ドキュメント更新
+- [x] 完了（2026-04-17）
+- **概要:** CLAUDE.md のルールに従い、主要ドキュメントを更新
+- **変更対象ファイル:**
+  - `docs/SPECIFICATION.md` — 伝助ページ自動作成機能の仕様追加
+  - `docs/SCREEN_LIST.md` — 作成モーダル、テンプレート編集タブを追記
+  - `docs/DESIGN.md` — 新規テーブル・クラス構成を追記
+- **依存タスク:** タスク14（動作確認完了後、実装が確定した内容で更新）
+- **対応 Issue:** [#467](https://github.com/poponta2020/match-tracker/issues/467)
+
+## 実装順序
+
+```
+タスク1 #453 (伝助仕様解析)
+  │
+  ├─ タスク2 #454 (densuke_templates テーブル)
+  ├─ タスク3 #455 (line_notification_preferences 列追加)
+  └─ タスク4 #456 (LineNotificationType enum 追加)
+       │
+       ├─ タスク5 #457 (DensukeTemplateService) ← タスク2
+       │    └─ タスク8 #460 (DensukeTemplateController)
+       │         └─ タスク11 #463 (テンプレート編集タブ)
+       │
+       ├─ タスク6 #458 (LINE 通知メソッド) ← タスク3, タスク4
+       │    │
+       │    └─ タスク7 #459 (DensukePageCreateService) ← タスク1, タスク2, タスク6
+       │         └─ タスク9 #461 (作成エンドポイント)
+       │              └─ タスク12 #464 (作成モーダル)
+       │
+       └─ タスク13 #465 (LINE 設定トグル) ← タスク3
+              │
+              └─ タスク10 #462 (バックエンドテスト) ← タスク7, タスク8, タスク9
+                   │
+                   └─ タスク14 #466 (E2E 動作確認) ← タスク10, タスク11, タスク12, タスク13
+                        │
+                        └─ タスク15 #467 (ドキュメント更新)
+```
+
+**並列可能な区分:**
+- 第1波: タスク2 #454, 3 #455, 4 #456（DB スキーマ整備、独立並列）
+- 第2波: タスク5 #457, 6 #458, 13 #465（Service/Entity 拡張、並列）
+- 第3波: タスク7 #459（コア実装、前提依存）
+- 第4波: タスク8 #460, 9 #461（Controller、並列）
+- 第5波: タスク10 #462, 11 #463, 12 #464（テスト・フロント、並列）
+- 第6波: タスク14 #466 → タスク15 #467（最終確認、順次）

--- a/docs/features/densuke-page-creator/requirements.md
+++ b/docs/features/densuke-page-creator/requirements.md
@@ -1,0 +1,501 @@
+---
+status: completed
+---
+# 伝助ページ自動作成機能（densuke-page-creator） 要件定義書（ドラフト）
+
+## 1. 概要
+
+### 目的
+アプリに登録されている練習会場（venues / venue_match_schedules）と練習日程（practice_sessions）を元に、指定された年月の出欠表ページを densuke.biz 上に自動作成する。
+
+### 背景・動機
+- 現在は管理者が手動で densuke.biz 上に月次の出欠ページを作成し、練習日・会場・試合枠を手入力している
+- アプリにはすでに練習日・会場・試合時間割が登録されており、それを元データに伝助ページを組み立てれば、管理者の手作業を大幅に削減できる
+- 既存の `DensukeImportService` / `DensukeWriteService` は「cd が既知の月次ページ」を読み書きする前提なので、「ページそのものの新規発行」機能は現状ゼロ
+
+### 初期確定事項（Q&A 結果）
+| 項目 | 確定内容 |
+|---|---|
+| 作成単位 | 団体 × 年月（既存 `densuke_urls` と同粒度） |
+| 作成トリガー | 管理画面から手動。年月選択ドロップダウン + 作成ボタン |
+| テンプレート | 団体ごとに事前登録可能。作成時の UI でも編集可能 |
+| テンプレート項目 | タイトル、説明／備考、集計締切、その他 densuke.biz 側の必須項目。**主催者名・連絡先は不要** |
+| 試合枠数 | `practice_sessions.total_matches` を優先。未設定なら `venues.default_match_count` |
+| 試合ごとの開始・終了時刻 | `venue_match_schedules` の `(venue_id, match_number)` → `start_time` / `end_time` |
+| 既存 `densuke_urls` がある場合の扱い | 既存 URL を残して新規作成をスキップ（上書きしない） |
+| 対象会場 | 全練習日（かでる2・7以外のクラ館・東🌸なども含めてまとめて送信） |
+| 機能名 | `densuke-page-creator` |
+
+### 最大の未確定事項（実装着手前に解析必須）
+- **densuke.biz の新規ページ作成フォーム構造が未解析**
+  - POST エンドポイント（URL パス・HTTP メソッド）
+  - フォームフィールド名と必須項目
+  - 作成には管理者ログインが必要か（必要なら認証情報の保管方針も要検討）
+  - 作成完了時に `cd`（サイトコード）がどう返ってくるか
+- → ヒアリング完了後、実装タスクの最初に「ユーザーがブラウザ DevTools で実際に伝助ページ作成操作を行い、通信ログを共有」する手順を組む
+
+## 2. ユーザーストーリー
+
+### 対象ユーザー
+- **SUPER_ADMIN + ADMIN**（既存の伝助関連 API と同じ権限ポリシー）
+
+### ユーザーの目的
+- アプリ側で練習日・会場・試合枠の情報を管理している上で、月初のメンバー周知に使う「伝助ページ」を手動作成する手間を無くす
+- アプリ内の練習データを真のマスタとし、伝助ページはそれを反映した「出欠収集の窓口」として機能させる
+
+### 利用シナリオ（典型フロー）
+1. 管理者が当月～翌月の練習日を `practice_sessions` に一通り登録し終える
+2. 伝助管理画面を開き、対象年月を選択して「伝助ページ作成」ボタンを押す
+3. 作成ダイアログでテンプレート（タイトル／説明／締切など）の初期値を確認、必要があれば編集
+4. 確定ボタンで densuke.biz に新規ページが作成され、発行された `cd` が `densuke_urls` に保存される
+5. 管理者はその伝助 URL をメンバーに周知（コピー or 既存の共有機能）
+6. 以降は既存の `DensukeSyncScheduler`（5 分間隔）が自動的にそのページを読み込み、メンバーの出欠登録がアプリ側に反映される
+
+### 成功の定義
+- **必須:** 指定月の全練習日×試合枠が、伝助ページ上の日程として並んでいる
+- **必須（暗黙）:** 伝助ページが作成され、`cd` が発行される／発行された URL が `densuke_urls` に保存される
+- **対象外:** 団体メンバーの伝助ページへの初期登録は**行わない**。メンバー登録はアプリ側または伝助側でのユーザー自身の操作に任せる
+
+### 失敗時の挙動
+- 伝助との通信が途中で失敗した場合: **エラー表示のみ**
+- 伝助側に中途半端なページが残っても、アプリからは削除・ロールバックは試みない。管理者が必要に応じて伝助上で手動削除する
+
+### 作成後のフォローアップ
+- 作成直後の即時同期は**行わない**
+- 既存の `DensukeSyncScheduler` が次回サイクル（最長5分）で新しい URL を読み込むのを待つ方式に任せる
+
+### メンバーへの通知
+- 作成成功後、その団体に所属する **PLAYER ロールのメンバー全員**に、LINE で「練習日程が公開された」旨を通知する
+- 通知対象から除外: ADMIN ロール、SUPER_ADMIN ロール（=管理者は既に知っているため不要）
+- 通知チャネル: **LINE のみ**（Push・アプリ内通知は送らない）
+- LINE 連携していないメンバーには通知が届かない（仕様上の許容）
+- 通知送信の失敗はログのみ。作成 API 自体の成功/失敗には影響させない
+
+## 3. 機能要件
+
+### 3.1 画面仕様
+
+#### 作成画面の配置
+- 既存の `DensukeManagement.jsx`（伝助管理画面）内の月別 URL カードに「伝助ページ作成」ボタンを追加
+- クリックで作成モーダルを表示
+- モーダル内容:
+  - 対象年月の表示（カードの年月をそのまま使用）
+  - テンプレート初期値が入った編集可能なフォーム（タイトル／説明／締切 等）
+  - 「作成」「キャンセル」ボタン
+
+#### テンプレート編集画面
+- 団体設定画面に新タブ「伝助テンプレート」を追加
+- 団体ごとに1レコードのテンプレートを編集・保存
+
+#### 年月選択範囲
+- 当月＋未来 2 ヶ月まで（過去月は作成不可）
+- 基本的な運用は「翌月分」を作成するユースケースを想定
+
+### 3.2 ビジネスルール
+
+#### 作成スキップ条件
+- 対象年月・団体の `densuke_urls` レコードが既に存在する場合は**作成をスキップ**（上書きしない）
+- UI 上は該当カードの「作成」ボタンを非活性化 or 表示させない
+
+#### 対象練習日
+- 指定年月・指定団体の `practice_sessions` 全件を対象にする
+- 会場の種別によらず、かでる以外（クラ館・東🌸など）も全て含めて送信
+
+#### 試合枠の決定ロジック
+- 試合数: `practice_sessions.total_matches` を優先。未設定時は `venues.default_match_count`
+- 試合ごとの開始・終了時刻: `venue_match_schedules` の `(venue_id, match_number)` → `start_time` / `end_time`
+
+### 3.3 バリデーション・エラーケース
+
+| ケース | 挙動 |
+|---|---|
+| 対象年月の `practice_sessions` が 0 件 | **エラーで作成中断**。「指定月に練習日が登録されていません」表示 |
+| 練習日の会場に `venue_match_schedules` が不足（`total_matches` 未満のレコード数） | **エラーで作成中断**。該当会場を明示してメッセージ表示 |
+| 対象年月・団体の `densuke_urls` が既存 | 「既に作成済みです」表示（作成ボタン自体を表示させない実装）|
+| densuke.biz との通信失敗（作成POST エラー、ネットワーク/タイムアウト） | エラー表示のみ。ロールバックは試みない |
+| densuke.biz 作成後、日程行書き込みで失敗 | エラー表示。伝助側に中途半端なページが残った場合は管理者が手動削除 |
+
+### 3.4 フィードバック
+
+| 状態 | UI |
+|---|---|
+| 進行中 | モーダル内スピナー、ボタン無効化 |
+| 完了 | トーストで伝助 URL 表示、モーダル自動クローズ、月別 URL カード更新（新 URL 反映） |
+| 失敗 | モーダル内エラーメッセージ表示、ボタン有効化（再試行可能）|
+
+### 3.5 通知
+
+#### 通知内容
+- **タイトル:** `{month}月の練習日程が出ました`（例: `5月の練習日程が出ました`）
+- **本文:**
+  ```
+  {団体名}の{year}年{month}月の練習出欠ページが作成されました。
+  以下のリンクから出欠を登録してください:
+  {伝助URL}
+  ```
+- **プレースホルダー:** `{year}`, `{month}`, `{organization_name}`, `{伝助URL}` を Java 側で置換
+
+#### 通知対象
+- 指定団体の `player_organizations` に所属する Player のうち、`role = PLAYER` のアクティブメンバー
+- LINE 連携済み & `LineNotificationPreference.densukePageCreated = true` のメンバーにのみ送信
+
+#### ON/OFF 設定
+- `line_notification_preferences` テーブルに `densuke_page_created BOOLEAN NOT NULL DEFAULT TRUE` 列を追加
+- LINE 通知設定画面（既存）に本項目の ON/OFF トグルを追加
+- デフォルトは ON
+
+#### 送信タイミング・エラー方針
+- 作成 API の処理完了後、トランザクションコミット後に LINE 送信を開始
+- 個別メンバーへの送信失敗はログに残すのみ（他メンバーへの送信は継続）
+- LINE送信が全員失敗しても作成 API のレスポンスは成功として返す
+
+## 4. 技術設計
+
+### 4.1 API 設計
+
+| Method | Path | 権限 | 用途 |
+|---|---|---|---|
+| POST | `/api/practice-sessions/densuke/create-page` | ADMIN, SUPER_ADMIN | 伝助ページ作成 |
+| GET  | `/api/densuke-templates/{organizationId}` | ADMIN, SUPER_ADMIN | テンプレート取得 |
+| PUT  | `/api/densuke-templates/{organizationId}` | ADMIN, SUPER_ADMIN | テンプレート更新 |
+
+#### POST `/api/practice-sessions/densuke/create-page`
+**Request:**
+```json
+{
+  "year": 2026,
+  "month": 5,
+  "organizationId": 1,
+  "overrides": {
+    "title": "...",           // 任意。未指定ならテンプレート値
+    "description": "...",     // 任意
+    "contactEmail": "..."     // 任意
+  }
+}
+```
+
+**Response (成功):**
+```json
+{
+  "cd": "abc123",
+  "url": "https://densuke.biz/list?cd=abc123",
+  "createdDateCount": 8,
+  "createdMatchSlotCount": 40
+}
+```
+
+**Response (失敗):** HTTP 4xx/5xx + メッセージ（バリデーション失敗／伝助通信失敗などケースごと）
+
+### 4.2 DB 設計
+
+#### 既存テーブル変更: `line_notification_preferences`
+
+```sql
+ALTER TABLE line_notification_preferences
+    ADD COLUMN densuke_page_created BOOLEAN NOT NULL DEFAULT TRUE;
+```
+
+#### 新規テーブル: `densuke_templates`
+
+```sql
+CREATE TABLE densuke_templates (
+    id BIGSERIAL PRIMARY KEY,
+    organization_id BIGINT NOT NULL UNIQUE REFERENCES organizations(id),
+    title_template VARCHAR(200) NOT NULL,   -- プレースホルダー対応 ({year}, {month}, {organization_name})
+    description TEXT,
+    contact_email VARCHAR(255),             -- 任意。伝助側フォームで主催者メアド等に使う想定
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+```
+
+- `organization_id` が UNIQUE（1団体1テンプレート）
+- プレースホルダー: `{year}`, `{month}`, `{organization_name}` を Java 側で置換
+- 締切カラムは持たない（伝助側のデフォルトに任せる方針）
+
+#### 既存テーブルの変更
+- `densuke_urls` テーブル自体はスキーマ変更なし（新規作成した `cd` / `url` / `year` / `month` / `organization_id` を保存するだけ）
+
+### 4.3 バックエンド設計
+
+#### 新規クラス構成
+```
+service/
+├── DensukePageCreateService.java         # 伝助ページ作成の中核
+│   ├── createPage(year, month, orgId, overrides, userId)
+│   ├── buildTitleFromTemplate(template, year, month, org)
+│   ├── postCreatePageRequest(...) — densuke.biz へ新規作成 POST
+│   └── postScheduleRows(cd, practiceSessions)  — 日程行書き込み
+├── DensukeTemplateService.java           # テンプレート CRUD
+│   ├── getTemplate(orgId)
+│   └── updateTemplate(orgId, request)
+
+entity/
+└── DensukeTemplate.java
+
+repository/
+└── DensukeTemplateRepository.java
+
+controller/
+├── PracticeSessionController (既存に POST /densuke/create-page を追加)
+└── DensukeTemplateController (新規)
+
+dto/
+├── DensukePageCreateRequest.java
+├── DensukePageCreateResponse.java
+├── DensukeTemplateDto.java
+└── DensukeTemplateUpdateRequest.java
+```
+
+#### 処理フロー（`createPage`）
+1. バリデーション:
+   - 指定月の `practice_sessions` を取得 → 0 件なら例外
+   - 関連 `venue_match_schedules` の整合性チェック（`total_matches` 分の行があるか）→ 不整合なら例外
+   - 既存 `densuke_urls` レコード有無チェック → 既存なら例外
+2. テンプレート取得（`DensukeTemplateRepository`）。`overrides` で上書き
+3. densuke.biz に POST で新規ページ作成 → `cd` を取得（★ 実フォーム解析後に確定）
+4. `cd` を元に日程行書き込み（日付 × 試合番号 × 時刻 × 会場）
+5. `densuke_urls` に新 URL を保存
+6. トランザクションコミット後 (`TransactionSynchronizationManager#registerSynchronization` か `@TransactionalEventListener(phase = AFTER_COMMIT)`) に LINE 通知を発火
+7. レスポンス返却
+
+#### LINE 通知の実装方針
+- `LineNotificationService` に `sendDensukePageCreatedNotification(Long organizationId, int year, int month, String densukeUrl)` を追加
+- 内部で対象団体の PLAYER を列挙し、個別に `sendToPlayer(playerId, LineNotificationType.DENSUKE_PAGE_CREATED, message)` を呼び出す
+- `LineNotificationType` enum に `DENSUKE_PAGE_CREATED` を追加
+- preference チェックは既存の `sendToPlayer` 内部で実施される前提（現実装に合わせる）
+
+### 4.4 フロントエンド設計
+
+#### 新規／変更コンポーネント
+```
+pages/densuke/
+├── DensukeManagement.jsx                 # 既存。月別 URL カードに「伝助ページ作成」ボタン追加
+└── DensukePageCreateModal.jsx            # 新規。作成ダイアログ本体
+
+pages/settings/
+├── OrganizationSettings.jsx              # 既存。タブに「伝助テンプレート」を追加
+└── DensukeTemplateTab.jsx                # 新規。テンプレート編集タブの中身
+
+api/
+├── practices.js                          # createDensukePage() 追加
+└── densukeTemplates.js                   # 新規
+```
+
+#### 状態管理
+- モーダル内の編集値は `useState` のローカル状態
+- 作成中はローディングフラグでボタン無効化
+- 完了時にトースト表示→親画面の月別 URL 一覧を再取得
+
+### 4.5 densuke.biz 側の仕様（確定済み、2026-04-17）
+
+詳細は [densuke-form-spec.md](./densuke-form-spec.md) 参照。要点:
+
+#### エンドポイント
+- **URL:** `POST https://www.densuke.biz/create`
+- **Content-Type:** `application/x-www-form-urlencoded` (UTF-8)
+- **認証:** 不要（匿名作成可能）
+- **/confirm の事前 POST は不要** — `/create` に直接 POST でOK（ワンショット）
+
+#### 必須ヘッダー
+- `User-Agent`: 通常のブラウザ UA
+- `Referer`: `https://www.densuke.biz/confirm`
+- `Origin`: `https://www.densuke.biz`
+
+#### フォームフィールド（固定値と可変値）
+| フィールド | 送信値 |
+|---|---|
+| `eventname` | テンプレートから組み立てたタイトル（プレースホルダー置換後）|
+| `schedule` | 練習日×試合枠を改行区切りで連結した文字列（詳細下記）|
+| `explain` | テンプレートの説明文 |
+| `email` | テンプレートの `contact_email`（空文字可）|
+| `pw` | **`0` で固定**（パスワードなし）|
+| `password` | 空文字 |
+| `eventchoice` | **`1` で固定**（`○△×`、既存 DensukeScraper の判定ロジックと整合）|
+| `postfix` | 空文字 |
+
+#### `schedule` 文字列の組み立てフォーマット ⚠️
+
+既存 [`DensukeScraper`](../../karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeScraper.java) の正規表現と整合させるため、以下の形式を厳守:
+
+```
+{M}/{D}({曜日}) {HH:MM}～{会場名} {N}試合目
+```
+
+各練習日について `total_matches`（未設定時は `venues.default_match_count`）の回数ループし、`venue_match_schedules` の `start_time` を時刻として使う。
+
+**例（1日3試合の場合）:**
+```
+4/20(月) 17:20～すずらん 1試合目
+4/20(月) 18:45～すずらん 2試合目
+4/20(月) 20:10～すずらん 3試合目
+4/22(水) 17:20～はまなす 1試合目
+...
+```
+
+#### レスポンス
+- **HTTP 302 Found**
+- **Location ヘッダー:** `complete?cd=<16文字>&sd=<13文字>`
+- `cd` を `Location` から正規表現で抽出 → `https://densuke.biz/list?cd={cd}` として `densuke_urls` に保存
+- `sd` は将来の編集・削除 API で必要になる可能性があるため、**`densuke_urls` テーブルに `sd` カラムを追加して保存する**
+
+#### DB スキーマ追加（4.2 の補強）
+`densuke_urls` テーブルに編集用シークレット `sd` カラムを追加:
+```sql
+ALTER TABLE densuke_urls ADD COLUMN densuke_sd VARCHAR(32);
+```
+- 手動登録 URL は NULL のまま（既存データと互換）
+- 自動作成時のみ値が入る
+
+#### Java 実装方針
+- `java.net.http.HttpClient` または Spring `RestTemplate` + `URLEncoder.encode(value, StandardCharsets.UTF_8)` で UTF-8 エンコードを行う
+- `HttpClient.Builder.followRedirects(NEVER)` で 302 を手動処理し、Location から cd を取得
+- タイムアウト: 10〜30 秒程度（既存 `DensukeScraper` の 10 秒と揃えるか長めに）
+
+#### contact_email の扱い
+- 伝助側の `email` フィールドに送信。主催者の控えメール送付先として使われる（伝助ページ上には表示されない）
+- 空でも正常に作成可能なので、`densuke_templates.contact_email` が NULL/空の団体はそのまま空で送信
+
+## 5. 影響範囲
+
+### 5.1 新規作成するファイル
+
+#### バックエンド
+| パス | 役割 |
+|---|---|
+| `database/create_densuke_templates.sql` | テンプレートテーブルのマイグレーション |
+| `database/add_densuke_page_created_line_preference.sql` | LINE 通知設定列の追加 |
+| `entity/DensukeTemplate.java` | テンプレートエンティティ |
+| `repository/DensukeTemplateRepository.java` | テンプレート Repository |
+| `service/DensukePageCreateService.java` | ページ作成サービス |
+| `service/DensukeTemplateService.java` | テンプレート CRUD サービス |
+| `controller/DensukeTemplateController.java` | テンプレート CRUD Controller |
+| `dto/DensukePageCreateRequest.java` | ページ作成リクエスト DTO |
+| `dto/DensukePageCreateResponse.java` | ページ作成レスポンス DTO |
+| `dto/DensukeTemplateDto.java` | テンプレート DTO |
+| `dto/DensukeTemplateUpdateRequest.java` | テンプレート更新リクエスト DTO |
+
+#### フロントエンド
+| パス | 役割 |
+|---|---|
+| `pages/densuke/DensukePageCreateModal.jsx` | 作成モーダル本体 |
+| `pages/settings/DensukeTemplateTab.jsx` | テンプレート編集タブ |
+| `api/densukeTemplates.js` | テンプレート API クライアント |
+
+### 5.2 既存ファイルの変更
+
+#### バックエンド
+| パス | 変更内容 |
+|---|---|
+| `controller/PracticeSessionController.java` | `POST /densuke/create-page` エンドポイント追加 |
+| `service/LineNotificationService.java` | `sendDensukePageCreatedNotification()` メソッド追加 |
+| `entity/LineNotificationPreference.java` | `densukePageCreated` フラグ列を追加 |
+| `entity/LineNotificationType.java`（または該当 enum） | `DENSUKE_PAGE_CREATED` 追加 |
+| `dto/LineNotificationPreferenceDto.java` 等 | 新フラグ項目の入出力対応 |
+| `service/DensukeSyncService.java` | 変更なし（新規作成された `densuke_urls` は既存フローで自動読込） |
+
+#### フロントエンド
+| パス | 変更内容 |
+|---|---|
+| `pages/densuke/DensukeManagement.jsx` | 各団体カードに「伝助ページ作成」ボタン追加、モーダル起動処理 |
+| `pages/settings/OrganizationSettings.jsx` | 「伝助テンプレート」タブを追加（`DensukeTemplateTab` を組み込む）|
+| LINE 通知設定画面（既存） | `densukePageCreated` の ON/OFF トグルを追加 |
+| `api/practices.js` | `createDensukePage()` 追加 |
+
+### 5.3 既存機能への影響
+
+| 既存機能 | 影響 |
+|---|---|
+| `DensukeSyncScheduler`（5分間隔読み書き） | **影響なし**。新規保存された `densuke_urls` は次回サイクルで通常通り読み込まれる |
+| `DensukeScraper` による会場名マッチング | **影響なし**。ただし伝助に書き込む会場名の文字列は Venue マスタと完全一致させる必要がある（マッチングに失敗すると `unmatchedVenues` 通知が発火する）|
+| `DensukeWriteService`（既存出欠書き込み） | **影響なし**。新機能は別クラスで実装 |
+| 既存の伝助手動 URL 登録（`PUT /densuke-url`） | **共存**。手動登録 or 自動作成、どちらのケースでも同じ `densuke_urls` 行が作られるだけ |
+| 既存 `DensukeUrl` のデータ | 既存データに変更なし。新規作成時のみ新レコード追加 |
+
+### 5.4 API・DB の後方互換性
+
+| 項目 | 互換性 |
+|---|---|
+| 既存 API | 変更なし（追加のみ）|
+| `densuke_urls` テーブル | スキーマ変更なし |
+| `densuke_templates` テーブル | 新規追加。団体ごとにレコードが無ければデフォルト値を Java 側で供給し動作（未整備団体でも `GET` は 404 ではなくデフォルト値返却にする設計を想定）|
+
+### 5.5 テストへの影響
+
+| レベル | 追加範囲 |
+|---|---|
+| Unit | `DensukePageCreateServiceTest`, `DensukeTemplateServiceTest`（新規）|
+| Controller | `DensukeTemplateControllerTest`（新規）、`PracticeSessionControllerTest` に作成エンドポイントのテスト追加 |
+| Integration | densuke.biz への実通信はモック化（既存の `DensukeWriteServiceTest` と同じ方針）|
+
+### 5.6 ドキュメント更新対象（CLAUDE.md ルール）
+
+| ドキュメント | 更新内容 |
+|---|---|
+| `docs/SPECIFICATION.md` | 伝助ページ自動作成機能の仕様追加 |
+| `docs/SCREEN_LIST.md` | 作成モーダル、テンプレート編集タブを追記 |
+| `docs/DESIGN.md` | 新規テーブル・クラス構成を追記 |
+
+### 5.7 運用・環境への影響
+
+| 項目 | 影響 |
+|---|---|
+| 環境変数 | 追加なし（認証情報は不要、メアドは団体ごとに DB 管理）|
+| GitHub Actions | 変更なし |
+| Render デプロイ | 変更なし（DB マイグレーション `create_densuke_templates.sql` の実行手順は通常通り）|
+| Docker | 変更なし |
+
+### 5.8 未確定事項が確定した時の追加影響
+
+densuke.biz の実フォーム解析後に判明する可能性のある追加変更:
+- フォームが想定より複雑で、テンプレートに列追加が必要になる可能性
+- 認証が必要と判明した場合、`densuke_templates` にクレデンシャル列追加 ＋ 暗号化処理が必要
+- `cd` の取得方法が HTML 本文パースの場合、`Jsoup` の追加処理が必要
+
+## 6. 設計判断の根拠
+
+### 6.1 作成ロジックを独立クラスにする理由
+- 既存 `DensukeWriteService` は 874 行あり「既知ページへの出欠書き込み」特化
+- 新機能「ページそのものの発行」は責務が全く異なる（テンプレート解決、プレースホルダー置換、初期日程の書き込みなど）
+- 同一クラスに混在させると可読性・テスト容易性が下がるため、`DensukePageCreateService` として分離
+
+### 6.2 テンプレートを団体ごとにする理由
+- 団体によってタイトルの書式、説明文、連絡先メアドが異なる
+- 既存設計でも `densuke_urls` が団体ごとに管理されており、自然な粒度
+- システムワイド1テンプレートだと、将来団体追加時に挙動が壊れるリスク
+
+### 6.3 作成後に即時同期を行わない理由
+- 既存 `DensukeSyncScheduler` が 5 分以内に必ず読み込みを実行
+- 即時同期を入れると「作成 API のレスポンス時間が長くなる」「同期失敗時のエラーハンドリングが二重で必要」というデメリット
+- ユーザー体験として「URL が作られ、5 分待てば反映される」は受容可能
+
+### 6.4 失敗時のロールバックを実装しない理由
+- densuke.biz 側に「作成したページの削除 API」があるか不明。現状のコードにも痕跡なし
+- 仮に削除手段があっても、伝助との通信が不安定な状況で削除 API も失敗する可能性が高く、結局手動対応になる
+- 発生頻度が低いエラーに実装コストを割くより、管理者手動対応を選ぶ方が合理的
+
+### 6.5 テンプレートに締切列を持たない理由
+- 伝助側の締切仕様（月単位 or 日単位）がまだ不明
+- 過剰設計を避け、伝助デフォルト挙動に任せる
+- 将来的に必要と判明したらカラム追加で対応可能
+
+### 6.6 試合枠数を `practice_sessions.total_matches` 優先、`venues.default_match_count` フォールバックにする理由
+- 既存コード（[PracticeSessionService.java:329](karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java#L329) など）と挙動を揃える
+- 同じロジックが複数箇所にあると不整合リスクが高まるため、既存慣習を踏襲
+
+### 6.7 通知を LINE のみに限定する理由
+- 既存の Densuke 関連通知（`DENSUKE_UNMATCHED_NAMES`）は管理者向けで Push のみ
+- 本機能は全メンバー向けで、気付かれやすさが最重要
+- LINE は能動的にチェックするチャネルのため伝助 URL の周知に適する
+- Push のみだとアプリを開かないメンバーに気付かれにくい／アプリ内通知のみでは手動確認が必要
+- 将来的に Push を追加したくなった場合でも、既存の `LineNotificationType` / `NotificationType` の仕組みで拡張可能
+
+### 6.8 作成 API 成功／LINE 送信失敗を独立扱いする理由
+- LINE 送信は外部 API コール（Messaging API）で失敗要因が多い
+- 送信失敗を作成 API 失敗にすると、伝助ページは作成済みなのに作成 API が失敗を返す矛盾が生じる
+- 通知は「連絡」であって作成処理本体の結果ではない
+
+### 6.9 対象年月を「当月＋2 ヶ月先まで」に絞る理由
+- 主ユースケース「翌月分の作成」に最適化
+- 過去月の作成は運用上意味がない（既に練習日が過ぎている）
+- 3 ヶ月以上先は練習日登録が無いので意味がない

--- a/docs/features/densuke-page-creator/requirements.md
+++ b/docs/features/densuke-page-creator/requirements.md
@@ -318,19 +318,21 @@ api/
 
 既存 [`DensukeScraper`](../../karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeScraper.java) の正規表現と整合させるため、以下の形式を厳守:
 
-```
-{M}/{D}({曜日}) {HH:MM}～{会場名} {N}試合目
-```
+- 各セッション（日付 × 会場）の **1試合目行**: `{M}/{D}({曜日}) {会場名} 1試合目`
+- 同じセッションの **2試合目以降**: `{N}試合目` のみ
+- **時刻は含めない**（混入すると `VENUE_PATTERN` が時刻込み文字列を会場名として拾うため）
 
-各練習日について `total_matches`（未設定時は `venues.default_match_count`）の回数ループし、`venue_match_schedules` の `start_time` を時刻として使う。
+`DensukeScraper` は `currentDate` / `currentVenue` を前行から引き継ぐので、2試合目以降で日付・会場を省略しても同期は成立する。
 
-**例（1日3試合の場合）:**
+各練習日について `total_matches`（未設定時は `venues.default_match_count`）の回数ループ。`venue_match_schedules` は「`total_matches` 分のレコードがあるか」という整合性チェックのためにロードするのみで、`start_time` は densuke 送信文字列には含めない。
+
+**例（1日3試合 × 2日）:**
 ```
-4/20(月) 17:20～すずらん 1試合目
-4/20(月) 18:45～すずらん 2試合目
-4/20(月) 20:10～すずらん 3試合目
-4/22(水) 17:20～はまなす 1試合目
-...
+4/20(月) すずらん 1試合目
+2試合目
+3試合目
+4/22(水) はまなす 1試合目
+2試合目
 ```
 
 #### レスポンス

--- a/karuta-tracker-ui/src/api/densukeTemplates.js
+++ b/karuta-tracker-ui/src/api/densukeTemplates.js
@@ -1,0 +1,11 @@
+import apiClient from './client';
+
+export const densukeTemplateAPI = {
+  // テンプレート取得（未登録団体にはデフォルト値が返る）
+  get: (organizationId) =>
+    apiClient.get(`/densuke-templates/${organizationId}`),
+
+  // テンプレート更新（upsert）
+  update: (organizationId, data) =>
+    apiClient.put(`/densuke-templates/${organizationId}`, data),
+};

--- a/karuta-tracker-ui/src/api/practices.js
+++ b/karuta-tracker-ui/src/api/practices.js
@@ -103,6 +103,15 @@ export const practiceAPI = {
   getDensukeWriteStatus: (organizationId) =>
     apiClient.get('/practice-sessions/densuke-write-status', { params: { organizationId } }),
 
+  // 伝助ページを自動作成
+  createDensukePage: (year, month, organizationId, overrides = {}) =>
+    apiClient.post('/practice-sessions/densuke/create-page', {
+      year,
+      month,
+      organizationId,
+      overrides,
+    }),
+
   // 隣室予約完了を記録
   confirmReservation: (sessionId) =>
     apiClient.post(`/practice-sessions/${sessionId}/confirm-reservation`),

--- a/karuta-tracker-ui/src/pages/densuke/DensukeManagement.jsx
+++ b/karuta-tracker-ui/src/pages/densuke/DensukeManagement.jsx
@@ -5,8 +5,10 @@ import { useAuth } from '../../context/AuthContext';
 import { isAdmin } from '../../utils/auth';
 import {
   ArrowLeft, RefreshCw, Link2, ChevronLeft, ChevronRight,
-  AlertCircle, CheckCircle, UserPlus, Loader2
+  AlertCircle, CheckCircle, UserPlus, Loader2, Plus, Settings
 } from 'lucide-react';
+import DensukePageCreateModal from './DensukePageCreateModal';
+import DensukeTemplateModal from './DensukeTemplateModal';
 
 const DensukeManagement = () => {
   const navigate = useNavigate();
@@ -205,6 +207,27 @@ const DensukeManagement = () => {
     }
   };
 
+  // 作成可能な年月か判定（当月 + 未来2ヶ月まで）
+  const monthDiff = (year - now.getFullYear()) * 12 + (month - (now.getMonth() + 1));
+  const canCreatePage = monthDiff >= 0 && monthDiff <= 2;
+
+  // モーダル制御
+  const openCreateModal = (orgId) => updateOrgState(orgId, { showCreateModal: true });
+  const closeCreateModal = (orgId) => updateOrgState(orgId, { showCreateModal: false });
+  const handleCreateSuccess = (orgId, result) => {
+    updateOrgState(orgId, {
+      showCreateModal: false,
+      savedUrl: result.url,
+      url: result.url,
+      success: `伝助ページを作成しました: ${result.url}`,
+    });
+    fetchWriteStatus(orgId);
+    setTimeout(() => updateOrgState(orgId, { success: '' }), 5000);
+  };
+
+  const openTemplateModal = (orgId) => updateOrgState(orgId, { showTemplateModal: true });
+  const closeTemplateModal = (orgId) => updateOrgState(orgId, { showTemplateModal: false });
+
   if (!currentPlayer || !isAdmin()) return null;
 
   return (
@@ -316,6 +339,27 @@ const DensukeManagement = () => {
                             <RefreshCw className="w-4 h-4" />
                           )}
                           {state.syncing ? '同期中...' : '同期実行'}
+                        </button>
+                      </div>
+
+                      {/* 伝助ページ作成 + テンプレート編集 */}
+                      <div className="mt-2 flex gap-2">
+                        {canCreatePage && !state.savedUrl && (
+                          <button
+                            onClick={() => openCreateModal(org.id)}
+                            className="flex-1 flex items-center justify-center gap-1.5 py-2 text-sm text-white rounded-lg font-medium"
+                            style={{ backgroundColor: orgColor }}
+                          >
+                            <Plus className="w-4 h-4" />
+                            伝助ページ作成
+                          </button>
+                        )}
+                        <button
+                          onClick={() => openTemplateModal(org.id)}
+                          className={`${canCreatePage && !state.savedUrl ? 'flex-1' : 'w-full'} flex items-center justify-center gap-1.5 py-2 text-sm border border-[#d4ddd7] rounded-lg font-medium text-[#374151] hover:bg-[#f9f6f2]`}
+                        >
+                          <Settings className="w-4 h-4" />
+                          テンプレート編集
                         </button>
                       </div>
                     </>
@@ -460,6 +504,25 @@ const DensukeManagement = () => {
                   </div>
                 )}
               </div>
+
+              {/* モーダル */}
+              <DensukePageCreateModal
+                isOpen={!!state.showCreateModal}
+                onClose={() => closeCreateModal(org.id)}
+                year={year}
+                month={month}
+                organizationId={org.id}
+                orgName={org.name}
+                orgColor={orgColor}
+                onSuccess={(result) => handleCreateSuccess(org.id, result)}
+              />
+              <DensukeTemplateModal
+                isOpen={!!state.showTemplateModal}
+                onClose={() => closeTemplateModal(org.id)}
+                organizationId={org.id}
+                orgName={org.name}
+                orgColor={orgColor}
+              />
             </div>
           );
         })}

--- a/karuta-tracker-ui/src/pages/densuke/DensukePageCreateModal.jsx
+++ b/karuta-tracker-ui/src/pages/densuke/DensukePageCreateModal.jsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from 'react';
+import { X, Loader2, AlertCircle } from 'lucide-react';
+import { practiceAPI } from '../../api';
+import { densukeTemplateAPI } from '../../api/densukeTemplates';
+
+/**
+ * 伝助ページ作成モーダル
+ *
+ * テンプレートをロードして初期値を表示し、ユーザーが編集・確定すると
+ * POST /api/practice-sessions/densuke/create-page を呼び出す。
+ */
+const DensukePageCreateModal = ({
+  isOpen,
+  onClose,
+  year,
+  month,
+  organizationId,
+  orgName,
+  orgColor,
+  onSuccess,
+}) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setError(null);
+    const loadTemplate = async () => {
+      setLoading(true);
+      try {
+        const res = await densukeTemplateAPI.get(organizationId);
+        const tpl = res.data || {};
+        const tplTitle = tpl.titleTemplate || '{year}年{month}月 練習出欠';
+        const resolvedTitle = tplTitle
+          .replace('{year}', String(year))
+          .replace('{month}', String(month))
+          .replace('{organization_name}', orgName || '');
+        setTitle(resolvedTitle);
+        setDescription(tpl.description || '');
+        setContactEmail(tpl.contactEmail || '');
+      } catch {
+        setError('テンプレートの読み込みに失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadTemplate();
+  }, [isOpen, year, month, organizationId, orgName]);
+
+  const handleCreate = async () => {
+    if (!title.trim()) {
+      setError('タイトルは必須です');
+      return;
+    }
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await practiceAPI.createDensukePage(year, month, organizationId, {
+        title: title.trim(),
+        description,
+        contactEmail,
+      });
+      onSuccess?.(res.data);
+      onClose();
+    } catch (err) {
+      setError(err.response?.data?.message || '伝助ページの作成に失敗しました');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
+        <div
+          className="flex items-center justify-between px-5 py-4 rounded-t-xl"
+          style={{ backgroundColor: orgColor }}
+        >
+          <h2 className="text-base font-semibold text-white">
+            伝助ページ作成（{year}年{month}月）
+          </h2>
+          <button
+            onClick={onClose}
+            disabled={creating}
+            className="text-white/80 hover:text-white disabled:opacity-50"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5">
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin" style={{ color: orgColor }} />
+            </div>
+          ) : (
+            <>
+              {error && (
+                <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-start gap-2 text-red-700">
+                  <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  <span className="text-sm">{error}</span>
+                </div>
+              )}
+
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-[#374151] mb-1">
+                    タイトル <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    disabled={creating}
+                    maxLength={200}
+                    className="w-full px-3 py-2 text-sm border border-[#d4ddd7] rounded-lg focus:ring-1 focus:ring-[#4a6b5a] focus:border-[#4a6b5a] disabled:bg-gray-50"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-[#374151] mb-1">
+                    説明
+                  </label>
+                  <textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    disabled={creating}
+                    rows={4}
+                    className="w-full px-3 py-2 text-sm border border-[#d4ddd7] rounded-lg focus:ring-1 focus:ring-[#4a6b5a] focus:border-[#4a6b5a] disabled:bg-gray-50"
+                    placeholder="伝助ページ先頭に表示される説明文"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-[#374151] mb-1">
+                    連絡先メアド
+                  </label>
+                  <input
+                    type="email"
+                    value={contactEmail}
+                    onChange={(e) => setContactEmail(e.target.value)}
+                    disabled={creating}
+                    maxLength={255}
+                    placeholder="省略可"
+                    className="w-full px-3 py-2 text-sm border border-[#d4ddd7] rounded-lg focus:ring-1 focus:ring-[#4a6b5a] focus:border-[#4a6b5a] disabled:bg-gray-50"
+                  />
+                  <p className="mt-1 text-xs text-[#6b7280]">
+                    伝助に登録されると主催者に控えメールが送られます
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-6 flex gap-2">
+                <button
+                  onClick={onClose}
+                  disabled={creating}
+                  className="flex-1 py-2.5 text-sm border border-[#d4ddd7] rounded-lg text-[#374151] hover:bg-[#f9f6f2] disabled:opacity-50 font-medium"
+                >
+                  キャンセル
+                </button>
+                <button
+                  onClick={handleCreate}
+                  disabled={creating || !title.trim()}
+                  className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-sm text-white rounded-lg disabled:opacity-50 font-medium"
+                  style={{ backgroundColor: orgColor }}
+                >
+                  {creating && <Loader2 className="w-4 h-4 animate-spin" />}
+                  {creating ? '作成中...' : '作成'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DensukePageCreateModal;

--- a/karuta-tracker-ui/src/pages/densuke/DensukeTemplateModal.jsx
+++ b/karuta-tracker-ui/src/pages/densuke/DensukeTemplateModal.jsx
@@ -1,0 +1,201 @@
+import { useState, useEffect } from 'react';
+import { X, Loader2, AlertCircle, CheckCircle } from 'lucide-react';
+import { densukeTemplateAPI } from '../../api/densukeTemplates';
+
+/**
+ * 伝助テンプレート編集モーダル
+ *
+ * 団体ごとの伝助ページ作成時デフォルト値（タイトル・説明・連絡先メアド）を編集する。
+ */
+const DensukeTemplateModal = ({
+  isOpen,
+  onClose,
+  organizationId,
+  orgName,
+  orgColor,
+  onSaved,
+}) => {
+  const [titleTemplate, setTitleTemplate] = useState('');
+  const [description, setDescription] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setError(null);
+    setSuccess(null);
+    const loadTemplate = async () => {
+      setLoading(true);
+      try {
+        const res = await densukeTemplateAPI.get(organizationId);
+        setTitleTemplate(res.data?.titleTemplate || '{year}年{month}月 練習出欠');
+        setDescription(res.data?.description || '');
+        setContactEmail(res.data?.contactEmail || '');
+      } catch {
+        setError('テンプレートの読み込みに失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadTemplate();
+  }, [isOpen, organizationId]);
+
+  const handleSave = async () => {
+    if (!titleTemplate.trim()) {
+      setError('タイトルテンプレートは必須です');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await densukeTemplateAPI.update(organizationId, {
+        titleTemplate: titleTemplate.trim(),
+        description,
+        contactEmail,
+      });
+      setSuccess('テンプレートを保存しました');
+      onSaved?.();
+      setTimeout(() => {
+        setSuccess(null);
+        onClose();
+      }, 1200);
+    } catch (err) {
+      setError(err.response?.data?.message || 'テンプレートの保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const now = new Date();
+  const previewTitle = titleTemplate
+    .replace('{year}', String(now.getFullYear()))
+    .replace('{month}', String(now.getMonth() + 1))
+    .replace('{organization_name}', orgName || '');
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
+        <div
+          className="flex items-center justify-between px-5 py-4 rounded-t-xl"
+          style={{ backgroundColor: orgColor }}
+        >
+          <h2 className="text-base font-semibold text-white">
+            伝助テンプレート編集（{orgName}）
+          </h2>
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="text-white/80 hover:text-white disabled:opacity-50"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5">
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin" style={{ color: orgColor }} />
+            </div>
+          ) : (
+            <>
+              {error && (
+                <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-start gap-2 text-red-700">
+                  <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  <span className="text-sm">{error}</span>
+                </div>
+              )}
+              {success && (
+                <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg flex items-start gap-2 text-green-700">
+                  <CheckCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  <span className="text-sm">{success}</span>
+                </div>
+              )}
+
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-[#374151] mb-1">
+                    タイトルテンプレート <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={titleTemplate}
+                    onChange={(e) => setTitleTemplate(e.target.value)}
+                    disabled={saving}
+                    maxLength={200}
+                    className="w-full px-3 py-2 text-sm border border-[#d4ddd7] rounded-lg focus:ring-1 focus:ring-[#4a6b5a] focus:border-[#4a6b5a] disabled:bg-gray-50"
+                  />
+                  <p className="mt-1.5 text-xs text-[#6b7280]">
+                    プレースホルダー:{' '}
+                    <code className="bg-[#f9f6f2] px-1 rounded">{'{year}'}</code>、{' '}
+                    <code className="bg-[#f9f6f2] px-1 rounded">{'{month}'}</code>、{' '}
+                    <code className="bg-[#f9f6f2] px-1 rounded">{'{organization_name}'}</code>
+                  </p>
+                  <p className="mt-1 text-xs text-[#6b7280]">
+                    今月で展開したプレビュー:{' '}
+                    <span className="font-medium text-[#374151]">{previewTitle}</span>
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-[#374151] mb-1">
+                    説明
+                  </label>
+                  <textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    disabled={saving}
+                    rows={4}
+                    className="w-full px-3 py-2 text-sm border border-[#d4ddd7] rounded-lg focus:ring-1 focus:ring-[#4a6b5a] focus:border-[#4a6b5a] disabled:bg-gray-50"
+                    placeholder="伝助ページ先頭に表示される説明文"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-[#374151] mb-1">
+                    連絡先メアド
+                  </label>
+                  <input
+                    type="email"
+                    value={contactEmail}
+                    onChange={(e) => setContactEmail(e.target.value)}
+                    disabled={saving}
+                    maxLength={255}
+                    placeholder="省略可"
+                    className="w-full px-3 py-2 text-sm border border-[#d4ddd7] rounded-lg focus:ring-1 focus:ring-[#4a6b5a] focus:border-[#4a6b5a] disabled:bg-gray-50"
+                  />
+                </div>
+              </div>
+
+              <div className="mt-6 flex gap-2">
+                <button
+                  onClick={onClose}
+                  disabled={saving}
+                  className="flex-1 py-2.5 text-sm border border-[#d4ddd7] rounded-lg text-[#374151] hover:bg-[#f9f6f2] disabled:opacity-50 font-medium"
+                >
+                  キャンセル
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={saving || !titleTemplate.trim()}
+                  className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-sm text-white rounded-lg disabled:opacity-50 font-medium"
+                  style={{ backgroundColor: orgColor }}
+                >
+                  {saving && <Loader2 className="w-4 h-4 animate-spin" />}
+                  {saving ? '保存中...' : '保存'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DensukeTemplateModal;

--- a/karuta-tracker-ui/src/pages/line/LineSettings.jsx
+++ b/karuta-tracker-ui/src/pages/line/LineSettings.jsx
@@ -16,6 +16,7 @@ const PLAYER_NOTIFICATION_TYPES = [
   { key: 'sameDayConfirmation', label: '当日確認通知' },
   { key: 'sameDayCancel', label: '当日キャンセル通知' },
   { key: 'sameDayVacancy', label: '当日空き通知' },
+  { key: 'densukePageCreated', label: '伝助ページ作成通知' },
 ];
 
 /** 管理者用通知種別 */

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/DensukeTemplateController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/DensukeTemplateController.java
@@ -1,0 +1,60 @@
+package com.karuta.matchtracker.controller;
+
+import com.karuta.matchtracker.annotation.RequireRole;
+import com.karuta.matchtracker.dto.DensukeTemplateDto;
+import com.karuta.matchtracker.dto.DensukeTemplateUpdateRequest;
+import com.karuta.matchtracker.entity.Player.Role;
+import com.karuta.matchtracker.service.DensukeTemplateService;
+import com.karuta.matchtracker.util.AdminScopeValidator;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 伝助テンプレート管理 Controller
+ */
+@RestController
+@RequestMapping("/api/densuke-templates")
+@RequiredArgsConstructor
+@Slf4j
+public class DensukeTemplateController {
+
+    private final DensukeTemplateService densukeTemplateService;
+
+    /**
+     * 指定団体のテンプレートを取得する。未登録団体にはデフォルト値を返す。
+     */
+    @GetMapping("/{organizationId}")
+    @RequireRole({Role.ADMIN, Role.SUPER_ADMIN})
+    public ResponseEntity<DensukeTemplateDto> getTemplate(
+            @PathVariable Long organizationId,
+            HttpServletRequest httpRequest) {
+        String role = (String) httpRequest.getAttribute("currentUserRole");
+        Long adminOrgId = (Long) httpRequest.getAttribute("adminOrganizationId");
+        AdminScopeValidator.validateScope(role, adminOrgId, organizationId,
+                "他団体のテンプレートは取得できません");
+
+        return ResponseEntity.ok(densukeTemplateService.getTemplate(organizationId));
+    }
+
+    /**
+     * 指定団体のテンプレートを upsert する。
+     */
+    @PutMapping("/{organizationId}")
+    @RequireRole({Role.ADMIN, Role.SUPER_ADMIN})
+    public ResponseEntity<DensukeTemplateDto> updateTemplate(
+            @PathVariable Long organizationId,
+            @Valid @RequestBody DensukeTemplateUpdateRequest request,
+            HttpServletRequest httpRequest) {
+        String role = (String) httpRequest.getAttribute("currentUserRole");
+        Long adminOrgId = (Long) httpRequest.getAttribute("adminOrganizationId");
+        AdminScopeValidator.validateScope(role, adminOrgId, organizationId,
+                "他団体のテンプレートは更新できません");
+
+        log.info("PUT /api/densuke-templates/{} - Updating template", organizationId);
+        return ResponseEntity.ok(densukeTemplateService.updateTemplate(organizationId, request));
+    }
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/PracticeSessionController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/PracticeSessionController.java
@@ -35,6 +35,7 @@ public class PracticeSessionController {
     private final com.karuta.matchtracker.service.DensukeImportService densukeImportService;
     private final com.karuta.matchtracker.service.DensukeWriteService densukeWriteService;
     private final com.karuta.matchtracker.service.DensukeSyncService densukeSyncService;
+    private final com.karuta.matchtracker.service.DensukePageCreateService densukePageCreateService;
     private final com.karuta.matchtracker.service.AdjacentRoomService adjacentRoomService;
 
     /**
@@ -577,5 +578,30 @@ public class PracticeSessionController {
         Long adminOrgId = (Long) httpRequest.getAttribute("adminOrganizationId");
         AdminScopeValidator.validateScope(role, adminOrgId, organizationId, "他団体の書き込み状況は取得できません");
         return ResponseEntity.ok(densukeWriteService.getStatus(organizationId));
+    }
+
+    /**
+     * 指定年月の伝助ページを自動作成する。
+     * アプリ側の練習日データ（会場 × 日付 × 試合時刻）を元に densuke.biz にページを新規発行する。
+     */
+    @PostMapping("/densuke/create-page")
+    @RequireRole({Role.SUPER_ADMIN, Role.ADMIN})
+    public ResponseEntity<?> createDensukePage(
+            @Valid @RequestBody DensukePageCreateRequest request,
+            HttpServletRequest httpRequest) {
+        String role = (String) httpRequest.getAttribute("currentUserRole");
+        Long adminOrgId = (Long) httpRequest.getAttribute("adminOrganizationId");
+        AdminScopeValidator.validateScope(role, adminOrgId, request.getOrganizationId(),
+                "他団体の伝助ページは作成できません");
+
+        log.info("POST /api/practice-sessions/densuke/create-page - year={}, month={}, orgId={}",
+                request.getYear(), request.getMonth(), request.getOrganizationId());
+
+        try {
+            DensukePageCreateResponse response = densukePageCreateService.createPage(request);
+            return ResponseEntity.ok(response);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
     }
 }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukePageCreateRequest.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukePageCreateRequest.java
@@ -1,0 +1,45 @@
+package com.karuta.matchtracker.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 伝助ページ作成リクエスト DTO
+ */
+@Data
+public class DensukePageCreateRequest {
+
+    @NotNull(message = "year は必須です")
+    @Min(value = 2000, message = "year が不正です")
+    @Max(value = 2100, message = "year が不正です")
+    private Integer year;
+
+    @NotNull(message = "month は必須です")
+    @Min(value = 1, message = "month は 1〜12 で指定してください")
+    @Max(value = 12, message = "month は 1〜12 で指定してください")
+    private Integer month;
+
+    @NotNull(message = "organizationId は必須です")
+    private Long organizationId;
+
+    @Valid
+    private Overrides overrides;
+
+    /**
+     * 作成時のテンプレート値オーバーライド。任意指定。
+     */
+    @Data
+    public static class Overrides {
+        @Size(max = 200)
+        private String title;
+
+        private String description;
+
+        @Size(max = 255)
+        private String contactEmail;
+    }
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukePageCreateResponse.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukePageCreateResponse.java
@@ -1,0 +1,24 @@
+package com.karuta.matchtracker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 伝助ページ作成レスポンス DTO
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DensukePageCreateResponse {
+    /** 発行された伝助サイトコード */
+    private String cd;
+    /** 公開 URL (https://densuke.biz/list?cd=xxx) */
+    private String url;
+    /** 作成された練習日数 */
+    private Integer createdDateCount;
+    /** 作成された試合枠の総数 */
+    private Integer createdMatchSlotCount;
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukeTemplateDto.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukeTemplateDto.java
@@ -1,0 +1,42 @@
+package com.karuta.matchtracker.dto;
+
+import com.karuta.matchtracker.entity.DensukeTemplate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 伝助テンプレート DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DensukeTemplateDto {
+    private Long organizationId;
+    private String titleTemplate;
+    private String description;
+    private String contactEmail;
+
+    public static DensukeTemplateDto fromEntity(DensukeTemplate entity) {
+        return DensukeTemplateDto.builder()
+                .organizationId(entity.getOrganizationId())
+                .titleTemplate(entity.getTitleTemplate())
+                .description(entity.getDescription())
+                .contactEmail(entity.getContactEmail())
+                .build();
+    }
+
+    /**
+     * テンプレート未登録団体向けのデフォルト値を返す。
+     */
+    public static DensukeTemplateDto defaultFor(Long organizationId) {
+        return DensukeTemplateDto.builder()
+                .organizationId(organizationId)
+                .titleTemplate("{year}年{month}月 練習出欠")
+                .description("")
+                .contactEmail("")
+                .build();
+    }
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukeTemplateUpdateRequest.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/DensukeTemplateUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.karuta.matchtracker.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 伝助テンプレート更新リクエスト DTO
+ */
+@Data
+public class DensukeTemplateUpdateRequest {
+
+    @NotBlank(message = "タイトルテンプレートは必須です")
+    @Size(max = 200, message = "タイトルテンプレートは200文字以内で入力してください")
+    private String titleTemplate;
+
+    private String description;
+
+    @Size(max = 255, message = "連絡先メールアドレスは255文字以内で入力してください")
+    private String contactEmail;
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/LineNotificationPreferenceDto.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/dto/LineNotificationPreferenceDto.java
@@ -26,6 +26,7 @@ public class LineNotificationPreferenceDto {
     private boolean adminSameDayConfirmation;
     private boolean adminSameDayCancel;
     private boolean mentorComment;
+    private boolean densukePageCreated;
 
     public static LineNotificationPreferenceDto fromEntity(LineNotificationPreference entity) {
         return LineNotificationPreferenceDto.builder()
@@ -44,6 +45,7 @@ public class LineNotificationPreferenceDto {
             .adminSameDayConfirmation(entity.getAdminSameDayConfirmation())
             .adminSameDayCancel(entity.getAdminSameDayCancel())
             .mentorComment(entity.getMentorComment())
+            .densukePageCreated(entity.getDensukePageCreated())
             .build();
     }
 }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/DensukeTemplate.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/DensukeTemplate.java
@@ -1,0 +1,49 @@
+package com.karuta.matchtracker.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 伝助テンプレート管理エンティティ（団体単位）
+ */
+@Entity
+@Table(name = "densuke_templates", uniqueConstraints = {
+    @UniqueConstraint(name = "densuke_templates_organization_id_key", columnNames = {"organization_id"})
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DensukeTemplate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "organization_id", nullable = false, unique = true)
+    private Long organizationId;
+
+    @Column(name = "title_template", nullable = false, length = 200)
+    private String titleTemplate;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "contact_email", length = 255)
+    private String contactEmail;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/DensukeUrl.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/DensukeUrl.java
@@ -39,6 +39,14 @@ public class DensukeUrl {
     @Column(name = "organization_id", nullable = false)
     private Long organizationId;
 
+    /**
+     * 伝助の編集用シークレット (sd)。
+     * アプリから自動作成した伝助ページでのみ値が入り、手動登録 URL は NULL。
+     * 将来の編集・削除 API で必要になる想定で保存する。
+     */
+    @Column(name = "densuke_sd", length = 32)
+    private String densukeSd;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineMessageLog.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineMessageLog.java
@@ -75,7 +75,8 @@ public class LineMessageLog {
         SAME_DAY_VACANCY,
         ADMIN_SAME_DAY_CONFIRMATION,
         MENTOR_COMMENT,
-        MENTEE_MEMO_UPDATE;
+        MENTEE_MEMO_UPDATE,
+        DENSUKE_PAGE_CREATED;
 
         /** 通知種別に対応するチャネル用途を返す */
         public ChannelType getRequiredChannelType() {

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineNotificationPreference.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/entity/LineNotificationPreference.java
@@ -98,6 +98,11 @@ public class LineNotificationPreference {
     @Builder.Default
     private Boolean mentorComment = true;
 
+    /** 伝助ページ作成通知 */
+    @Column(name = "densuke_page_created", nullable = false, columnDefinition = "BOOLEAN NOT NULL DEFAULT TRUE")
+    @Builder.Default
+    private Boolean densukePageCreated = true;
+
     /** 更新日時 */
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/DensukeTemplateRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/DensukeTemplateRepository.java
@@ -1,0 +1,13 @@
+package com.karuta.matchtracker.repository;
+
+import com.karuta.matchtracker.entity.DensukeTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DensukeTemplateRepository extends JpaRepository<DensukeTemplate, Long> {
+
+    Optional<DensukeTemplate> findByOrganizationId(Long organizationId);
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java
@@ -23,7 +23,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -201,9 +200,10 @@ public class DensukePageCreateService {
     // schedule 組み立てとバリデーション
     // ========================================================================
 
-    private BuildResult buildScheduleText(List<PracticeSession> sessions,
-                                           Map<Long, Venue> venueMap,
-                                           Map<Long, Map<Integer, VenueMatchSchedule>> scheduleMap) {
+    // package-private: フォーマットの回帰テストから直接呼び出せるよう可視性を広げている
+    BuildResult buildScheduleText(List<PracticeSession> sessions,
+                                   Map<Long, Venue> venueMap,
+                                   Map<Long, Map<Integer, VenueMatchSchedule>> scheduleMap) {
         StringBuilder sb = new StringBuilder();
         int matchSlotCount = 0;
 
@@ -236,13 +236,19 @@ public class DensukePageCreateService {
             int d = date.getDayOfMonth();
             String weekday = WEEKDAY_JP[date.getDayOfWeek().getValue() % 7];
 
+            // 新フォーマット:
+            //   1試合目行:      「M/D(曜) 会場名 1試合目」（日付・会場のヘッダーを兼ねる）
+            //   2試合目以降:   「N試合目」のみ（DensukeScraper は currentDate/currentVenue を
+            //                                    前行から引き継ぐため、日付・会場省略でも同期可能）
             for (int mn = 1; mn <= totalMatches; mn++) {
-                LocalTime startTime = venueSchedules.get(mn).getStartTime();
-                sb.append(m).append('/').append(d)
-                        .append('(').append(weekday).append(") ")
-                        .append(String.format("%02d:%02d", startTime.getHour(), startTime.getMinute()))
-                        .append('～')
-                        .append(venue.getName()).append(' ').append(mn).append("試合目\n");
+                if (mn == 1) {
+                    sb.append(m).append('/').append(d)
+                            .append('(').append(weekday).append(") ")
+                            .append(venue.getName()).append(' ')
+                            .append(mn).append("試合目\n");
+                } else {
+                    sb.append(mn).append("試合目\n");
+                }
                 matchSlotCount++;
             }
         }
@@ -355,7 +361,7 @@ public class DensukePageCreateService {
     // 内部データクラス
     // ========================================================================
 
-    private record BuildResult(String scheduleText, int matchSlotCount) {}
+    record BuildResult(String scheduleText, int matchSlotCount) {}
 
     private record ResolvedTemplate(String title, String description, String contactEmail, String organizationName) {}
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java
@@ -1,0 +1,320 @@
+package com.karuta.matchtracker.service;
+
+import com.karuta.matchtracker.dto.DensukePageCreateRequest;
+import com.karuta.matchtracker.dto.DensukePageCreateResponse;
+import com.karuta.matchtracker.entity.*;
+import com.karuta.matchtracker.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * 伝助ページ作成サービス
+ *
+ * アプリ側の練習日データから densuke.biz にページを新規作成し、
+ * 発行された cd/sd を densuke_urls に保存する。
+ * 処理完了後 (AFTER_COMMIT) に LINE 通知を発火する。
+ *
+ * 作成フォーム仕様は docs/features/densuke-page-creator/densuke-form-spec.md 参照。
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DensukePageCreateService {
+
+    private final DensukeUrlRepository densukeUrlRepository;
+    private final DensukeTemplateRepository densukeTemplateRepository;
+    private final PracticeSessionRepository practiceSessionRepository;
+    private final VenueRepository venueRepository;
+    private final VenueMatchScheduleRepository venueMatchScheduleRepository;
+    private final OrganizationRepository organizationRepository;
+    private final LineNotificationService lineNotificationService;
+
+    private static final String DENSUKE_CREATE_URL = "https://www.densuke.biz/create";
+    private static final String DENSUKE_LIST_URL_PREFIX = "https://densuke.biz/list?cd=";
+    private static final String DEFAULT_TITLE_TEMPLATE = "{year}年{month}月 練習出欠";
+    private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
+    /** LocalDate.getDayOfWeek().getValue() は 月=1..日=7。modulo 7 で日=0..土=6 にそろえる。 */
+    private static final String[] WEEKDAY_JP = {"日", "月", "火", "水", "木", "金", "土"};
+
+    private static final Pattern CD_PATTERN = Pattern.compile("cd=([A-Za-z0-9]+)");
+    private static final Pattern SD_PATTERN = Pattern.compile("sd=([A-Za-z0-9.]+)");
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    @Transactional
+    public DensukePageCreateResponse createPage(DensukePageCreateRequest request) {
+        int year = request.getYear();
+        int month = request.getMonth();
+        Long organizationId = request.getOrganizationId();
+
+        // 1. 既存 URL の重複チェック
+        if (densukeUrlRepository.findByYearAndMonthAndOrganizationId(year, month, organizationId).isPresent()) {
+            throw new IllegalStateException(year + "年" + month + "月の伝助URLは既に登録されています");
+        }
+
+        // 2. 対象月の練習セッション取得
+        List<PracticeSession> sessions = practiceSessionRepository
+                .findByYearAndMonthAndOrganizationId(year, month, organizationId);
+        if (sessions.isEmpty()) {
+            throw new IllegalStateException(year + "年" + month + "月に練習日が登録されていません");
+        }
+
+        // 3. 会場・試合時刻マスタのロード
+        List<Long> venueIds = sessions.stream()
+                .map(PracticeSession::getVenueId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<Long, Venue> venueMap = venueRepository.findAllById(venueIds).stream()
+                .collect(Collectors.toMap(Venue::getId, v -> v));
+        Map<Long, Map<Integer, VenueMatchSchedule>> scheduleMap = venueMatchScheduleRepository
+                .findByVenueIdIn(venueIds).stream()
+                .collect(Collectors.groupingBy(
+                        VenueMatchSchedule::getVenueId,
+                        Collectors.toMap(VenueMatchSchedule::getMatchNumber, s -> s)
+                ));
+
+        // 4. schedule 文字列組み立て + 不整合チェック
+        BuildResult built = buildScheduleText(sessions, venueMap, scheduleMap);
+
+        // 5. テンプレート + overrides の解決
+        ResolvedTemplate resolved = resolveTemplate(organizationId, year, month, request.getOverrides());
+
+        // 6. densuke.biz に新規作成 POST
+        CdSdPair cdSd;
+        try {
+            cdSd = postCreateRequest(resolved.title, built.scheduleText,
+                    resolved.description, resolved.contactEmail);
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.error("Failed to create Densuke page (org={}, year={}, month={})",
+                    organizationId, year, month, e);
+            throw new IllegalStateException("伝助ページの作成に失敗しました: " + e.getMessage(), e);
+        }
+
+        String densukeUrl = DENSUKE_LIST_URL_PREFIX + cdSd.cd;
+
+        // 7. densuke_urls に保存
+        DensukeUrl urlEntity = DensukeUrl.builder()
+                .year(year)
+                .month(month)
+                .organizationId(organizationId)
+                .url(densukeUrl)
+                .densukeSd(cdSd.sd)
+                .build();
+        densukeUrlRepository.save(urlEntity);
+
+        // 8. AFTER_COMMIT で LINE 通知発火
+        String lineMessage = buildLineMessage(resolved.organizationName, year, month, densukeUrl);
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                try {
+                    lineNotificationService.sendDensukePageCreatedNotification(organizationId, lineMessage);
+                } catch (Exception e) {
+                    log.warn("DENSUKE_PAGE_CREATED notification failed: org={}, err={}",
+                            organizationId, e.getMessage());
+                }
+            }
+        });
+
+        log.info("Densuke page created: org={}, year={}, month={}, cd={}, dates={}, matchSlots={}",
+                organizationId, year, month, cdSd.cd, sessions.size(), built.matchSlotCount);
+
+        return DensukePageCreateResponse.builder()
+                .cd(cdSd.cd)
+                .url(densukeUrl)
+                .createdDateCount(sessions.size())
+                .createdMatchSlotCount(built.matchSlotCount)
+                .build();
+    }
+
+    // ========================================================================
+    // schedule 組み立てとバリデーション
+    // ========================================================================
+
+    private BuildResult buildScheduleText(List<PracticeSession> sessions,
+                                           Map<Long, Venue> venueMap,
+                                           Map<Long, Map<Integer, VenueMatchSchedule>> scheduleMap) {
+        StringBuilder sb = new StringBuilder();
+        int matchSlotCount = 0;
+
+        for (PracticeSession session : sessions) {
+            Long venueId = session.getVenueId();
+            Venue venue = (venueId != null) ? venueMap.get(venueId) : null;
+            if (venue == null) {
+                throw new IllegalStateException(
+                        session.getSessionDate() + " の会場が登録されていません");
+            }
+
+            int totalMatches = (session.getTotalMatches() != null)
+                    ? session.getTotalMatches()
+                    : venue.getDefaultMatchCount();
+
+            Map<Integer, VenueMatchSchedule> venueSchedules =
+                    scheduleMap.getOrDefault(venueId, Collections.emptyMap());
+
+            // 不整合チェック: total_matches 分の時刻があるか
+            for (int mn = 1; mn <= totalMatches; mn++) {
+                if (!venueSchedules.containsKey(mn)) {
+                    throw new IllegalStateException(
+                            "会場「" + venue.getName() + "」に" + mn
+                                    + "試合目の時間割が登録されていません");
+                }
+            }
+
+            LocalDate date = session.getSessionDate();
+            int m = date.getMonthValue();
+            int d = date.getDayOfMonth();
+            String weekday = WEEKDAY_JP[date.getDayOfWeek().getValue() % 7];
+
+            for (int mn = 1; mn <= totalMatches; mn++) {
+                LocalTime startTime = venueSchedules.get(mn).getStartTime();
+                sb.append(m).append('/').append(d)
+                        .append('(').append(weekday).append(") ")
+                        .append(String.format("%02d:%02d", startTime.getHour(), startTime.getMinute()))
+                        .append('～')
+                        .append(venue.getName()).append(' ').append(mn).append("試合目\n");
+                matchSlotCount++;
+            }
+        }
+
+        return new BuildResult(sb.toString(), matchSlotCount);
+    }
+
+    // ========================================================================
+    // テンプレート解決
+    // ========================================================================
+
+    private ResolvedTemplate resolveTemplate(Long organizationId, int year, int month,
+                                              DensukePageCreateRequest.Overrides overrides) {
+        DensukeTemplate template = densukeTemplateRepository
+                .findByOrganizationId(organizationId).orElse(null);
+
+        String titleTemplate = (template != null && template.getTitleTemplate() != null)
+                ? template.getTitleTemplate() : DEFAULT_TITLE_TEMPLATE;
+        String description = (template != null && template.getDescription() != null)
+                ? template.getDescription() : "";
+        String contactEmail = (template != null && template.getContactEmail() != null)
+                ? template.getContactEmail() : "";
+
+        if (overrides != null) {
+            if (overrides.getTitle() != null) titleTemplate = overrides.getTitle();
+            if (overrides.getDescription() != null) description = overrides.getDescription();
+            if (overrides.getContactEmail() != null) contactEmail = overrides.getContactEmail();
+        }
+
+        Organization org = organizationRepository.findById(organizationId).orElse(null);
+        String orgName = (org != null) ? org.getName() : "";
+
+        String title = applyPlaceholders(titleTemplate, year, month, orgName);
+        return new ResolvedTemplate(title, description, contactEmail, orgName);
+    }
+
+    private String applyPlaceholders(String template, int year, int month, String orgName) {
+        return template
+                .replace("{year}", String.valueOf(year))
+                .replace("{month}", String.valueOf(month))
+                .replace("{organization_name}", orgName != null ? orgName : "");
+    }
+
+    // ========================================================================
+    // densuke.biz への POST
+    // ========================================================================
+
+    private CdSdPair postCreateRequest(String title, String scheduleText,
+                                        String description, String contactEmail)
+            throws IOException, InterruptedException {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("postfix", "");
+        fields.put("eventname", title);
+        fields.put("schedule", scheduleText);
+        fields.put("explain", description != null ? description : "");
+        fields.put("email", contactEmail != null ? contactEmail : "");
+        fields.put("pw", "0");
+        fields.put("password", "");
+        fields.put("eventchoice", "1");
+
+        String body = fields.entrySet().stream()
+                .map(e -> URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8) + "="
+                        + URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8))
+                .collect(Collectors.joining("&"));
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(DENSUKE_CREATE_URL))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("User-Agent", USER_AGENT)
+                .header("Origin", "https://www.densuke.biz")
+                .header("Referer", "https://www.densuke.biz/confirm")
+                .timeout(Duration.ofSeconds(30))
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+
+        HttpResponse<Void> res = HTTP_CLIENT.send(req, HttpResponse.BodyHandlers.discarding());
+
+        if (res.statusCode() != 302) {
+            throw new IOException("伝助からの応答が不正です: HTTP " + res.statusCode());
+        }
+
+        String location = res.headers().firstValue("Location")
+                .orElseThrow(() -> new IOException("Location ヘッダーが取得できませんでした"));
+
+        Matcher cdMatcher = CD_PATTERN.matcher(location);
+        if (!cdMatcher.find()) {
+            throw new IOException("伝助レスポンスから cd を抽出できませんでした: Location=" + location);
+        }
+        String cd = cdMatcher.group(1);
+
+        Matcher sdMatcher = SD_PATTERN.matcher(location);
+        String sd = sdMatcher.find() ? sdMatcher.group(1) : null;
+
+        return new CdSdPair(cd, sd);
+    }
+
+    // ========================================================================
+    // LINE 通知メッセージ組み立て
+    // ========================================================================
+
+    private String buildLineMessage(String orgName, int year, int month, String densukeUrl) {
+        String titleLine = month + "月の練習日程が出ました";
+        String prefix = (orgName != null && !orgName.isEmpty()) ? orgName + "の" : "";
+        String body = prefix + year + "年" + month + "月の練習出欠ページが作成されました。\n"
+                + "以下のリンクから出欠を登録してください:\n" + densukeUrl;
+        return titleLine + "\n\n" + body;
+    }
+
+    // ========================================================================
+    // 内部データクラス
+    // ========================================================================
+
+    private record BuildResult(String scheduleText, int matchSlotCount) {}
+
+    private record ResolvedTemplate(String title, String description, String contactEmail, String organizationName) {}
+
+    private record CdSdPair(String cd, String sd) {}
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java
@@ -147,7 +147,12 @@ public class DensukePageCreateService {
         urlEntity.setDensukeSd(cdSd.sd);
         densukeUrlRepository.save(urlEntity);
 
-        // 9. AFTER_COMMIT で LINE 通知発火
+        // 9. AFTER_COMMIT で LINE 通知を非同期ディスパッチ
+        //    sendDensukePageCreatedNotification は @Async 指定で TaskExecutor 上に fire-and-forget
+        //    される。afterCommit 内で呼ぶのは「コミット前の未反映レコードを非同期スレッドが読んで
+        //    しまう」のを避けるため。ここでの try/catch は @Async ディスパッチ自体が失敗した場合の
+        //    保険（通常発生しないが、エグゼキューター満杯等で RejectedExecutionException が出ると
+        //    呼び出し元に伝播してしまうため握りつぶしてログ化する）。
         String lineMessage = buildLineMessage(resolved.organizationName, year, month, densukeUrl);
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
@@ -155,7 +160,7 @@ public class DensukePageCreateService {
                 try {
                     lineNotificationService.sendDensukePageCreatedNotification(organizationId, lineMessage);
                 } catch (Exception e) {
-                    log.warn("DENSUKE_PAGE_CREATED notification failed: org={}, err={}",
+                    log.warn("DENSUKE_PAGE_CREATED async dispatch failed: org={}, err={}",
                             organizationId, e.getMessage());
                 }
             }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukePageCreateService.java
@@ -4,8 +4,10 @@ import com.karuta.matchtracker.dto.DensukePageCreateRequest;
 import com.karuta.matchtracker.dto.DensukePageCreateResponse;
 import com.karuta.matchtracker.entity.*;
 import com.karuta.matchtracker.repository.*;
+import com.karuta.matchtracker.util.JstDateTimeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -18,9 +20,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -70,7 +74,10 @@ public class DensukePageCreateService {
         int month = request.getMonth();
         Long organizationId = request.getOrganizationId();
 
-        // 1. 既存 URL の重複チェック
+        // 0. 作成対象年月の範囲チェック（当月〜+2ヶ月のみ。UI の canCreatePage と同等の制約を API 側にも強制）
+        validateYearMonth(year, month, YearMonth.now(JstDateTimeUtil.JST));
+
+        // 1. 既存 URL の重複チェック（早期失敗）
         if (densukeUrlRepository.findByYearAndMonthAndOrganizationId(year, month, organizationId).isPresent()) {
             throw new IllegalStateException(year + "年" + month + "月の伝助URLは既に登録されています");
         }
@@ -103,7 +110,24 @@ public class DensukePageCreateService {
         // 5. テンプレート + overrides の解決
         ResolvedTemplate resolved = resolveTemplate(organizationId, year, month, request.getOverrides());
 
-        // 6. densuke.biz に新規作成 POST
+        // 6. 排他制御のための仮レコード先行確保
+        //    densuke_urls の UNIQUE(year, month, organization_id) により、同時実行された2つ目の
+        //    トランザクションは 1つ目がコミット/ロールバックするまでブロックされ、その後ユニーク違反で失敗する。
+        //    これにより densuke.biz への二重 POST（オーファンページ発生）を防ぐ。
+        DensukeUrl urlEntity = DensukeUrl.builder()
+                .year(year)
+                .month(month)
+                .organizationId(organizationId)
+                .url(DENSUKE_LIST_URL_PREFIX + "pending")
+                .build();
+        try {
+            densukeUrlRepository.saveAndFlush(urlEntity);
+        } catch (DataIntegrityViolationException e) {
+            throw new IllegalStateException(
+                    year + "年" + month + "月の伝助URLは既に登録されています", e);
+        }
+
+        // 7. densuke.biz に新規作成 POST（失敗時はロールバックで仮レコードも消える）
         CdSdPair cdSd;
         try {
             cdSd = postCreateRequest(resolved.title, built.scheduleText,
@@ -119,17 +143,12 @@ public class DensukePageCreateService {
 
         String densukeUrl = DENSUKE_LIST_URL_PREFIX + cdSd.cd;
 
-        // 7. densuke_urls に保存
-        DensukeUrl urlEntity = DensukeUrl.builder()
-                .year(year)
-                .month(month)
-                .organizationId(organizationId)
-                .url(densukeUrl)
-                .densukeSd(cdSd.sd)
-                .build();
+        // 8. 仮レコードを実 URL / sd で更新
+        urlEntity.setUrl(densukeUrl);
+        urlEntity.setDensukeSd(cdSd.sd);
         densukeUrlRepository.save(urlEntity);
 
-        // 8. AFTER_COMMIT で LINE 通知発火
+        // 9. AFTER_COMMIT で LINE 通知発火
         String lineMessage = buildLineMessage(resolved.organizationName, year, month, densukeUrl);
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
@@ -152,6 +171,30 @@ public class DensukePageCreateService {
                 .createdDateCount(sessions.size())
                 .createdMatchSlotCount(built.matchSlotCount)
                 .build();
+    }
+
+    // ========================================================================
+    // 年月バリデーション
+    // ========================================================================
+
+    /**
+     * 作成対象年月が「当月〜+2ヶ月」の範囲内にあることを検証する。
+     * 範囲外（過去月・3ヶ月以上先）は IllegalStateException として 400 を返す。
+     *
+     * package-private としてテストから任意の「現在年月」を注入できるようにしている。
+     */
+    static void validateYearMonth(int year, int month, YearMonth current) {
+        YearMonth target;
+        try {
+            target = YearMonth.of(year, month);
+        } catch (DateTimeException e) {
+            throw new IllegalStateException("年月の指定が不正です: " + year + "/" + month, e);
+        }
+        YearMonth maxAllowed = current.plusMonths(2);
+        if (target.isBefore(current) || target.isAfter(maxAllowed)) {
+            throw new IllegalStateException(
+                    year + "年" + month + "月は作成可能範囲外です（当月〜+2ヶ月のみ作成可能）");
+        }
     }
 
     // ========================================================================

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeTemplateService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeTemplateService.java
@@ -1,0 +1,52 @@
+package com.karuta.matchtracker.service;
+
+import com.karuta.matchtracker.dto.DensukeTemplateDto;
+import com.karuta.matchtracker.dto.DensukeTemplateUpdateRequest;
+import com.karuta.matchtracker.entity.DensukeTemplate;
+import com.karuta.matchtracker.repository.DensukeTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 伝助テンプレート CRUD サービス
+ *
+ * 団体ごとに1レコードのテンプレートを管理する。未登録団体にはデフォルト値を返す。
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DensukeTemplateService {
+
+    private final DensukeTemplateRepository repository;
+
+    /**
+     * 指定団体のテンプレートを取得する。未登録の場合はデフォルト値を返す。
+     */
+    @Transactional(readOnly = true)
+    public DensukeTemplateDto getTemplate(Long organizationId) {
+        return repository.findByOrganizationId(organizationId)
+                .map(DensukeTemplateDto::fromEntity)
+                .orElseGet(() -> DensukeTemplateDto.defaultFor(organizationId));
+    }
+
+    /**
+     * 指定団体のテンプレートを更新する (upsert)。
+     */
+    @Transactional
+    public DensukeTemplateDto updateTemplate(Long organizationId, DensukeTemplateUpdateRequest request) {
+        DensukeTemplate template = repository.findByOrganizationId(organizationId)
+                .orElseGet(() -> DensukeTemplate.builder()
+                        .organizationId(organizationId)
+                        .build());
+
+        template.setTitleTemplate(request.getTitleTemplate());
+        template.setDescription(request.getDescription());
+        template.setContactEmail(request.getContactEmail());
+
+        DensukeTemplate saved = repository.save(template);
+        log.info("DensukeTemplate upserted: organizationId={}, id={}", organizationId, saved.getId());
+        return DensukeTemplateDto.fromEntity(saved);
+    }
+}

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -2368,6 +2368,7 @@ public class LineNotificationService {
             case ADMIN_SAME_DAY_CONFIRMATION -> pref.getAdminSameDayConfirmation();
             case MENTOR_COMMENT -> pref.getMentorComment();
             case MENTEE_MEMO_UPDATE -> pref.getMentorComment();
+            case DENSUKE_PAGE_CREATED -> pref.getDensukePageCreated();
         };
     }
 
@@ -2694,6 +2695,51 @@ public class LineNotificationService {
      * isMenteeAuthor=true: メンティーがコメント → 全ACTIVEメンターに送信
      * isMenteeAuthor=false: メンターがコメント → メンティーに送信
      */
+    /**
+     * 伝助ページ作成完了通知を、指定団体に所属する PLAYER ロールのメンバーへ LINE 送信する。
+     * ADMIN / SUPER_ADMIN は対象外。個別送信の失敗は警告ログに残し、他メンバーへの送信は継続する。
+     *
+     * メッセージ本文は呼び出し側で組み立てる。タイトル行 + 本文 の改行連結が前提。
+     *
+     * @param organizationId 対象団体 ID
+     * @param message 送信メッセージ全文
+     */
+    public void sendDensukePageCreatedNotification(Long organizationId, String message) {
+        List<PlayerOrganization> memberships = playerOrganizationRepository.findByOrganizationId(organizationId);
+        if (memberships.isEmpty()) {
+            log.info("DENSUKE_PAGE_CREATED: no members in organization {}", organizationId);
+            return;
+        }
+
+        List<Long> playerIds = memberships.stream()
+                .map(PlayerOrganization::getPlayerId)
+                .toList();
+
+        List<Player> targetPlayers = playerRepository.findAllById(playerIds).stream()
+                .filter(p -> p.getDeletedAt() == null)
+                .filter(p -> p.getRole() == Player.Role.PLAYER)
+                .toList();
+
+        int sent = 0;
+        int failed = 0;
+        for (Player player : targetPlayers) {
+            try {
+                SendResult result = sendToPlayer(player.getId(), LineNotificationType.DENSUKE_PAGE_CREATED, message);
+                if (result == SendResult.SUCCESS) {
+                    sent++;
+                } else if (result == SendResult.FAILED) {
+                    failed++;
+                }
+            } catch (Exception e) {
+                log.warn("Failed to send DENSUKE_PAGE_CREATED to player {}: {}", player.getId(), e.getMessage());
+                failed++;
+            }
+        }
+
+        log.info("DENSUKE_PAGE_CREATED: organizationId={}, targetCount={}, sent={}, failed={}",
+                organizationId, targetPlayers.size(), sent, failed);
+    }
+
     public SendResult sendMentorCommentFlexNotification(Long authorId, Long menteeId,
                                                          Match match, List<MatchComment> comments,
                                                          boolean isMenteeAuthor) {

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -1034,6 +1034,7 @@ public class LineNotificationService {
         pref.setAdminSameDayConfirmation(dto.isAdminSameDayConfirmation());
         pref.setAdminSameDayCancel(dto.isAdminSameDayCancel());
         pref.setMentorComment(dto.isMentorComment());
+        pref.setDensukePageCreated(dto.isDensukePageCreated());
 
         lineNotificationPreferenceRepository.save(pref);
     }
@@ -2722,7 +2723,15 @@ public class LineNotificationService {
 
         int sent = 0;
         int failed = 0;
+        int skipped = 0;
         for (Player player : targetPlayers) {
+            // 対象団体の通知設定を直接参照（sendToPlayer 内の anyMatch 判定だと他団体のONに引きずられるため）
+            Optional<LineNotificationPreference> prefOpt = lineNotificationPreferenceRepository
+                    .findByPlayerIdAndOrganizationId(player.getId(), organizationId);
+            if (prefOpt.isPresent() && Boolean.FALSE.equals(prefOpt.get().getDensukePageCreated())) {
+                skipped++;
+                continue;
+            }
             try {
                 SendResult result = sendToPlayer(player.getId(), LineNotificationType.DENSUKE_PAGE_CREATED, message);
                 if (result == SendResult.SUCCESS) {
@@ -2736,8 +2745,8 @@ public class LineNotificationService {
             }
         }
 
-        log.info("DENSUKE_PAGE_CREATED: organizationId={}, targetCount={}, sent={}, failed={}",
-                organizationId, targetPlayers.size(), sent, failed);
+        log.info("DENSUKE_PAGE_CREATED: organizationId={}, targetCount={}, sent={}, failed={}, skipped={}",
+                organizationId, targetPlayers.size(), sent, failed, skipped);
     }
 
     public SendResult sendMentorCommentFlexNotification(Long authorId, Long menteeId,

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LineNotificationService.java
@@ -10,6 +10,7 @@ import com.karuta.matchtracker.entity.Venue;
 import com.karuta.matchtracker.repository.*;
 import com.karuta.matchtracker.util.JstDateTimeUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -2702,51 +2703,64 @@ public class LineNotificationService {
      *
      * メッセージ本文は呼び出し側で組み立てる。タイトル行 + 本文 の改行連結が前提。
      *
+     * <p>
+     * 非同期実行（{@link Async}）。呼び出し元 API のレスポンス時間が団体人数や LINE API
+     * レイテンシに引きずられないよう、Spring の TaskExecutor 上で fire-and-forget で走らせる。
+     * 例外は {@code @Async} により呼び出しスレッドには伝播しないため、メソッド全体を try/catch で
+     * 包んで必ずログに残す（LINE API 失敗でも作成トランザクションはコミット済みで巻き戻せないため）。
+     *
      * @param organizationId 対象団体 ID
      * @param message 送信メッセージ全文
      */
+    @Async
     public void sendDensukePageCreatedNotification(Long organizationId, String message) {
-        List<PlayerOrganization> memberships = playerOrganizationRepository.findByOrganizationId(organizationId);
-        if (memberships.isEmpty()) {
-            log.info("DENSUKE_PAGE_CREATED: no members in organization {}", organizationId);
-            return;
-        }
-
-        List<Long> playerIds = memberships.stream()
-                .map(PlayerOrganization::getPlayerId)
-                .toList();
-
-        List<Player> targetPlayers = playerRepository.findAllById(playerIds).stream()
-                .filter(p -> p.getDeletedAt() == null)
-                .filter(p -> p.getRole() == Player.Role.PLAYER)
-                .toList();
-
-        int sent = 0;
-        int failed = 0;
-        int skipped = 0;
-        for (Player player : targetPlayers) {
-            // 対象団体の通知設定を直接参照（sendToPlayer 内の anyMatch 判定だと他団体のONに引きずられるため）
-            Optional<LineNotificationPreference> prefOpt = lineNotificationPreferenceRepository
-                    .findByPlayerIdAndOrganizationId(player.getId(), organizationId);
-            if (prefOpt.isPresent() && Boolean.FALSE.equals(prefOpt.get().getDensukePageCreated())) {
-                skipped++;
-                continue;
+        try {
+            List<PlayerOrganization> memberships = playerOrganizationRepository.findByOrganizationId(organizationId);
+            if (memberships.isEmpty()) {
+                log.info("DENSUKE_PAGE_CREATED: no members in organization {}", organizationId);
+                return;
             }
-            try {
-                SendResult result = sendToPlayer(player.getId(), LineNotificationType.DENSUKE_PAGE_CREATED, message);
-                if (result == SendResult.SUCCESS) {
-                    sent++;
-                } else if (result == SendResult.FAILED) {
+
+            List<Long> playerIds = memberships.stream()
+                    .map(PlayerOrganization::getPlayerId)
+                    .toList();
+
+            List<Player> targetPlayers = playerRepository.findAllById(playerIds).stream()
+                    .filter(p -> p.getDeletedAt() == null)
+                    .filter(p -> p.getRole() == Player.Role.PLAYER)
+                    .toList();
+
+            int sent = 0;
+            int failed = 0;
+            int skipped = 0;
+            for (Player player : targetPlayers) {
+                // 対象団体の通知設定を直接参照（sendToPlayer 内の anyMatch 判定だと他団体のONに引きずられるため）
+                Optional<LineNotificationPreference> prefOpt = lineNotificationPreferenceRepository
+                        .findByPlayerIdAndOrganizationId(player.getId(), organizationId);
+                if (prefOpt.isPresent() && Boolean.FALSE.equals(prefOpt.get().getDensukePageCreated())) {
+                    skipped++;
+                    continue;
+                }
+                try {
+                    SendResult result = sendToPlayer(player.getId(), LineNotificationType.DENSUKE_PAGE_CREATED, message);
+                    if (result == SendResult.SUCCESS) {
+                        sent++;
+                    } else if (result == SendResult.FAILED) {
+                        failed++;
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to send DENSUKE_PAGE_CREATED to player {}: {}", player.getId(), e.getMessage());
                     failed++;
                 }
-            } catch (Exception e) {
-                log.warn("Failed to send DENSUKE_PAGE_CREATED to player {}: {}", player.getId(), e.getMessage());
-                failed++;
             }
-        }
 
-        log.info("DENSUKE_PAGE_CREATED: organizationId={}, targetCount={}, sent={}, failed={}, skipped={}",
-                organizationId, targetPlayers.size(), sent, failed, skipped);
+            log.info("DENSUKE_PAGE_CREATED: organizationId={}, targetCount={}, sent={}, failed={}, skipped={}",
+                    organizationId, targetPlayers.size(), sent, failed, skipped);
+        } catch (Exception e) {
+            // @Async のスレッドで失敗しても呼び出し元には伝播しないため、ここで必ずログに落とす
+            log.warn("Async DENSUKE_PAGE_CREATED dispatch failed: org={}, err={}",
+                    organizationId, e.getMessage(), e);
+        }
     }
 
     public SendResult sendMentorCommentFlexNotification(Long authorId, Long menteeId,

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
@@ -745,6 +745,9 @@ public class PracticeSessionService {
         DensukeUrl entity = densukeUrlRepository.findByYearAndMonthAndOrganizationId(year, month, organizationId)
                 .orElse(DensukeUrl.builder().year(year).month(month).organizationId(organizationId).build());
         entity.setUrl(url);
+        // 手動保存経路では sd（編集用シークレット）を持たない。自動作成済みレコードを手動 URL で
+        // 上書きしたケースで旧 sd が残留して整合性が崩れないよう、明示的にクリアする。
+        entity.setDensukeSd(null);
         return densukeUrlRepository.save(entity);
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/DensukeTemplateControllerTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/DensukeTemplateControllerTest.java
@@ -1,0 +1,99 @@
+package com.karuta.matchtracker.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.karuta.matchtracker.dto.DensukeTemplateDto;
+import com.karuta.matchtracker.dto.DensukeTemplateUpdateRequest;
+import com.karuta.matchtracker.repository.PlayerRepository;
+import com.karuta.matchtracker.service.DensukeTemplateService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DensukeTemplateController.class)
+@DisplayName("DensukeTemplateController 単体テスト")
+class DensukeTemplateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private DensukeTemplateService densukeTemplateService;
+
+    @MockitoBean
+    private PlayerRepository playerRepository;
+
+    @Test
+    @DisplayName("GET /api/densuke-templates/{orgId}: 200 でテンプレート DTO を返す")
+    void getTemplate_returns200() throws Exception {
+        DensukeTemplateDto dto = DensukeTemplateDto.builder()
+                .organizationId(1L)
+                .titleTemplate("{year}年{month}月 練習出欠")
+                .description("説明")
+                .contactEmail("test@example.com")
+                .build();
+        when(densukeTemplateService.getTemplate(1L)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/densuke-templates/1")
+                        .header("X-User-Role", "SUPER_ADMIN")
+                        .header("X-User-Id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.organizationId").value(1))
+                .andExpect(jsonPath("$.titleTemplate").value("{year}年{month}月 練習出欠"))
+                .andExpect(jsonPath("$.description").value("説明"))
+                .andExpect(jsonPath("$.contactEmail").value("test@example.com"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/densuke-templates/{orgId}: 正常更新で 200")
+    void updateTemplate_returns200() throws Exception {
+        DensukeTemplateUpdateRequest request = new DensukeTemplateUpdateRequest();
+        request.setTitleTemplate("{year}/{month} 練習");
+        request.setDescription("新説明");
+        request.setContactEmail("new@example.com");
+
+        DensukeTemplateDto updated = DensukeTemplateDto.builder()
+                .organizationId(1L)
+                .titleTemplate("{year}/{month} 練習")
+                .description("新説明")
+                .contactEmail("new@example.com")
+                .build();
+        when(densukeTemplateService.updateTemplate(eq(1L), any())).thenReturn(updated);
+
+        mockMvc.perform(put("/api/densuke-templates/1")
+                        .header("X-User-Role", "SUPER_ADMIN")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.titleTemplate").value("{year}/{month} 練習"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/densuke-templates/{orgId}: titleTemplate が空なら 400")
+    void updateTemplate_returns400_whenTitleMissing() throws Exception {
+        DensukeTemplateUpdateRequest request = new DensukeTemplateUpdateRequest();
+        request.setTitleTemplate("");
+
+        mockMvc.perform(put("/api/densuke-templates/1")
+                        .header("X-User-Role", "SUPER_ADMIN")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/PracticeSessionControllerTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/PracticeSessionControllerTest.java
@@ -66,6 +66,9 @@ class PracticeSessionControllerTest {
     @MockitoBean
     private com.karuta.matchtracker.service.AdjacentRoomService adjacentRoomService;
 
+    @MockitoBean
+    private com.karuta.matchtracker.service.DensukePageCreateService densukePageCreateService;
+
     private PracticeSessionDto testSessionDto;
     private PracticeSessionCreateRequest createRequest;
     private LocalDate today;
@@ -476,5 +479,73 @@ class PracticeSessionControllerTest {
                 .andExpect(status().isForbidden());
 
         verify(practiceParticipantService, never()).registerParticipations(any());
+    }
+
+    // ===== POST /api/practice-sessions/densuke/create-page テスト =====
+
+    @Test
+    @DisplayName("POST /densuke/create-page: 正常作成で 200 とレスポンス DTO を返す")
+    void createDensukePage_returns200() throws Exception {
+        com.karuta.matchtracker.dto.DensukePageCreateRequest req =
+                new com.karuta.matchtracker.dto.DensukePageCreateRequest();
+        req.setYear(2026);
+        req.setMonth(5);
+        req.setOrganizationId(1L);
+
+        com.karuta.matchtracker.dto.DensukePageCreateResponse res =
+                com.karuta.matchtracker.dto.DensukePageCreateResponse.builder()
+                        .cd("wAeAQgkBpAAgeMrK")
+                        .url("https://densuke.biz/list?cd=wAeAQgkBpAAgeMrK")
+                        .createdDateCount(4)
+                        .createdMatchSlotCount(12)
+                        .build();
+        when(densukePageCreateService.createPage(any())).thenReturn(res);
+
+        mockMvc.perform(post("/api/practice-sessions/densuke/create-page")
+                        .header("X-User-Role", "SUPER_ADMIN")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cd").value("wAeAQgkBpAAgeMrK"))
+                .andExpect(jsonPath("$.url").value("https://densuke.biz/list?cd=wAeAQgkBpAAgeMrK"))
+                .andExpect(jsonPath("$.createdDateCount").value(4))
+                .andExpect(jsonPath("$.createdMatchSlotCount").value(12));
+    }
+
+    @Test
+    @DisplayName("POST /densuke/create-page: IllegalStateException は 400 で message を返す")
+    void createDensukePage_returns400_onIllegalState() throws Exception {
+        com.karuta.matchtracker.dto.DensukePageCreateRequest req =
+                new com.karuta.matchtracker.dto.DensukePageCreateRequest();
+        req.setYear(2026);
+        req.setMonth(5);
+        req.setOrganizationId(1L);
+
+        when(densukePageCreateService.createPage(any()))
+                .thenThrow(new IllegalStateException("2026年5月に練習日が登録されていません"));
+
+        mockMvc.perform(post("/api/practice-sessions/densuke/create-page")
+                        .header("X-User-Role", "SUPER_ADMIN")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("2026年5月に練習日が登録されていません"));
+    }
+
+    @Test
+    @DisplayName("POST /densuke/create-page: year/month/organizationId が無いと 400")
+    void createDensukePage_returns400_whenRequiredFieldsMissing() throws Exception {
+        com.karuta.matchtracker.dto.DensukePageCreateRequest req =
+                new com.karuta.matchtracker.dto.DensukePageCreateRequest();
+        // 空リクエスト → @NotNull 違反
+
+        mockMvc.perform(post("/api/practice-sessions/densuke/create-page")
+                        .header("X-User-Role", "SUPER_ADMIN")
+                        .header("X-User-Id", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukePageCreateServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukePageCreateServiceTest.java
@@ -1,0 +1,133 @@
+package com.karuta.matchtracker.service;
+
+import com.karuta.matchtracker.dto.DensukePageCreateRequest;
+import com.karuta.matchtracker.entity.DensukeUrl;
+import com.karuta.matchtracker.entity.PracticeSession;
+import com.karuta.matchtracker.entity.Venue;
+import com.karuta.matchtracker.entity.VenueMatchSchedule;
+import com.karuta.matchtracker.repository.DensukeTemplateRepository;
+import com.karuta.matchtracker.repository.DensukeUrlRepository;
+import com.karuta.matchtracker.repository.OrganizationRepository;
+import com.karuta.matchtracker.repository.PracticeSessionRepository;
+import com.karuta.matchtracker.repository.VenueMatchScheduleRepository;
+import com.karuta.matchtracker.repository.VenueRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * バリデーション系のテスト。densuke.biz への HTTP 呼び出しは到達しないため副作用なし。
+ * 正常系（HTTP 成功）は E2E テストで検証する。
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DensukePageCreateService 単体テスト（バリデーション）")
+class DensukePageCreateServiceTest {
+
+    @Mock private DensukeUrlRepository densukeUrlRepository;
+    @Mock private DensukeTemplateRepository densukeTemplateRepository;
+    @Mock private PracticeSessionRepository practiceSessionRepository;
+    @Mock private VenueRepository venueRepository;
+    @Mock private VenueMatchScheduleRepository venueMatchScheduleRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private LineNotificationService lineNotificationService;
+
+    @InjectMocks
+    private DensukePageCreateService service;
+
+    private DensukePageCreateRequest baseRequest;
+
+    @BeforeEach
+    void setUp() {
+        baseRequest = new DensukePageCreateRequest();
+        baseRequest.setYear(2026);
+        baseRequest.setMonth(5);
+        baseRequest.setOrganizationId(1L);
+    }
+
+    @Test
+    @DisplayName("既存の densuke_urls がある月は IllegalStateException")
+    void createPage_throws_whenDensukeUrlAlreadyExists() {
+        DensukeUrl existing = DensukeUrl.builder()
+                .id(1L).year(2026).month(5).organizationId(1L)
+                .url("https://densuke.biz/list?cd=abc").build();
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.createPage(baseRequest))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("既に登録されています");
+    }
+
+    @Test
+    @DisplayName("practice_sessions が 0 件なら IllegalStateException")
+    void createPage_throws_whenNoPracticeSessions() {
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+                .thenReturn(Optional.empty());
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+                .thenReturn(Collections.emptyList());
+
+        assertThatThrownBy(() -> service.createPage(baseRequest))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("練習日が登録されていません");
+    }
+
+    @Test
+    @DisplayName("会場が Venue マスタに存在しないと IllegalStateException")
+    void createPage_throws_whenVenueNotFound() {
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).sessionDate(LocalDate.of(2026, 5, 10))
+                .venueId(999L).totalMatches(1).organizationId(1L)
+                .build();
+
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+                .thenReturn(Optional.empty());
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+                .thenReturn(List.of(session));
+        when(venueRepository.findAllById(any())).thenReturn(Collections.emptyList());
+        when(venueMatchScheduleRepository.findByVenueIdIn(any())).thenReturn(Collections.emptyList());
+
+        assertThatThrownBy(() -> service.createPage(baseRequest))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("会場が登録されていません");
+    }
+
+    @Test
+    @DisplayName("venue_match_schedules に試合時刻が足りないと IllegalStateException")
+    void createPage_throws_whenMatchScheduleMissing() {
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).sessionDate(LocalDate.of(2026, 5, 10))
+                .venueId(10L).totalMatches(3).organizationId(1L)
+                .build();
+        Venue venue = Venue.builder().id(10L).name("テスト会場").defaultMatchCount(3).build();
+        // matchNumber=1 のみ、2と3は未登録
+        VenueMatchSchedule vms1 = VenueMatchSchedule.builder()
+                .id(1L).venueId(10L).matchNumber(1)
+                .startTime(LocalTime.of(17, 0)).endTime(LocalTime.of(18, 0))
+                .build();
+
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+                .thenReturn(Optional.empty());
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+                .thenReturn(List.of(session));
+        when(venueRepository.findAllById(any())).thenReturn(List.of(venue));
+        when(venueMatchScheduleRepository.findByVenueIdIn(any())).thenReturn(List.of(vms1));
+
+        assertThatThrownBy(() -> service.createPage(baseRequest))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("試合目の時間割が登録されていません");
+    }
+}

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukePageCreateServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukePageCreateServiceTest.java
@@ -11,6 +11,7 @@ import com.karuta.matchtracker.repository.OrganizationRepository;
 import com.karuta.matchtracker.repository.PracticeSessionRepository;
 import com.karuta.matchtracker.repository.VenueMatchScheduleRepository;
 import com.karuta.matchtracker.repository.VenueRepository;
+import com.karuta.matchtracker.util.JstDateTimeUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,13 +19,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -49,12 +53,18 @@ class DensukePageCreateServiceTest {
     private DensukePageCreateService service;
 
     private DensukePageCreateRequest baseRequest;
+    private int baseYear;
+    private int baseMonth;
 
     @BeforeEach
     void setUp() {
+        // テストは実行日の JST「翌月」を対象にする（当月〜+2ヶ月の範囲内で固定）
+        YearMonth ym = YearMonth.now(JstDateTimeUtil.JST).plusMonths(1);
+        baseYear = ym.getYear();
+        baseMonth = ym.getMonthValue();
         baseRequest = new DensukePageCreateRequest();
-        baseRequest.setYear(2026);
-        baseRequest.setMonth(5);
+        baseRequest.setYear(baseYear);
+        baseRequest.setMonth(baseMonth);
         baseRequest.setOrganizationId(1L);
     }
 
@@ -62,9 +72,9 @@ class DensukePageCreateServiceTest {
     @DisplayName("既存の densuke_urls がある月は IllegalStateException")
     void createPage_throws_whenDensukeUrlAlreadyExists() {
         DensukeUrl existing = DensukeUrl.builder()
-                .id(1L).year(2026).month(5).organizationId(1L)
+                .id(1L).year(baseYear).month(baseMonth).organizationId(1L)
                 .url("https://densuke.biz/list?cd=abc").build();
-        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
                 .thenReturn(Optional.of(existing));
 
         assertThatThrownBy(() -> service.createPage(baseRequest))
@@ -75,9 +85,9 @@ class DensukePageCreateServiceTest {
     @Test
     @DisplayName("practice_sessions が 0 件なら IllegalStateException")
     void createPage_throws_whenNoPracticeSessions() {
-        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
                 .thenReturn(Optional.empty());
-        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
                 .thenReturn(Collections.emptyList());
 
         assertThatThrownBy(() -> service.createPage(baseRequest))
@@ -89,13 +99,13 @@ class DensukePageCreateServiceTest {
     @DisplayName("会場が Venue マスタに存在しないと IllegalStateException")
     void createPage_throws_whenVenueNotFound() {
         PracticeSession session = PracticeSession.builder()
-                .id(1L).sessionDate(LocalDate.of(2026, 5, 10))
+                .id(1L).sessionDate(LocalDate.of(baseYear, baseMonth, 10))
                 .venueId(999L).totalMatches(1).organizationId(1L)
                 .build();
 
-        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
                 .thenReturn(Optional.empty());
-        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
                 .thenReturn(List.of(session));
         when(venueRepository.findAllById(any())).thenReturn(Collections.emptyList());
         when(venueMatchScheduleRepository.findByVenueIdIn(any())).thenReturn(Collections.emptyList());
@@ -109,7 +119,7 @@ class DensukePageCreateServiceTest {
     @DisplayName("venue_match_schedules に試合時刻が足りないと IllegalStateException")
     void createPage_throws_whenMatchScheduleMissing() {
         PracticeSession session = PracticeSession.builder()
-                .id(1L).sessionDate(LocalDate.of(2026, 5, 10))
+                .id(1L).sessionDate(LocalDate.of(baseYear, baseMonth, 10))
                 .venueId(10L).totalMatches(3).organizationId(1L)
                 .build();
         Venue venue = Venue.builder().id(10L).name("テスト会場").defaultMatchCount(3).build();
@@ -119,9 +129,9 @@ class DensukePageCreateServiceTest {
                 .startTime(LocalTime.of(17, 0)).endTime(LocalTime.of(18, 0))
                 .build();
 
-        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
                 .thenReturn(Optional.empty());
-        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(2026, 5, 1L))
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
                 .thenReturn(List.of(session));
         when(venueRepository.findAllById(any())).thenReturn(List.of(venue));
         when(venueMatchScheduleRepository.findByVenueIdIn(any())).thenReturn(List.of(vms1));
@@ -129,5 +139,97 @@ class DensukePageCreateServiceTest {
         assertThatThrownBy(() -> service.createPage(baseRequest))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("試合目の時間割が登録されていません");
+    }
+
+    @Test
+    @DisplayName("過去月を指定すると IllegalStateException（API 直叩きでもフロントと同じ制約を適用）")
+    void createPage_throws_whenTargetMonthIsInPast() {
+        YearMonth past = YearMonth.now(JstDateTimeUtil.JST).minusMonths(1);
+        DensukePageCreateRequest req = new DensukePageCreateRequest();
+        req.setYear(past.getYear());
+        req.setMonth(past.getMonthValue());
+        req.setOrganizationId(1L);
+
+        assertThatThrownBy(() -> service.createPage(req))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("作成可能範囲外");
+    }
+
+    @Test
+    @DisplayName("3ヶ月以上先を指定すると IllegalStateException")
+    void createPage_throws_whenTargetMonthIsTooFarInFuture() {
+        YearMonth far = YearMonth.now(JstDateTimeUtil.JST).plusMonths(3);
+        DensukePageCreateRequest req = new DensukePageCreateRequest();
+        req.setYear(far.getYear());
+        req.setMonth(far.getMonthValue());
+        req.setOrganizationId(1L);
+
+        assertThatThrownBy(() -> service.createPage(req))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("作成可能範囲外");
+    }
+
+    @Test
+    @DisplayName("saveAndFlush で UNIQUE 制約違反が起きたら『既に登録されています』で IllegalStateException に変換する（同時実行レース）")
+    void createPage_throws_whenConcurrentRaceHitsUniqueConstraint() {
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).sessionDate(LocalDate.of(baseYear, baseMonth, 10))
+                .venueId(10L).totalMatches(1).organizationId(1L)
+                .build();
+        Venue venue = Venue.builder().id(10L).name("テスト会場").defaultMatchCount(1).build();
+        VenueMatchSchedule vms1 = VenueMatchSchedule.builder()
+                .id(1L).venueId(10L).matchNumber(1)
+                .startTime(LocalTime.of(17, 0)).endTime(LocalTime.of(18, 0))
+                .build();
+
+        // 事前チェックは通過（= もう片方の同時リクエストがまだコミットしていない想定）
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
+                .thenReturn(Optional.empty());
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(baseYear, baseMonth, 1L))
+                .thenReturn(List.of(session));
+        when(venueRepository.findAllById(any())).thenReturn(List.of(venue));
+        when(venueMatchScheduleRepository.findByVenueIdIn(any())).thenReturn(List.of(vms1));
+        // 仮レコード INSERT のフラッシュで UNIQUE 制約違反（もう片方が先にコミット済み）
+        when(densukeUrlRepository.saveAndFlush(any(DensukeUrl.class)))
+                .thenThrow(new DataIntegrityViolationException("unique_violation"));
+
+        assertThatThrownBy(() -> service.createPage(baseRequest))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("既に登録されています");
+    }
+
+    @Test
+    @DisplayName("validateYearMonth: 当月・+2ヶ月は許可、過去月・+3ヶ月は拒否（境界値）")
+    void validateYearMonth_boundaries() {
+        YearMonth current = YearMonth.of(2026, 5);
+
+        // 許可: 当月、+1、+2
+        assertThatCode(() -> DensukePageCreateService.validateYearMonth(2026, 5, current))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> DensukePageCreateService.validateYearMonth(2026, 6, current))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> DensukePageCreateService.validateYearMonth(2026, 7, current))
+                .doesNotThrowAnyException();
+
+        // 拒否: -1、+3
+        assertThatThrownBy(() -> DensukePageCreateService.validateYearMonth(2026, 4, current))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("作成可能範囲外");
+        assertThatThrownBy(() -> DensukePageCreateService.validateYearMonth(2026, 8, current))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("作成可能範囲外");
+
+        // 年跨ぎ: 12月 current → 翌年2月まで許可
+        YearMonth dec = YearMonth.of(2026, 12);
+        assertThatCode(() -> DensukePageCreateService.validateYearMonth(2027, 2, dec))
+                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> DensukePageCreateService.validateYearMonth(2027, 3, dec))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("作成可能範囲外");
+
+        // 不正な月
+        assertThatThrownBy(() -> DensukePageCreateService.validateYearMonth(2026, 13, current))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("不正");
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukePageCreateServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukePageCreateServiceTest.java
@@ -26,8 +26,10 @@ import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -196,6 +198,95 @@ class DensukePageCreateServiceTest {
         assertThatThrownBy(() -> service.createPage(baseRequest))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("既に登録されています");
+    }
+
+    @Test
+    @DisplayName("buildScheduleText: 1セッション3試合 → 1試合目行に日付+会場、2/3試合目は試合番号のみ（時刻は含めない）")
+    void buildScheduleText_singleSession_headerThenBareMatches() {
+        // 2026/4/20(月) すずらん 3試合
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).sessionDate(LocalDate.of(2026, 4, 20))
+                .venueId(10L).totalMatches(3).organizationId(1L)
+                .build();
+        Venue venue = Venue.builder().id(10L).name("すずらん").defaultMatchCount(3).build();
+        Map<Integer, VenueMatchSchedule> vms = Map.of(
+                1, VenueMatchSchedule.builder().venueId(10L).matchNumber(1)
+                        .startTime(LocalTime.of(17, 20)).endTime(LocalTime.of(18, 40)).build(),
+                2, VenueMatchSchedule.builder().venueId(10L).matchNumber(2)
+                        .startTime(LocalTime.of(18, 45)).endTime(LocalTime.of(20, 5)).build(),
+                3, VenueMatchSchedule.builder().venueId(10L).matchNumber(3)
+                        .startTime(LocalTime.of(20, 10)).endTime(LocalTime.of(21, 30)).build()
+        );
+
+        DensukePageCreateService.BuildResult result = service.buildScheduleText(
+                List.of(session), Map.of(10L, venue), Map.of(10L, vms));
+
+        assertThat(result.scheduleText()).isEqualTo(
+                "4/20(月) すずらん 1試合目\n" +
+                "2試合目\n" +
+                "3試合目\n");
+        assertThat(result.matchSlotCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("buildScheduleText: 複数日・複数会場 → セッションごとにヘッダー行、同日同会場の2試合目以降は試合番号のみ")
+    void buildScheduleText_multipleSessions_eachSessionStartsFreshHeader() {
+        PracticeSession s1 = PracticeSession.builder()
+                .id(1L).sessionDate(LocalDate.of(2026, 4, 2))
+                .venueId(10L).totalMatches(2).organizationId(1L).build();
+        PracticeSession s2 = PracticeSession.builder()
+                .id(2L).sessionDate(LocalDate.of(2026, 4, 4))
+                .venueId(20L).totalMatches(3).organizationId(1L).build();
+
+        Venue azuma = Venue.builder().id(10L).name("東全室").defaultMatchCount(2).build();
+        Venue ezomatsu = Venue.builder().id(20L).name("えぞまつ").defaultMatchCount(3).build();
+
+        Map<Integer, VenueMatchSchedule> azumaSchedules = Map.of(
+                1, VenueMatchSchedule.builder().venueId(10L).matchNumber(1)
+                        .startTime(LocalTime.of(17, 0)).endTime(LocalTime.of(18, 0)).build(),
+                2, VenueMatchSchedule.builder().venueId(10L).matchNumber(2)
+                        .startTime(LocalTime.of(18, 5)).endTime(LocalTime.of(19, 5)).build()
+        );
+        Map<Integer, VenueMatchSchedule> ezoSchedules = Map.of(
+                1, VenueMatchSchedule.builder().venueId(20L).matchNumber(1)
+                        .startTime(LocalTime.of(17, 20)).endTime(LocalTime.of(18, 40)).build(),
+                2, VenueMatchSchedule.builder().venueId(20L).matchNumber(2)
+                        .startTime(LocalTime.of(18, 45)).endTime(LocalTime.of(20, 5)).build(),
+                3, VenueMatchSchedule.builder().venueId(20L).matchNumber(3)
+                        .startTime(LocalTime.of(20, 10)).endTime(LocalTime.of(21, 30)).build()
+        );
+
+        DensukePageCreateService.BuildResult result = service.buildScheduleText(
+                List.of(s1, s2),
+                Map.of(10L, azuma, 20L, ezomatsu),
+                Map.of(10L, azumaSchedules, 20L, ezoSchedules));
+
+        assertThat(result.scheduleText()).isEqualTo(
+                "4/2(木) 東全室 1試合目\n" +
+                "2試合目\n" +
+                "4/4(土) えぞまつ 1試合目\n" +
+                "2試合目\n" +
+                "3試合目\n");
+        assertThat(result.matchSlotCount()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("buildScheduleText: 1試合セッションは単独で1行（ヘッダーのみ、試合番号のみ行は出ない）")
+    void buildScheduleText_singleMatchSession_onlyHeaderLine() {
+        PracticeSession session = PracticeSession.builder()
+                .id(1L).sessionDate(LocalDate.of(2026, 5, 3))
+                .venueId(10L).totalMatches(1).organizationId(1L).build();
+        Venue venue = Venue.builder().id(10L).name("あかなら").defaultMatchCount(1).build();
+        Map<Integer, VenueMatchSchedule> vms = Map.of(
+                1, VenueMatchSchedule.builder().venueId(10L).matchNumber(1)
+                        .startTime(LocalTime.of(10, 0)).endTime(LocalTime.of(11, 20)).build()
+        );
+
+        DensukePageCreateService.BuildResult result = service.buildScheduleText(
+                List.of(session), Map.of(10L, venue), Map.of(10L, vms));
+
+        assertThat(result.scheduleText()).isEqualTo("5/3(日) あかなら 1試合目\n");
+        assertThat(result.matchSlotCount()).isEqualTo(1);
     }
 
     @Test

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeTemplateServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeTemplateServiceTest.java
@@ -1,0 +1,109 @@
+package com.karuta.matchtracker.service;
+
+import com.karuta.matchtracker.dto.DensukeTemplateDto;
+import com.karuta.matchtracker.dto.DensukeTemplateUpdateRequest;
+import com.karuta.matchtracker.entity.DensukeTemplate;
+import com.karuta.matchtracker.repository.DensukeTemplateRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DensukeTemplateService 単体テスト")
+class DensukeTemplateServiceTest {
+
+    @Mock
+    private DensukeTemplateRepository repository;
+
+    @InjectMocks
+    private DensukeTemplateService service;
+
+    @Test
+    @DisplayName("getTemplate: 未登録団体にはデフォルト値を返す")
+    void getTemplate_returnsDefault_whenNotRegistered() {
+        when(repository.findByOrganizationId(10L)).thenReturn(Optional.empty());
+
+        DensukeTemplateDto dto = service.getTemplate(10L);
+
+        assertThat(dto.getOrganizationId()).isEqualTo(10L);
+        assertThat(dto.getTitleTemplate()).isEqualTo("{year}年{month}月 練習出欠");
+        assertThat(dto.getDescription()).isEmpty();
+        assertThat(dto.getContactEmail()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getTemplate: 登録済み団体は保存値をそのまま返す")
+    void getTemplate_returnsSavedValues_whenRegistered() {
+        DensukeTemplate saved = DensukeTemplate.builder()
+                .id(1L)
+                .organizationId(10L)
+                .titleTemplate("{year}年{month}月 カスタム出欠")
+                .description("説明文")
+                .contactEmail("owner@example.com")
+                .build();
+        when(repository.findByOrganizationId(10L)).thenReturn(Optional.of(saved));
+
+        DensukeTemplateDto dto = service.getTemplate(10L);
+
+        assertThat(dto.getTitleTemplate()).isEqualTo("{year}年{month}月 カスタム出欠");
+        assertThat(dto.getDescription()).isEqualTo("説明文");
+        assertThat(dto.getContactEmail()).isEqualTo("owner@example.com");
+    }
+
+    @Test
+    @DisplayName("updateTemplate: 既存レコードがあれば上書き更新")
+    void updateTemplate_updates_whenExists() {
+        DensukeTemplate existing = DensukeTemplate.builder()
+                .id(1L)
+                .organizationId(10L)
+                .titleTemplate("旧タイトル")
+                .description("旧説明")
+                .contactEmail("old@example.com")
+                .build();
+        when(repository.findByOrganizationId(10L)).thenReturn(Optional.of(existing));
+        when(repository.save(any(DensukeTemplate.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        DensukeTemplateUpdateRequest req = new DensukeTemplateUpdateRequest();
+        req.setTitleTemplate("新タイトル {year}");
+        req.setDescription("新説明");
+        req.setContactEmail("new@example.com");
+
+        DensukeTemplateDto dto = service.updateTemplate(10L, req);
+
+        assertThat(dto.getTitleTemplate()).isEqualTo("新タイトル {year}");
+        assertThat(dto.getDescription()).isEqualTo("新説明");
+        assertThat(dto.getContactEmail()).isEqualTo("new@example.com");
+        verify(repository).save(any(DensukeTemplate.class));
+    }
+
+    @Test
+    @DisplayName("updateTemplate: 未登録なら新規作成して保存")
+    void updateTemplate_creates_whenNotExists() {
+        when(repository.findByOrganizationId(10L)).thenReturn(Optional.empty());
+        when(repository.save(any(DensukeTemplate.class))).thenAnswer(inv -> {
+            DensukeTemplate t = inv.getArgument(0);
+            t.setId(99L);
+            return t;
+        });
+
+        DensukeTemplateUpdateRequest req = new DensukeTemplateUpdateRequest();
+        req.setTitleTemplate("新規タイトル");
+        req.setDescription("説明");
+
+        DensukeTemplateDto dto = service.updateTemplate(10L, req);
+
+        assertThat(dto.getTitleTemplate()).isEqualTo("新規タイトル");
+        assertThat(dto.getOrganizationId()).isEqualTo(10L);
+        verify(repository).save(any(DensukeTemplate.class));
+    }
+}

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
@@ -3,6 +3,7 @@ package com.karuta.matchtracker.service;
 import com.karuta.matchtracker.dto.PracticeSessionCreateRequest;
 import com.karuta.matchtracker.dto.PracticeSessionDto;
 import com.karuta.matchtracker.dto.PracticeSessionUpdateRequest;
+import com.karuta.matchtracker.entity.DensukeUrl;
 import com.karuta.matchtracker.entity.ParticipantStatus;
 import com.karuta.matchtracker.entity.Player;
 import com.karuta.matchtracker.entity.PracticeParticipant;
@@ -403,5 +404,39 @@ class PracticeSessionServiceTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("saveDensukeUrl は手動 URL 更新時に densuke_sd を NULL にクリアする（自動作成→手動上書きの整合性）")
+    void saveDensukeUrl_clearsDensukeSd_onManualOverwrite() {
+        // 自動作成済みレコード（sd 保持）を手動 URL で上書きするケース
+        DensukeUrl existing = DensukeUrl.builder()
+                .id(1L).year(2026).month(5).organizationId(10L)
+                .url("https://densuke.biz/list?cd=auto123")
+                .densukeSd("secret-sd-456")
+                .build();
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 5, 10L))
+                .thenReturn(Optional.of(existing));
+        when(densukeUrlRepository.save(any(DensukeUrl.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        DensukeUrl result = practiceSessionService.saveDensukeUrl(
+                2026, 5, "https://densuke.biz/list?cd=manualABC", 10L);
+
+        assertThat(result.getUrl()).isEqualTo("https://densuke.biz/list?cd=manualABC");
+        assertThat(result.getDensukeSd()).isNull();
+    }
+
+    @Test
+    @DisplayName("saveDensukeUrl は新規レコード作成時にも densuke_sd を NULL のままにする")
+    void saveDensukeUrl_newRecord_hasNullDensukeSd() {
+        when(densukeUrlRepository.findByYearAndMonthAndOrganizationId(2026, 6, 10L))
+                .thenReturn(Optional.empty());
+        when(densukeUrlRepository.save(any(DensukeUrl.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        DensukeUrl result = practiceSessionService.saveDensukeUrl(
+                2026, 6, "https://densuke.biz/list?cd=newXYZ", 10L);
+
+        assertThat(result.getUrl()).isEqualTo("https://densuke.biz/list?cd=newXYZ");
+        assertThat(result.getDensukeSd()).isNull();
     }
 }


### PR DESCRIPTION
## 概要
アプリに登録されている練習日データ (`practice_sessions` × `venues` × `venue_match_schedules`) から densuke.biz に出欠ページを自動発行する機能を追加する。作成成功後、団体所属の PLAYER ロールメンバーに LINE 通知を送信する。

- 親 Issue: #452
- 子 Issue: #453–#467 (15 個中 14 個クローズ、#466 E2E のみマージ後に実施)

## 変更サマリ

### バックエンド (新規)
- `DensukePageCreateService` — コア。バリデーション → テンプレート解決 → densuke.biz POST → `densuke_urls` 保存 → AFTER_COMMIT で LINE 通知発火
- `DensukeTemplateService` — 団体ごとの作成時デフォルト値 (タイトル / 説明 / 連絡先メアド) の CRUD
- `DensukeTemplateController` — `GET / PUT /api/densuke-templates/{orgId}` (ADMIN+)
- DTO: `DensukePageCreateRequest`, `DensukePageCreateResponse`, `DensukeTemplateDto`, `DensukeTemplateUpdateRequest`

### バックエンド (変更)
- `PracticeSessionController` — `POST /densuke/create-page` 追加
- `LineNotificationService.sendDensukePageCreatedNotification()` 追加、`isLineTypeEnabled` switch に case 追加
- `LineMessageLog.LineNotificationType` に `DENSUKE_PAGE_CREATED` 追加
- `LineNotificationPreference` に `densukePageCreated` 追加（`columnDefinition="BOOLEAN NOT NULL DEFAULT TRUE"` で既存レコード安全対応）
- `LineNotificationPreferenceDto` に対応フィールド追加
- `DensukeUrl` に `densukeSd`（伝助の編集用シークレット）追加
- Entity + Repository: `DensukeTemplate`, `DensukeTemplateRepository`

### DB マイグレーション
- `database/create_densuke_templates.sql` (新規テーブル)
- `database/add_densuke_sd_column.sql`
- `database/add_densuke_page_created_line_preference.sql`

⚠️ `ddl-auto=update` が有効なので、アプリ起動時に Hibernate が自動反映する想定。上記 SQL は手動マイグレーション用の予備。

### フロントエンド
- `DensukePageCreateModal.jsx` (新規) — 作成モーダル。テンプレートロード & プレースホルダー展開
- `DensukeTemplateModal.jsx` (新規) — テンプレート編集モーダル。プレースホルダーの現在月プレビュー付き
- `DensukeManagement.jsx` — 団体カードに「伝助ページ作成」「テンプレート編集」ボタン追加（当月＋未来2ヶ月、既存URL登録済み月は作成ボタン非表示）
- `LineSettings.jsx` — LINE 通知種別に `densukePageCreated` トグル追加
- `api/densukeTemplates.js` (新規), `api/practices.js` に `createDensukePage()` 追加

### テスト (全 14 件パス)
- `DensukePageCreateServiceTest` — バリデーション系 4 件
- `DensukeTemplateServiceTest` — CRUD 4 件
- `DensukeTemplateControllerTest` — GET / PUT / 400 3 件
- `PracticeSessionControllerTest` — create-page 3 件追加

### ドキュメント
- `docs/SPECIFICATION.md` — 4.1.7 伝助ページ自動作成サブセクション新規
- `docs/DESIGN.md` — densuke_sd カラム追加、densuke_templates テーブル新規、DensukePageCreateService 概要追記
- `docs/SCREEN_LIST.md` — 伝助管理画面のモーダル情報追記
- `docs/features/densuke-page-creator/` — 要件定義書、実装手順書、densuke.biz フォーム仕様

### 設定 (注意)
- `claude.md` と `.claude/skills/startapp/SKILL.md` の DB パスワードを現行値に更新
  - 既にリポジトリに平文で書かれていた運用の踏襲。将来的には `.env` / Render 環境変数管理への移行を推奨

## densuke.biz との連携仕様
- エンドポイント: `POST https://www.densuke.biz/create`
- `/confirm` はスキップ可能、認証不要
- 302 レスポンスの Location から `cd` と `sd` を正規表現で抽出
- schedule 文字列: `{M}/{D}({曜}) {HH:MM}～{会場} {N}試合目` 形式（既存 `DensukeScraper` の正規表現と整合）
- 固定値: `eventchoice=1` (○△×), `pw=0` (パスワードなし)

詳細は `docs/features/densuke-page-creator/densuke-form-spec.md` 参照。

## Test plan
- [x] Java コンパイル (`./gradlew compileJava`) — BUILD SUCCESSFUL
- [x] フロント Lint (`eslint`) — densuke 関連ファイルでクリーン
- [x] 新規 14 テストすべてパス
- [x] curl でのフォーム送信 E2E — テストイベント `cd=wAeAQgkBpAAgeMrK` が作成済み (伝助側に残留)
- [ ] マージ後: アプリを `/startapp` で起動し、`ddl-auto=update` でスキーマが正しく反映されること
- [ ] マージ後: 伝助管理画面から「伝助ページ作成」ボタンで実作成できること
- [ ] マージ後: 団体メンバーに LINE 通知が届くこと (ADMIN/SUPER_ADMIN には届かない)
- [ ] マージ後: `DensukeSyncScheduler` が新 URL を次回サイクルで自動取り込みすること
- [ ] マージ後: バリデーションエラー (練習日0件 / 会場未登録 / venue_match_schedules 不足) が期待通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)