### PR TITLE
fix: 2択伝助ページで先頭メンバーが同期されないバグ修正

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeScraper.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeScraper.java
@@ -58,6 +58,13 @@ public class DensukeScraper {
                 .timeout(10000)
                 .get();
 
+        return parse(doc, year);
+    }
+
+    /**
+     * Jsoup Document から伝助データをパースする。ネットワーク I/O を持たないのでユニットテスト可能。
+     */
+    DensukeData parse(Document doc, int year) throws IOException {
         Element table = doc.selectFirst("table.listtbl");
         if (table == null) {
             throw new IOException("伝助のテーブルが見つかりません");
@@ -68,17 +75,23 @@ public class DensukeScraper {
             throw new IOException("テーブルにデータがありません");
         }
 
-        // 1行目: ヘッダー行 — 列4以降が参加者名
+        // 1行目: ヘッダー行。先頭の凡例列数はページ設定 (○/△/× の3択 or ○/× の2択) で変わるため、
+        // 「memberdata アンカーを持つ最初のセル」を動的に検出してメンバー列の開始位置を求める。
         Element headerRow = rows.get(0);
         Elements headerCells = headerRow.select("td");
+        int memberStartIdx = findMemberStartIndex(headerCells);
+        if (memberStartIdx < 0) {
+            throw new IOException("伝助のメンバー列が見つかりません");
+        }
+
         List<String> memberNames = new ArrayList<>();
-        for (int i = 4; i < headerCells.size(); i++) {
+        for (int i = memberStartIdx; i < headerCells.size(); i++) {
             Element cell = headerCells.get(i);
             Element link = cell.selectFirst("a");
             String name = stripLeadingEmoji(link != null ? link.text() : cell.text());
             memberNames.add(name);
         }
-        log.info("Found {} members in densuke", memberNames.size());
+        log.info("Found {} members in densuke (memberStartIdx={})", memberNames.size(), memberStartIdx);
 
         // 2行目以降: 日程データ
         DensukeData data = new DensukeData();
@@ -117,15 +130,15 @@ public class DensukeScraper {
                 matchNumber = Integer.parseInt(matchMatcher.group(1));
             }
 
-            // 列4以降が各参加者の出欠データ
+            // memberStartIdx 以降が各参加者の出欠データ
             ScheduleEntry entry = new ScheduleEntry();
             entry.setDate(currentDate);
             entry.setMatchNumber(matchNumber);
             entry.setVenueName(currentVenue);
             entry.setRawLabel(label);
 
-            for (int colIdx = 4; colIdx < cells.size(); colIdx++) {
-                int memberIdx = colIdx - 4;
+            for (int colIdx = memberStartIdx; colIdx < cells.size(); colIdx++) {
+                int memberIdx = colIdx - memberStartIdx;
                 if (memberIdx >= memberNames.size()) break;
 
                 Element cell = cells.get(colIdx);
@@ -149,6 +162,19 @@ public class DensukeScraper {
 
         log.info("Scraped {} schedule entries from densuke", data.getEntries().size());
         return data;
+    }
+
+    /**
+     * ヘッダー行セルから、最初の「memberdata アンカー（参加者名リンク）」を含むセルの index を返す。
+     * 見つからなければ -1。
+     */
+    static int findMemberStartIndex(Elements headerCells) {
+        for (int i = 0; i < headerCells.size(); i++) {
+            if (headerCells.get(i).selectFirst("a[href*=memberdata]") != null) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeScraperTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeScraperTest.java
@@ -4,6 +4,8 @@ import com.karuta.matchtracker.service.DensukeScraper.DensukeData;
 import com.karuta.matchtracker.service.DensukeScraper.ScheduleEntry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -101,5 +103,111 @@ class DensukeScraperTest {
         assertThat(DensukeScraper.stripLeadingEmoji("井桁\uFE0E堅章")).isEqualTo("井桁堅章");
         // 絵文字 + Variation Selector の組み合わせ
         assertThat(DensukeScraper.stripLeadingEmoji("🔰\uFE0E田中")).isEqualTo("田中");
+    }
+
+    @Test
+    @DisplayName("parse: 3択 (○/△/×) ページで全メンバー・出欠が正しく取得される")
+    void testParseThreeChoicePage() throws IOException {
+        String html = buildDensukeHtml(
+                // 3択 → 凡例は ○/△/× の3列
+                new String[]{"○", "△", "×"},
+                new String[]{"田中", "鈴木", "佐藤"},
+                new DataRow("3/1(日)会場A 1試合目", new String[]{"col3:○", "col2:△", "col1:×"}),
+                new DataRow("2試合目", new String[]{"col3:○", "col0:-", "col3:○"})
+        );
+        Document doc = Jsoup.parse(html);
+        DensukeData data = scraper.parse(doc, 2026);
+
+        assertThat(data.getMemberNames()).containsExactly("田中", "鈴木", "佐藤");
+        assertThat(data.getEntries()).hasSize(2);
+
+        ScheduleEntry entry1 = data.getEntries().get(0);
+        assertThat(entry1.getDate()).isEqualTo(LocalDate.of(2026, 3, 1));
+        assertThat(entry1.getMatchNumber()).isEqualTo(1);
+        assertThat(entry1.getParticipants()).containsExactly("田中");
+        assertThat(entry1.getMaybeParticipants()).containsExactly("鈴木");
+
+        ScheduleEntry entry2 = data.getEntries().get(1);
+        assertThat(entry2.getMatchNumber()).isEqualTo(2);
+        assertThat(entry2.getParticipants()).containsExactly("田中", "佐藤");
+        assertThat(entry2.getMaybeParticipants()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("parse: 2択 (○/×) ページでも先頭メンバーが読み飛ばされない (Issue #470)")
+    void testParseTwoChoicePageIncludesFirstMember() throws IOException {
+        // 再現: 伝助ページ自動作成で eventchoice=1 (2択) で作られたページは
+        // 凡例列が ○/× の2列しかなく、先頭メンバー列が index=3 になる。
+        // 旧コードは index=4 ハードコードで先頭メンバーを黙って読み飛ばしていた。
+        String html = buildDensukeHtml(
+                new String[]{"○", "×"},
+                new String[]{"遠藤明日真", "米山優花", "土居悠太"},
+                new DataRow("5/2(土) クラ館 1試合目", new String[]{"col3:○", "col3:○", "col1:×"})
+        );
+        Document doc = Jsoup.parse(html);
+        DensukeData data = scraper.parse(doc, 2026);
+
+        assertThat(data.getMemberNames())
+                .as("2択ページでも先頭メンバーがメンバーリストに含まれる")
+                .containsExactly("遠藤明日真", "米山優花", "土居悠太");
+
+        ScheduleEntry entry = data.getEntries().get(0);
+        assertThat(entry.getParticipants())
+                .as("先頭メンバーの ○ 出欠が取り込まれる")
+                .containsExactly("遠藤明日真", "米山優花");
+    }
+
+    @Test
+    @DisplayName("parse: memberdata アンカーが見つからないテーブルは例外を投げる")
+    void testParseRejectsTableWithoutMembers() {
+        String html = "<table class=\"listtbl\"><tr><td></td><td class=\"rline\">○</td></tr></table>";
+        Document doc = Jsoup.parse(html);
+        assertThatThrownBy(() -> scraper.parse(doc, 2026))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("メンバー列");
+    }
+
+    // ====================================================================
+    // ヘルパー: 伝助HTMLのモック構築
+    // ====================================================================
+
+    private record DataRow(String label, String[] memberCells) {}
+
+    /** 伝助ページ相当の最小HTMLを組み立てる（凡例列 + メンバー列 + 試合行） */
+    private static String buildDensukeHtml(String[] legendSymbols, String[] memberNames, DataRow... dataRows) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<table class=\"listtbl\">");
+        // header row
+        sb.append("<tr>");
+        sb.append("<td> </td>"); // 空の先頭セル
+        for (String sym : legendSymbols) {
+            sb.append("<td class=\"rline\"><div align=\"center\">").append(sym).append("</div></td>");
+        }
+        for (int i = 0; i < memberNames.length; i++) {
+            sb.append("<td nowrap><a href=\"javascript:memberdata(")
+                    .append(1000 + i).append(");\">")
+                    .append(memberNames[i]).append("</a></td>");
+        }
+        sb.append("</tr>");
+        // data rows
+        for (DataRow row : dataRows) {
+            sb.append("<tr>");
+            sb.append("<td nowrap>").append(row.label()).append("</td>");
+            // 凡例列相当のカウントセル（実際のHTMLと同様に legendSymbols と同じ数だけ並べる）
+            for (int i = 0; i < legendSymbols.length; i++) {
+                sb.append("<td class=\"rline\"><div align=\"center\"><div class=\"col2\">0</div></div></td>");
+            }
+            // member vote cells
+            for (String cell : row.memberCells()) {
+                int colon = cell.indexOf(':');
+                String cls = cell.substring(0, colon);
+                String text = cell.substring(colon + 1);
+                sb.append("<td><div align=\"center\"><div class=\"")
+                        .append(cls).append("\">").append(text).append("</div></div></td>");
+            }
+            sb.append("</tr>");
+        }
+        sb.append("</table>");
+        return sb.toString();
     }
 }


### PR DESCRIPTION
## Summary
- 伝助ページ自動作成 (eventchoice=1 / 2択 ○/×) で作られたページではヘッダーの凡例列が1つ減り、先頭メンバーが index=3 に来るため、列4ハードコードのスクレイパーが先頭メンバーを読み飛ばしていた
- `findMemberStartIndex()` で `memberdata` アンカーを持つ最初のセルを走査し、メンバー列の開始位置を動的検出するよう変更
- ついでに `scrape()` からパース部分を `parse(Document, year)` に切り出しユニットテスト可能化、2択/3択ページ双方の回帰テストを追加

## Bug
Fixes #470

## Test plan
- [x] `./gradlew test --tests "*Densuke*"` が pass する
- [ ] 本番で 5月伝助同期を再実行し、遠藤明日真の practice_participants レコードが作成されることを確認
- [ ] 従来の3択伝助ページ (4月など) の同期に回帰がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)