### PR TITLE
fix: 定員拡張後もキャンセル待ち残存時に新規参加できない問題を修正

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2503,11 +2503,12 @@ Entity Layer (JPA Entity)
 [バックエンド: AdjacentRoomService.expandVenue()]
 13. 会場を拡張後会場に変更、定員を更新
    ↓
-14. WAITLISTED→OFFERED（応答期限なし）、既存OFFEREDの応答期限をクリア
-   - WAITLISTED → OFFERED（waitlistNumber をクリア、offeredAt=現在時刻、offerDeadline=null）
-   - OFFERED → offerDeadline をnullにクリア（ステータス・offeredAt等はそのまま）
-   - dirty=true をセット（伝助同期対象にする）
-   - 対象が0件の場合は saveAll をスキップ
+14. WaitlistPromotionService.promoteWaitlistedAfterCapacityIncrease(sessionId) を呼び出し
+   - 既存 OFFERED の offerDeadline を null にクリア（拡張で参加確定）
+   - match_number ごとに `(capacity - WON - 既存OFFERED)` 名分だけ、WAITLISTED を waitlist_number 昇順に OFFERED 化（offeredAt=現在時刻、offerDeadline=null）
+   - 余り枠を超える WAITLISTED は据え置き（status・waitlist_number そのまま）
+   - 全件 dirty=true、最後に renumberRemainingWaitlist で 1..N に再採番
+   - 練習編集 (PracticeSessionService.updateSession) で capacity を増加させた場合も同じメソッドが呼ばれる
    ↓
 15. レスポンス: 200 OK + 更新後のセッション情報
 ```

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -509,8 +509,9 @@ SUPER_ADMIN のみ操作可能。
 3. **結果確定**: 定員超過の試合では当選（`WON`）・キャンセル待ち（`WAITLISTED`、番号付き）に振り分け
 4. **キャンセル→繰り上げ**: 当選者がキャンセル専用ページから理由付きでキャンセルするとキャンセル待ち1番に通知。応答期限内に承諾/辞退。PLAYERロールは過去の練習日のキャンセル不可（ADMIN+はデータ修正目的で可能）。**定員未達（キャンセル待ちなし）の場合は繰り上げ・管理者通知ともに送信しない**
 5. **キャンセル待ち辞退**: キャンセル待ち中のプレイヤーはセッション単位でキャンセル待ちを辞退可能（`WAITLISTED`→`WAITLIST_DECLINED`）。辞退時に後続のキャンセル待ち番号は自動繰り上げ。辞退後の復帰も可能（最後尾番号が付与される）
-6. **締切後の新規登録**: 抽選締切後かつ抽選実行済みの試合に新規参加登録する場合、定員超過なら`WAITLISTED`（最後尾）、空きがあれば即`WON`で登録
-7. **締切後の登録解除禁止**: 締切後は参加登録画面から既存登録のチェックを外すことができない（チェックボックスが disabled＋グレーアウト）。既存登録のキャンセルはキャンセル専用画面（`/practice/cancel`）から行う。未登録試合への追加登録は締切後でも可能
+6. **締切後の新規登録**: 抽選締切後かつ抽選実行済みの試合に新規参加登録する場合、`(WON + OFFERED) < capacity` かつ既存の `WAITLISTED` がなければ即 `WON` で登録、定員超過または `WAITLISTED` 残存時は `WAITLISTED`（最後尾）。`OFFERED`（応答待ち）も定員カウントに含めることで、待機中の枠を新規申込が横取りしないようにする
+7. **容量拡張時の昇格**: 会場拡張 (`POST /{id}/expand-venue`) や練習編集での `capacity` 増加時、その時点の `WAITLISTED` を `waitlist_number` 昇順に `OFFERED`（応答期限なし）へ昇格。新定員 `capacity - (WON + 既存OFFERED)` に収まらない超過分は `WAITLISTED` のまま据え置き。既存 `OFFERED` は応答期限を一律クリア
+8. **締切後の登録解除禁止**: 締切後は参加登録画面から既存登録のチェックを外すことができない（チェックボックスが disabled＋グレーアウト）。既存登録のキャンセルはキャンセル専用画面（`/practice/cancel`）から行う。未登録試合への追加登録は締切後でも可能
 
 #### 3.7.2 抽選アルゴリズムの特徴
 
@@ -1881,7 +1882,7 @@ UNIQUE制約: (player_id, organization_id)
 | POST | `/date/{date}/matches/{num}/participants/{pid}` | ADMIN+ | 参加者追加 |
 | DELETE | `/{sid}/matches/{num}/participants/{pid}` | ADMIN+ | 参加者削除 |
 | POST | `/{id}/confirm-reservation` | ADMIN+ | 隣室予約完了を記録（`reservation_confirmed_at` をセット） |
-| POST | `/{id}/expand-venue` | ADMIN+ | 会場を隣室と合わせた大部屋に拡張（予約確認済みが前提）。拡張時にWAITLISTED→OFFERED（応答期限なし）、既存OFFEREDの応答期限をクリア |
+| POST | `/{id}/expand-venue` | ADMIN+ | 会場を隣室と合わせた大部屋に拡張（予約確認済みが前提）。拡張時に WAITLISTED を waitlist_number 昇順で OFFERED（応答期限なし）に昇格。新定員に収まらない超過分は WAITLISTED のまま据え置き。既存 OFFERED の応答期限をクリア。練習編集 (`PUT /api/practice-sessions/{id}`) で capacity を増やした場合も同じ昇格処理を実行 |
 
 ### 7.7 伝助連携 (`/api/practice-sessions`)
 

--- a/karuta-tracker-ui/src/pages/practice/PracticeForm.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeForm.jsx
@@ -13,7 +13,8 @@ const PracticeEditForm = ({ id }) => {
     sessionDate: '',
     venueId: null,
     totalMatches: 10,
-    notes: ''
+    notes: '',
+    capacity: null
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -31,7 +32,8 @@ const PracticeEditForm = ({ id }) => {
           sessionDate: session.sessionDate,
           venueId: session.venueId || null,
           totalMatches: session.totalMatches,
-          notes: session.notes || ''
+          notes: session.notes || '',
+          capacity: session.capacity ?? null
         });
       } catch (err) {
         console.error('Error fetching data:', err);

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/AdjacentRoomService.java
@@ -2,13 +2,9 @@ package com.karuta.matchtracker.service;
 
 import com.karuta.matchtracker.config.AdjacentRoomConfig;
 import com.karuta.matchtracker.dto.AdjacentRoomStatusDto;
-import com.karuta.matchtracker.entity.ParticipantStatus;
-import com.karuta.matchtracker.entity.PracticeParticipant;
 import com.karuta.matchtracker.entity.PracticeSession;
-import com.karuta.matchtracker.entity.RoomAvailabilityCache;
 import com.karuta.matchtracker.entity.Venue;
 import com.karuta.matchtracker.exception.ResourceNotFoundException;
-import com.karuta.matchtracker.repository.PracticeParticipantRepository;
 import com.karuta.matchtracker.repository.PracticeSessionRepository;
 import com.karuta.matchtracker.repository.RoomAvailabilityCacheRepository;
 import com.karuta.matchtracker.repository.VenueRepository;
@@ -22,8 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.karuta.matchtracker.util.JstDateTimeUtil;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 隣室空き確認・会場拡張サービス
@@ -34,9 +28,9 @@ import java.util.List;
 public class AdjacentRoomService {
 
     private final RoomAvailabilityCacheRepository roomAvailabilityCacheRepository;
-    private final PracticeParticipantRepository practiceParticipantRepository;
     private final PracticeSessionRepository practiceSessionRepository;
     private final VenueRepository venueRepository;
+    private final WaitlistPromotionService waitlistPromotionService;
 
     private static final String TIME_SLOT_EVENING = "evening";
 
@@ -143,31 +137,7 @@ public class AdjacentRoomService {
         log.info("Expanded venue for session {}: venueId {} -> {}, capacity -> {}",
                 sessionId, currentVenueId, expandedVenueId, expandedVenue.getCapacity());
 
-        // キャンセル待ち→OFFERED（応答期限なし）、既存OFFERED→応答期限をクリア
-        LocalDateTime now = JstDateTimeUtil.now();
-        List<PracticeParticipant> waitlisted = practiceParticipantRepository
-                .findBySessionIdAndStatus(sessionId, ParticipantStatus.WAITLISTED);
-        List<PracticeParticipant> offered = practiceParticipantRepository
-                .findBySessionIdAndStatus(sessionId, ParticipantStatus.OFFERED);
-
-        for (PracticeParticipant p : waitlisted) {
-            p.setStatus(ParticipantStatus.OFFERED);
-            p.setWaitlistNumber(null);
-            p.setOfferedAt(now);
-            p.setOfferDeadline(null);
-            p.setDirty(true);
-        }
-        for (PracticeParticipant p : offered) {
-            p.setOfferDeadline(null);
-            p.setDirty(true);
-        }
-
-        List<PracticeParticipant> promoted = new java.util.ArrayList<>(waitlisted);
-        promoted.addAll(offered);
-        if (!promoted.isEmpty()) {
-            practiceParticipantRepository.saveAll(promoted);
-            log.info("Promoted {} participants (waitlisted={}, offered={}) to OFFERED for session {}",
-                    promoted.size(), waitlisted.size(), offered.size(), sessionId);
-        }
+        // キャンセル待ち→OFFERED（応答期限なし、定員までに制限）／既存OFFERED→応答期限クリア
+        waitlistPromotionService.promoteWaitlistedAfterCapacityIncrease(sessionId);
     }
 }

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeParticipantService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeParticipantService.java
@@ -383,9 +383,11 @@ public class PracticeParticipantService {
         if (session.getCapacity() == null) return true;
         long wonCount = practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(
                 session.getId(), matchNumber, ParticipantStatus.WON);
-        if (wonCount >= session.getCapacity()) return false;
-        return !practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(session.getId(), matchNumber, ParticipantStatus.WAITLISTED)
-            && !practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(session.getId(), matchNumber, ParticipantStatus.OFFERED);
+        long offeredCount = practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(
+                session.getId(), matchNumber, ParticipantStatus.OFFERED);
+        if (wonCount + offeredCount >= session.getCapacity()) return false;
+        return !practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(
+                session.getId(), matchNumber, ParticipantStatus.WAITLISTED);
     }
 
     @Transactional(readOnly = true)

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
@@ -489,13 +489,18 @@ public class PracticeSessionService {
 
     /**
      * capacity が拡張されたか（拡張時にキャンセル待ち昇格処理を呼ぶ判定）。
-     * - non-null → null（制限解除）：拡張扱い
-     * - non-null → non-null で増加：拡張扱い
-     * - それ以外（同値・縮小・null→non-null）：拡張ではない
+     * 「明示的な定員増加」が確認できる場合のみ true を返す（= 旧・新ともに非nullで増加した場合）。
+     *
+     * リクエストの capacity が null の場合は「未指定」とみなし拡張扱いしない。
+     * 編集フォームから capacity を送らない既存ケース（PracticeForm の通常編集）でも
+     * 意図せず昇格処理が走らないようにするため。
+     *
+     * 「制限解除（明示的に capacity を null にする）」を拡張扱いしたい場合は、
+     * 未指定と明示 null を区別できる DTO（PATCH 用 DTO、JsonNullable、capacityUnlimited フラグ等）を
+     * 導入してから判定する必要がある。
      */
     private boolean isCapacityExpanded(Integer oldCapacity, Integer newCapacity) {
-        if (oldCapacity == null) return false;
-        if (newCapacity == null) return true;
+        if (oldCapacity == null || newCapacity == null) return false;
         return newCapacity > oldCapacity;
     }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
@@ -418,11 +418,6 @@ public class PracticeSessionService {
 
         PracticeSession updated = practiceSessionRepository.save(session);
 
-        // 容量が拡張された場合は WAITLISTED を OFFERED に昇格（応答期限なし、定員までに制限）
-        if (isCapacityExpanded(oldCapacity, newCapacity)) {
-            waitlistPromotionService.promoteWaitlistedAfterCapacityIncrease(id);
-        }
-
         // 差分更新: 既存参加者のdirty値を保持しつつ、参加者の追加・削除を行う
         int totalMatches = request.getTotalMatches() != null ? request.getTotalMatches() : 7;
         List<PracticeParticipant> existingParticipants = practiceParticipantRepository.findBySessionId(id);
@@ -478,6 +473,13 @@ public class PracticeSessionService {
 
         if (!newParticipants.isEmpty()) {
             practiceParticipantRepository.saveAll(newParticipants);
+        }
+
+        // 容量が拡張された場合は WAITLISTED を OFFERED に昇格（応答期限なし、定員までに制限）
+        // 参加者の差分更新（キャンセル・削除・追加）の後に実行することで、
+        // 最終状態の WON / OFFERED 数を基準に昇格数が決まる。
+        if (isCapacityExpanded(oldCapacity, newCapacity)) {
+            waitlistPromotionService.promoteWaitlistedAfterCapacityIncrease(id);
         }
 
         log.info("Successfully updated practice session id: {}", id);

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeSessionService.java
@@ -58,6 +58,7 @@ public class PracticeSessionService {
     private final DensukeMemberMappingRepository densukeMemberMappingRepository;
     private final DensukeSyncService densukeSyncService;
     private final AdjacentRoomService adjacentRoomService;
+    private final WaitlistPromotionService waitlistPromotionService;
 
     /**
      * IDで練習日を取得
@@ -401,6 +402,10 @@ public class PracticeSessionService {
             }
         }
 
+        // 容量変更検知のため変更前 capacity を保持
+        Integer oldCapacity = session.getCapacity();
+        Integer newCapacity = request.getCapacity();
+
         // セッション情報を更新
         session.setSessionDate(request.getSessionDate());
         session.setTotalMatches(request.getTotalMatches());
@@ -408,10 +413,15 @@ public class PracticeSessionService {
         session.setNotes(request.getNotes());
         session.setStartTime(request.getStartTime());
         session.setEndTime(request.getEndTime());
-        session.setCapacity(request.getCapacity());
+        session.setCapacity(newCapacity);
         session.setUpdatedBy(currentUserId);
 
         PracticeSession updated = practiceSessionRepository.save(session);
+
+        // 容量が拡張された場合は WAITLISTED を OFFERED に昇格（応答期限なし、定員までに制限）
+        if (isCapacityExpanded(oldCapacity, newCapacity)) {
+            waitlistPromotionService.promoteWaitlistedAfterCapacityIncrease(id);
+        }
 
         // 差分更新: 既存参加者のdirty値を保持しつつ、参加者の追加・削除を行う
         int totalMatches = request.getTotalMatches() != null ? request.getTotalMatches() : 7;
@@ -473,6 +483,18 @@ public class PracticeSessionService {
         log.info("Successfully updated practice session id: {}", id);
         densukeSyncService.triggerWriteAsync();
         return enrichSessionWithParticipants(updated);
+    }
+
+    /**
+     * capacity が拡張されたか（拡張時にキャンセル待ち昇格処理を呼ぶ判定）。
+     * - non-null → null（制限解除）：拡張扱い
+     * - non-null → non-null で増加：拡張扱い
+     * - それ以外（同値・縮小・null→non-null）：拡張ではない
+     */
+    private boolean isCapacityExpanded(Integer oldCapacity, Integer newCapacity) {
+        if (oldCapacity == null) return false;
+        if (newCapacity == null) return true;
+        return newCapacity > oldCapacity;
     }
 
     /**

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
@@ -23,6 +23,7 @@ import com.karuta.matchtracker.dto.SameDayCancelContext;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * キャンセル・繰り上げサービス
@@ -1276,6 +1278,109 @@ public class WaitlistPromotionService {
         } catch (Exception e) {
             log.error("Failed to send batched waitlist change notifications: {}", e.getMessage(), e);
         }
+    }
+
+    /**
+     * 容量拡張に伴い、キャンセル待ちを応答期限なしの OFFERED に昇格する。
+     *
+     * 各試合について WON + 既存OFFERED が capacity に達するまで、waitlist_number 昇順で
+     * WAITLISTED を OFFERED（offer_deadline=null）に変更する。空き枠を超えた分の WAITLISTED は
+     * そのまま残す（waitlist_number も維持）。
+     * 既存OFFERED の応答期限は一律 null にクリアする（容量拡張で参加が確定したため）。
+     *
+     * @param sessionId 対象セッションID
+     */
+    @Transactional
+    public void promoteWaitlistedAfterCapacityIncrease(Long sessionId) {
+        PracticeSession session = practiceSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResourceNotFoundException("PracticeSession", sessionId));
+
+        LocalDateTime now = JstDateTimeUtil.now();
+
+        // 既存OFFERED は応答期限を一律クリア（拡張で参加確定）
+        List<PracticeParticipant> existingOffered = practiceParticipantRepository
+                .findBySessionIdAndStatus(sessionId, ParticipantStatus.OFFERED);
+        for (PracticeParticipant p : existingOffered) {
+            if (p.getOfferDeadline() != null) {
+                p.setOfferDeadline(null);
+                p.setDirty(true);
+            }
+        }
+        if (!existingOffered.isEmpty()) {
+            practiceParticipantRepository.saveAll(existingOffered);
+        }
+
+        Integer capacity = session.getCapacity();
+
+        // 容量制限なし／match_number 別の WAITLISTED を waitlist_number 昇順で処理
+        List<PracticeParticipant> waitlisted = practiceParticipantRepository
+                .findBySessionIdAndStatus(sessionId, ParticipantStatus.WAITLISTED);
+        if (waitlisted.isEmpty()) {
+            log.info("promoteWaitlistedAfterCapacityIncrease: session {} has no WAITLISTED to promote", sessionId);
+            return;
+        }
+
+        Map<Integer, List<PracticeParticipant>> waitlistedByMatch = waitlisted.stream()
+                .filter(p -> p.getMatchNumber() != null)
+                .collect(Collectors.groupingBy(PracticeParticipant::getMatchNumber));
+
+        int totalPromoted = 0;
+        int totalRemained = 0;
+        List<PracticeParticipant> toSave = new ArrayList<>();
+
+        for (Map.Entry<Integer, List<PracticeParticipant>> entry : waitlistedByMatch.entrySet()) {
+            Integer matchNumber = entry.getKey();
+            List<PracticeParticipant> matchWaitlisted = new ArrayList<>(entry.getValue());
+            matchWaitlisted.sort(Comparator.comparing(p ->
+                    p.getWaitlistNumber() == null ? Integer.MAX_VALUE : p.getWaitlistNumber()));
+
+            long wonCount = practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(
+                    sessionId, matchNumber, ParticipantStatus.WON);
+            long offeredCount = practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(
+                    sessionId, matchNumber, ParticipantStatus.OFFERED);
+
+            long availableSlots;
+            if (capacity == null) {
+                // 容量無制限：全員昇格
+                availableSlots = matchWaitlisted.size();
+            } else {
+                availableSlots = (long) capacity - wonCount - offeredCount;
+            }
+
+            if (availableSlots <= 0) {
+                log.info("Skip match {} in session {}: no available slot (won={}, offered={}, capacity={})",
+                        matchNumber, sessionId, wonCount, offeredCount, capacity);
+                totalRemained += matchWaitlisted.size();
+                continue;
+            }
+
+            int promoteCount = (int) Math.min(availableSlots, matchWaitlisted.size());
+            for (int i = 0; i < promoteCount; i++) {
+                PracticeParticipant p = matchWaitlisted.get(i);
+                p.setStatus(ParticipantStatus.OFFERED);
+                p.setOfferedAt(now);
+                p.setOfferDeadline(null);
+                p.setDirty(true);
+                toSave.add(p);
+            }
+            totalPromoted += promoteCount;
+            totalRemained += matchWaitlisted.size() - promoteCount;
+            log.info("Promoted {} WAITLISTED to OFFERED for session {} match {} (won={}, offered_before={}, capacity={}, remained={})",
+                    promoteCount, sessionId, matchNumber, wonCount, offeredCount, capacity,
+                    matchWaitlisted.size() - promoteCount);
+        }
+
+        if (!toSave.isEmpty()) {
+            practiceParticipantRepository.saveAll(toSave);
+        }
+
+        // 影響試合ごとに waitlist_number を 1..N で再採番
+        for (Integer matchNumber : waitlistedByMatch.keySet()) {
+            renumberRemainingWaitlist(sessionId, matchNumber);
+        }
+
+        log.info("promoteWaitlistedAfterCapacityIncrease completed for session {}: promoted={}, remainedAsWaitlisted={}",
+                sessionId, totalPromoted, totalRemained);
     }
 
     /**

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/AdjacentRoomServiceTest.java
@@ -1,13 +1,10 @@
 package com.karuta.matchtracker.service;
 
 import com.karuta.matchtracker.dto.AdjacentRoomStatusDto;
-import com.karuta.matchtracker.entity.ParticipantStatus;
-import com.karuta.matchtracker.entity.PracticeParticipant;
 import com.karuta.matchtracker.entity.PracticeSession;
 import com.karuta.matchtracker.entity.RoomAvailabilityCache;
 import com.karuta.matchtracker.entity.Venue;
 import com.karuta.matchtracker.exception.ResourceNotFoundException;
-import com.karuta.matchtracker.repository.PracticeParticipantRepository;
 import com.karuta.matchtracker.repository.PracticeSessionRepository;
 import com.karuta.matchtracker.repository.RoomAvailabilityCacheRepository;
 import com.karuta.matchtracker.repository.VenueRepository;
@@ -22,8 +19,6 @@ import org.springframework.dao.DataAccessResourceFailureException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,11 +31,11 @@ class AdjacentRoomServiceTest {
     @Mock
     private RoomAvailabilityCacheRepository roomAvailabilityCacheRepository;
     @Mock
-    private PracticeParticipantRepository practiceParticipantRepository;
-    @Mock
     private PracticeSessionRepository practiceSessionRepository;
     @Mock
     private VenueRepository venueRepository;
+    @Mock
+    private WaitlistPromotionService waitlistPromotionService;
 
     @InjectMocks
     private AdjacentRoomService adjacentRoomService;
@@ -141,12 +136,12 @@ class AdjacentRoomServiceTest {
     }
 
     @Test
-    @DisplayName("会場拡張 - 正常系（予約確認済み）")
+    @DisplayName("会場拡張 - 正常系（予約確認済み・WaitlistPromotionServiceに昇格処理を委譲）")
     void expandVenue_success() {
         LocalDate date = LocalDate.of(2026, 4, 12);
         PracticeSession session = PracticeSession.builder()
                 .id(1L).venueId(3L).capacity(14).sessionDate(date)
-                .reservationConfirmedAt(java.time.LocalDateTime.of(2026, 4, 12, 10, 0)).build();
+                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
         Venue expandedVenue = Venue.builder().id(7L).name("すずらん・はまなす").capacity(24).build();
         RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
                 .roomName("はまなす").targetDate(date).timeSlot("evening").status("○").build();
@@ -156,10 +151,6 @@ class AdjacentRoomServiceTest {
                 .thenReturn(Optional.of(cache));
         when(venueRepository.findById(7L)).thenReturn(Optional.of(expandedVenue));
         when(practiceSessionRepository.save(any())).thenReturn(session);
-        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.WAITLISTED))
-                .thenReturn(Collections.emptyList());
-        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.OFFERED))
-                .thenReturn(Collections.emptyList());
 
         adjacentRoomService.expandVenue(1L, 100L);
 
@@ -168,111 +159,7 @@ class AdjacentRoomServiceTest {
         assertEquals(100L, session.getUpdatedBy());
         assertNull(session.getReservationConfirmedAt()); // 拡張後にクリアされる
         verify(practiceSessionRepository).save(session);
-    }
-
-    @Test
-    @DisplayName("会場拡張 - WAITLISTEDがOFFEREDに繰り上げられる（応答期限なし）")
-    void expandVenue_promotesWaitlisted() {
-        LocalDate date = LocalDate.of(2026, 4, 12);
-        PracticeSession session = PracticeSession.builder()
-                .id(1L).venueId(3L).capacity(14).sessionDate(date)
-                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
-        Venue expandedVenue = Venue.builder().id(7L).name("すずらん・はまなす").capacity(24).build();
-        RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
-                .roomName("はまなす").targetDate(date).timeSlot("evening").status("○").build();
-
-        PracticeParticipant w1 = PracticeParticipant.builder()
-                .id(10L).sessionId(1L).playerId(201L)
-                .status(ParticipantStatus.WAITLISTED).waitlistNumber(1).build();
-        PracticeParticipant w2 = PracticeParticipant.builder()
-                .id(11L).sessionId(1L).playerId(202L)
-                .status(ParticipantStatus.WAITLISTED).waitlistNumber(2).build();
-
-        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
-        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))
-                .thenReturn(Optional.of(cache));
-        when(venueRepository.findById(7L)).thenReturn(Optional.of(expandedVenue));
-        when(practiceSessionRepository.save(any())).thenReturn(session);
-        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.WAITLISTED))
-                .thenReturn(List.of(w1, w2));
-        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.OFFERED))
-                .thenReturn(Collections.emptyList());
-
-        adjacentRoomService.expandVenue(1L, 100L);
-
-        assertEquals(ParticipantStatus.OFFERED, w1.getStatus());
-        assertNull(w1.getWaitlistNumber());
-        assertNotNull(w1.getOfferedAt());
-        assertNull(w1.getOfferDeadline());
-        assertTrue(w1.isDirty());
-        assertEquals(ParticipantStatus.OFFERED, w2.getStatus());
-        assertNull(w2.getWaitlistNumber());
-        assertNotNull(w2.getOfferedAt());
-        assertNull(w2.getOfferDeadline());
-        verify(practiceParticipantRepository).saveAll(anyList());
-    }
-
-    @Test
-    @DisplayName("会場拡張 - OFFEREDの応答期限がクリアされる")
-    void expandVenue_promotesOffered() {
-        LocalDate date = LocalDate.of(2026, 4, 12);
-        PracticeSession session = PracticeSession.builder()
-                .id(1L).venueId(3L).capacity(14).sessionDate(date)
-                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
-        Venue expandedVenue = Venue.builder().id(7L).name("すずらん・はまなす").capacity(24).build();
-        RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
-                .roomName("はまなす").targetDate(date).timeSlot("evening").status("○").build();
-
-        PracticeParticipant offered = PracticeParticipant.builder()
-                .id(12L).sessionId(1L).playerId(203L)
-                .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                .offeredAt(LocalDateTime.of(2026, 4, 11, 12, 0))
-                .offerDeadline(LocalDateTime.of(2026, 4, 12, 12, 0))
-                .build();
-
-        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
-        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))
-                .thenReturn(Optional.of(cache));
-        when(venueRepository.findById(7L)).thenReturn(Optional.of(expandedVenue));
-        when(practiceSessionRepository.save(any())).thenReturn(session);
-        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.WAITLISTED))
-                .thenReturn(Collections.emptyList());
-        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.OFFERED))
-                .thenReturn(List.of(offered));
-
-        adjacentRoomService.expandVenue(1L, 100L);
-
-        assertEquals(ParticipantStatus.OFFERED, offered.getStatus());
-        assertNotNull(offered.getOfferedAt()); // 元のofferedAtは維持される
-        assertNull(offered.getOfferDeadline());
-        assertTrue(offered.isDirty());
-        verify(practiceParticipantRepository).saveAll(anyList());
-    }
-
-    @Test
-    @DisplayName("会場拡張 - 昇格対象0件時はsaveAllしない")
-    void expandVenue_noPromotionTarget() {
-        LocalDate date = LocalDate.of(2026, 4, 12);
-        PracticeSession session = PracticeSession.builder()
-                .id(1L).venueId(3L).capacity(14).sessionDate(date)
-                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
-        Venue expandedVenue = Venue.builder().id(7L).name("すずらん・はまなす").capacity(24).build();
-        RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
-                .roomName("はまなす").targetDate(date).timeSlot("evening").status("○").build();
-
-        when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
-        when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))
-                .thenReturn(Optional.of(cache));
-        when(venueRepository.findById(7L)).thenReturn(Optional.of(expandedVenue));
-        when(practiceSessionRepository.save(any())).thenReturn(session);
-        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.WAITLISTED))
-                .thenReturn(Collections.emptyList());
-        when(practiceParticipantRepository.findBySessionIdAndStatus(1L, ParticipantStatus.OFFERED))
-                .thenReturn(Collections.emptyList());
-
-        adjacentRoomService.expandVenue(1L, 100L);
-
-        verify(practiceParticipantRepository, never()).saveAll(anyList());
+        verify(waitlistPromotionService).promoteWaitlistedAfterCapacityIncrease(1L);
     }
 
     @Test
@@ -288,6 +175,7 @@ class AdjacentRoomServiceTest {
                 () -> adjacentRoomService.expandVenue(1L, 100L));
         assertEquals("隣室の予約が確認されていません。先に予約を完了してください", ex.getMessage());
         verify(practiceSessionRepository, never()).save(any());
+        verify(waitlistPromotionService, never()).promoteWaitlistedAfterCapacityIncrease(anyLong());
     }
 
     @Test
@@ -298,6 +186,7 @@ class AdjacentRoomServiceTest {
         when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
 
         assertThrows(IllegalStateException.class, () -> adjacentRoomService.expandVenue(1L, 100L));
+        verify(waitlistPromotionService, never()).promoteWaitlistedAfterCapacityIncrease(anyLong());
     }
 
     @Test
@@ -306,6 +195,7 @@ class AdjacentRoomServiceTest {
         when(practiceSessionRepository.findById(999L)).thenReturn(Optional.empty());
 
         assertThrows(ResourceNotFoundException.class, () -> adjacentRoomService.expandVenue(999L, 100L));
+        verify(waitlistPromotionService, never()).promoteWaitlistedAfterCapacityIncrease(anyLong());
     }
 
     @Test
@@ -314,7 +204,7 @@ class AdjacentRoomServiceTest {
         LocalDate date = LocalDate.of(2026, 4, 12);
         PracticeSession session = PracticeSession.builder()
                 .id(1L).venueId(3L).capacity(14).sessionDate(date)
-                .reservationConfirmedAt(java.time.LocalDateTime.of(2026, 4, 12, 10, 0)).build();
+                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
         RoomAvailabilityCache cache = RoomAvailabilityCache.builder()
                 .roomName("はまなす").targetDate(date).timeSlot("evening").status("×").build();
 
@@ -326,6 +216,7 @@ class AdjacentRoomServiceTest {
                 () -> adjacentRoomService.expandVenue(1L, 100L));
         assertEquals("隣室が空いていないため、会場を拡張できません", ex.getMessage());
         verify(practiceSessionRepository, never()).save(any());
+        verify(waitlistPromotionService, never()).promoteWaitlistedAfterCapacityIncrease(anyLong());
     }
 
     @Test
@@ -334,7 +225,7 @@ class AdjacentRoomServiceTest {
         LocalDate date = LocalDate.of(2026, 4, 12);
         PracticeSession session = PracticeSession.builder()
                 .id(1L).venueId(3L).capacity(14).sessionDate(date)
-                .reservationConfirmedAt(java.time.LocalDateTime.of(2026, 4, 12, 10, 0)).build();
+                .reservationConfirmedAt(LocalDateTime.of(2026, 4, 12, 10, 0)).build();
 
         when(practiceSessionRepository.findById(1L)).thenReturn(Optional.of(session));
         when(roomAvailabilityCacheRepository.findByRoomNameAndTargetDateAndTimeSlot("はまなす", date, "evening"))
@@ -344,5 +235,6 @@ class AdjacentRoomServiceTest {
                 () -> adjacentRoomService.expandVenue(1L, 100L));
         assertEquals("隣室が空いていないため、会場を拡張できません", ex.getMessage());
         verify(practiceSessionRepository, never()).save(any());
+        verify(waitlistPromotionService, never()).promoteWaitlistedAfterCapacityIncrease(anyLong());
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeParticipantServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeParticipantServiceTest.java
@@ -113,9 +113,9 @@ class PracticeParticipantServiceTest {
                 2025, 4, LotteryExecution.ExecutionStatus.SUCCESS)).thenReturn(true);
         when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
                 .thenReturn(2L);
+        when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.OFFERED))
+                .thenReturn(0L);
         when(practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WAITLISTED))
-                .thenReturn(false);
-        when(practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.OFFERED))
                 .thenReturn(false);
 
         PracticeParticipationRequest request = new PracticeParticipationRequest();
@@ -147,9 +147,9 @@ class PracticeParticipantServiceTest {
                 .thenReturn(false);
         when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
                 .thenReturn(2L);
+        when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.OFFERED))
+                .thenReturn(0L);
         when(practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WAITLISTED))
-                .thenReturn(false);
-        when(practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.OFFERED))
                 .thenReturn(false);
 
         PracticeParticipant cancelled = PracticeParticipant.builder()
@@ -389,9 +389,9 @@ class PracticeParticipantServiceTest {
         when(lotteryDeadlineHelper.getDeadlineType(ORG_ID)).thenReturn(DeadlineType.SAME_DAY);
         when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
                 .thenReturn(0L);
+        when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.OFFERED))
+                .thenReturn(0L);
         when(practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WAITLISTED))
-                .thenReturn(false);
-        when(practiceParticipantRepository.existsBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.OFFERED))
                 .thenReturn(false);
 
         PracticeParticipationRequest request = new PracticeParticipationRequest();

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
@@ -367,6 +367,45 @@ class PracticeSessionServiceTest {
     }
 
     @Test
+    @DisplayName("updateSession: capacity 未指定（null）の通常編集ではキャンセル待ち昇格が実行されない")
+    void testUpdateSession_capacityNotSpecified_doesNotPromoteWaitlisted() {
+        // Given: capacity=10 の既存セッション、編集フォームから capacity 未指定で他項目だけ更新するケース
+        // PracticeForm の通常編集（日付・会場・メモ等の更新）では request.capacity が null になるため、
+        // 「制限解除」と誤判定して昇格処理が走らないことを保証する。
+        Long sessionId = 1L;
+        PracticeSession session = PracticeSession.builder()
+                .id(sessionId).sessionDate(today).totalMatches(1).capacity(10)
+                .organizationId(1L).build();
+
+        PracticeParticipant pp1 = PracticeParticipant.builder()
+                .id(100L).sessionId(sessionId).playerId(1L).matchNumber(1)
+                .status(ParticipantStatus.WON).dirty(false).build();
+        List<PracticeParticipant> existingParticipants = new ArrayList<>(List.of(pp1));
+
+        Player p1 = new Player(); p1.setId(1L); p1.setName("選手1");
+
+        when(practiceSessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(practiceParticipantRepository.findBySessionId(sessionId)).thenReturn(existingParticipants);
+        when(playerRepository.findAllById(List.of(1L))).thenReturn(List.of(p1));
+        when(practiceSessionRepository.save(any(PracticeSession.class))).thenReturn(session);
+        when(matchRepository.countByMatchDate(today)).thenReturn(0L);
+
+        // capacity を含めずメモだけ更新するリクエスト（通常の編集フロー）
+        PracticeSessionUpdateRequest request = PracticeSessionUpdateRequest.builder()
+                .sessionDate(today)
+                .totalMatches(1)
+                .notes("メモを更新")
+                .participantIds(List.of(1L))
+                .build();
+
+        // When
+        practiceSessionService.updateSession(sessionId, request, 1L);
+
+        // Then: capacity 未指定では昇格処理が呼ばれない
+        verify(waitlistPromotionService, never()).promoteWaitlistedAfterCapacityIncrease(any());
+    }
+
+    @Test
     @DisplayName("updateSession: 定員拡張+参加者削除時、削除反映後にキャンセル待ち昇格が実行される")
     void testUpdateSession_capacityExpandWithParticipantRemoval_promotionRunsAfterCancellation() {
         // Given: capacity=10 / totalMatches=1 / 既存 WON 3名

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
@@ -82,6 +82,9 @@ class PracticeSessionServiceTest {
     @Mock
     private AdjacentRoomService adjacentRoomService;
 
+    @Mock
+    private WaitlistPromotionService waitlistPromotionService;
+
     @InjectMocks
     private PracticeSessionService practiceSessionService;
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
@@ -321,6 +321,98 @@ class PracticeSessionServiceTest {
     }
 
     @Test
+    @DisplayName("updateSession: 定員拡張+参加者追加時、新規参加者の保存後にキャンセル待ち昇格が実行される")
+    void testUpdateSession_capacityExpandWithNewParticipants_promotionRunsAfterSaveAll() {
+        // Given: capacity=10 / totalMatches=1 / 既存 WON 2名
+        Long sessionId = 1L;
+        PracticeSession session = PracticeSession.builder()
+                .id(sessionId).sessionDate(today).totalMatches(1).capacity(10)
+                .organizationId(1L).build();
+
+        PracticeParticipant pp1 = PracticeParticipant.builder()
+                .id(100L).sessionId(sessionId).playerId(1L).matchNumber(1)
+                .status(ParticipantStatus.WON).dirty(false).build();
+        PracticeParticipant pp2 = PracticeParticipant.builder()
+                .id(101L).sessionId(sessionId).playerId(2L).matchNumber(1)
+                .status(ParticipantStatus.WON).dirty(false).build();
+        List<PracticeParticipant> existingParticipants = new ArrayList<>(List.of(pp1, pp2));
+
+        Player p1 = new Player(); p1.setId(1L); p1.setName("選手1");
+        Player p2 = new Player(); p2.setId(2L); p2.setName("選手2");
+        Player p3 = new Player(); p3.setId(3L); p3.setName("選手3");
+
+        when(practiceSessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(practiceParticipantRepository.findBySessionId(sessionId)).thenReturn(existingParticipants);
+        when(playerRepository.findAllById(List.of(1L, 2L, 3L))).thenReturn(List.of(p1, p2, p3));
+        when(practiceSessionRepository.save(any(PracticeSession.class))).thenReturn(session);
+        when(practiceParticipantRepository.saveAll(anyList())).thenReturn(List.of());
+        when(matchRepository.countByMatchDate(today)).thenReturn(0L);
+
+        // capacity 10 → 12 + player3 を追加
+        PracticeSessionUpdateRequest request = PracticeSessionUpdateRequest.builder()
+                .sessionDate(today)
+                .totalMatches(1)
+                .capacity(12)
+                .participantIds(List.of(1L, 2L, 3L))
+                .build();
+
+        // When
+        practiceSessionService.updateSession(sessionId, request, 1L);
+
+        // Then: 新規参加者の saveAll が先 → 昇格処理が後の順で呼ばれる
+        // 先に昇格すると、新規参加者の WON カウント前に昇格数が決まり定員超過の原因となる
+        var ordered = inOrder(practiceParticipantRepository, waitlistPromotionService);
+        ordered.verify(practiceParticipantRepository).saveAll(anyList());
+        ordered.verify(waitlistPromotionService).promoteWaitlistedAfterCapacityIncrease(sessionId);
+    }
+
+    @Test
+    @DisplayName("updateSession: 定員拡張+参加者削除時、削除反映後にキャンセル待ち昇格が実行される")
+    void testUpdateSession_capacityExpandWithParticipantRemoval_promotionRunsAfterCancellation() {
+        // Given: capacity=10 / totalMatches=1 / 既存 WON 3名
+        Long sessionId = 1L;
+        PracticeSession session = PracticeSession.builder()
+                .id(sessionId).sessionDate(today).totalMatches(1).capacity(10)
+                .organizationId(1L).build();
+
+        PracticeParticipant pp1 = PracticeParticipant.builder()
+                .id(100L).sessionId(sessionId).playerId(1L).matchNumber(1)
+                .status(ParticipantStatus.WON).dirty(false).build();
+        PracticeParticipant pp2 = PracticeParticipant.builder()
+                .id(101L).sessionId(sessionId).playerId(2L).matchNumber(1)
+                .status(ParticipantStatus.WON).dirty(false).build();
+        PracticeParticipant pp3 = PracticeParticipant.builder()
+                .id(102L).sessionId(sessionId).playerId(3L).matchNumber(1)
+                .status(ParticipantStatus.WON).dirty(false).build();
+        List<PracticeParticipant> existingParticipants = new ArrayList<>(List.of(pp1, pp2, pp3));
+
+        Player p1 = new Player(); p1.setId(1L); p1.setName("選手1");
+        Player p2 = new Player(); p2.setId(2L); p2.setName("選手2");
+
+        when(practiceSessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(practiceParticipantRepository.findBySessionId(sessionId)).thenReturn(existingParticipants);
+        when(playerRepository.findAllById(List.of(1L, 2L))).thenReturn(List.of(p1, p2));
+        when(practiceSessionRepository.save(any(PracticeSession.class))).thenReturn(session);
+        when(matchRepository.countByMatchDate(today)).thenReturn(0L);
+
+        // capacity 10 → 12 + player3 を削除
+        PracticeSessionUpdateRequest request = PracticeSessionUpdateRequest.builder()
+                .sessionDate(today)
+                .totalMatches(1)
+                .capacity(12)
+                .participantIds(List.of(1L, 2L))
+                .build();
+
+        // When
+        practiceSessionService.updateSession(sessionId, request, 1L);
+
+        // Then: 削除対象の player3 が CANCELLED に変更された後で昇格処理が呼ばれる
+        // （昇格処理が先だと、削除分の空き枠が昇格対象に含まれない）
+        assertThat(pp3.getStatus()).isEqualTo(ParticipantStatus.CANCELLED);
+        verify(waitlistPromotionService).promoteWaitlistedAfterCapacityIncrease(sessionId);
+    }
+
+    @Test
     @DisplayName("存在しない練習日を削除するとResourceNotFoundExceptionが発生")
     void testDeleteSessionNotFound() {
         // Given

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceAdditionalTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceAdditionalTest.java
@@ -184,4 +184,132 @@ class WaitlistPromotionServiceAdditionalTest {
         // OFFERED#1と重複せず#2が割り当てられる
         assertThat(declined.getWaitlistNumber()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("promoteWaitlistedAfterCapacityIncrease: 定員内なら全WAITLISTED→OFFERED（応答期限なし）")
+    void promoteOnExpand_allWithinCapacity() {
+        PracticeSession session = PracticeSession.builder()
+                .id(100L).sessionDate(LocalDate.of(2026, 5, 1)).capacity(24).build();
+        PracticeParticipant w1 = PracticeParticipant.builder()
+                .id(10L).sessionId(100L).playerId(201L).matchNumber(1)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(1).build();
+        PracticeParticipant w2 = PracticeParticipant.builder()
+                .id(11L).sessionId(100L).playerId(202L).matchNumber(1)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(2).build();
+
+        when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+        when(practiceParticipantRepository.findBySessionIdAndStatus(100L, ParticipantStatus.OFFERED))
+                .thenReturn(List.of());
+        when(practiceParticipantRepository.findBySessionIdAndStatus(100L, ParticipantStatus.WAITLISTED))
+                .thenReturn(List.of(w1, w2));
+        when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                .thenReturn(14L);
+        when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.OFFERED))
+                .thenReturn(0L);
+        when(practiceParticipantRepository
+                .findBySessionIdAndMatchNumberAndStatusInOrderByWaitlistNumberAsc(
+                        eq(100L), eq(1), eq(List.of(ParticipantStatus.WAITLISTED, ParticipantStatus.OFFERED))))
+                .thenReturn(List.of(w1, w2));
+
+        service.promoteWaitlistedAfterCapacityIncrease(100L);
+
+        assertThat(w1.getStatus()).isEqualTo(ParticipantStatus.OFFERED);
+        assertThat(w1.getOfferDeadline()).isNull();
+        assertThat(w1.getOfferedAt()).isNotNull();
+        assertThat(w1.isDirty()).isTrue();
+        assertThat(w2.getStatus()).isEqualTo(ParticipantStatus.OFFERED);
+        assertThat(w2.getOfferDeadline()).isNull();
+        assertThat(w2.getOfferedAt()).isNotNull();
+        assertThat(w2.isDirty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("promoteWaitlistedAfterCapacityIncrease: 定員超過分はWAITLISTEDのまま（waitlist_number順で昇格）")
+    void promoteOnExpand_partialPromotion() {
+        // capacity=20, WON=18 → 残2枠。WAITLISTED 4人のうち #1,#2 のみ OFFERED、#3,#4 は据え置き
+        PracticeSession session = PracticeSession.builder()
+                .id(100L).sessionDate(LocalDate.of(2026, 5, 1)).capacity(20).build();
+        PracticeParticipant w1 = PracticeParticipant.builder()
+                .id(10L).sessionId(100L).playerId(201L).matchNumber(1)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(1).build();
+        PracticeParticipant w2 = PracticeParticipant.builder()
+                .id(11L).sessionId(100L).playerId(202L).matchNumber(1)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(2).build();
+        PracticeParticipant w3 = PracticeParticipant.builder()
+                .id(12L).sessionId(100L).playerId(203L).matchNumber(1)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(3).build();
+        PracticeParticipant w4 = PracticeParticipant.builder()
+                .id(13L).sessionId(100L).playerId(204L).matchNumber(1)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(4).build();
+
+        when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+        when(practiceParticipantRepository.findBySessionIdAndStatus(100L, ParticipantStatus.OFFERED))
+                .thenReturn(List.of());
+        // 入力順をシャッフルしても waitlist_number 順で処理されることを確認
+        when(practiceParticipantRepository.findBySessionIdAndStatus(100L, ParticipantStatus.WAITLISTED))
+                .thenReturn(List.of(w3, w1, w4, w2));
+        when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.WON))
+                .thenReturn(18L);
+        when(practiceParticipantRepository.countBySessionIdAndMatchNumberAndStatus(100L, 1, ParticipantStatus.OFFERED))
+                .thenReturn(0L);
+        // renumberRemainingWaitlist 用：OFFERED→#1,#2、残WAITLISTED→#3,#4 の並び
+        when(practiceParticipantRepository
+                .findBySessionIdAndMatchNumberAndStatusInOrderByWaitlistNumberAsc(
+                        eq(100L), eq(1), eq(List.of(ParticipantStatus.WAITLISTED, ParticipantStatus.OFFERED))))
+                .thenReturn(List.of(w1, w2, w3, w4));
+
+        service.promoteWaitlistedAfterCapacityIncrease(100L);
+
+        assertThat(w1.getStatus()).isEqualTo(ParticipantStatus.OFFERED);
+        assertThat(w2.getStatus()).isEqualTo(ParticipantStatus.OFFERED);
+        assertThat(w3.getStatus()).isEqualTo(ParticipantStatus.WAITLISTED);
+        assertThat(w4.getStatus()).isEqualTo(ParticipantStatus.WAITLISTED);
+        // waitlist_number は再採番で 1..N に保たれる
+        assertThat(w1.getWaitlistNumber()).isEqualTo(1);
+        assertThat(w2.getWaitlistNumber()).isEqualTo(2);
+        assertThat(w3.getWaitlistNumber()).isEqualTo(3);
+        assertThat(w4.getWaitlistNumber()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("promoteWaitlistedAfterCapacityIncrease: 既存OFFEREDの offer_deadline をクリア")
+    void promoteOnExpand_clearsExistingOfferDeadline() {
+        PracticeSession session = PracticeSession.builder()
+                .id(100L).sessionDate(LocalDate.of(2026, 5, 1)).capacity(24).build();
+        PracticeParticipant existingOffered = PracticeParticipant.builder()
+                .id(20L).sessionId(100L).playerId(301L).matchNumber(1)
+                .status(ParticipantStatus.OFFERED).waitlistNumber(1)
+                .offerDeadline(java.time.LocalDateTime.of(2026, 5, 1, 12, 0))
+                .build();
+
+        when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+        when(practiceParticipantRepository.findBySessionIdAndStatus(100L, ParticipantStatus.OFFERED))
+                .thenReturn(List.of(existingOffered));
+        when(practiceParticipantRepository.findBySessionIdAndStatus(100L, ParticipantStatus.WAITLISTED))
+                .thenReturn(List.of());
+
+        service.promoteWaitlistedAfterCapacityIncrease(100L);
+
+        assertThat(existingOffered.getOfferDeadline()).isNull();
+        assertThat(existingOffered.isDirty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("promoteWaitlistedAfterCapacityIncrease: WAITLISTED 0件なら何もしない")
+    void promoteOnExpand_noWaitlistedNoop() {
+        PracticeSession session = PracticeSession.builder()
+                .id(100L).sessionDate(LocalDate.of(2026, 5, 1)).capacity(24).build();
+
+        when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
+        when(practiceParticipantRepository.findBySessionIdAndStatus(100L, ParticipantStatus.OFFERED))
+                .thenReturn(List.of());
+        when(practiceParticipantRepository.findBySessionIdAndStatus(100L, ParticipantStatus.WAITLISTED))
+                .thenReturn(List.of());
+
+        service.promoteWaitlistedAfterCapacityIncrease(100L);
+
+        // count 系は呼ばれない
+        verify(practiceParticipantRepository, never())
+                .countBySessionIdAndMatchNumberAndStatus(eq(100L), org.mockito.ArgumentMatchers.anyInt(), eq(ParticipantStatus.WON));
+    }
 }


### PR DESCRIPTION
## Summary
- `PracticeParticipantService.isFreeRegistrationOpen` を修正し、`(WON + OFFERED) < capacity` かつ `WAITLISTED` 残存なしなら新規 `WON` 登録を許可（OFFEREDも定員カウントに含める案A）
- `WaitlistPromotionService.promoteWaitlistedAfterCapacityIncrease(sessionId)` を新設し、容量拡張時に WAITLISTED を `waitlist_number` 昇順で OFFERED（応答期限なし）に昇格、新定員に収まらない超過分は WAITLISTED のまま据え置き
- `AdjacentRoomService.expandVenue` の WAITLISTED→OFFERED 変換を新ヘルパーに置き換え（一律変換だった旧挙動を改善）
- `PracticeSessionService.updateSession` で `capacity` が拡張された場合にも同じ昇格処理を呼ぶ
- 関連テスト（AdjacentRoomServiceTest / WaitlistPromotionServiceAdditionalTest / PracticeParticipantServiceTest / PracticeSessionServiceTest）と SPECIFICATION.md / DESIGN.md を更新

## Bug
Fixes #552

## Test plan
- [ ] 4/25練習（session_id=936）で「練習編集」から定員を一旦下げ→上げて、WAITLISTED が waitlist_number 順に OFFERED 化することを確認
- [ ] 同セッションに新規参加者を追加し、`(WON+OFFERED) < capacity` であれば WON 登録されることを確認
- [ ] 隣室予約フローで会場拡張ボタンから expandVenue を呼び、同等の昇格が発生することを確認
- [ ] capacity を縮小・同値に変更しても昇格処理が走らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)