### PR TITLE
fix: system_settings の古い単独 unique 制約を削除（保存失敗の解消）

### DIFF
--- a/database/drop_legacy_system_settings_unique.sql
+++ b/database/drop_legacy_system_settings_unique.sql
@@ -1,0 +1,21 @@
+-- ============================================
+-- system_settings の不要な unique 制約を削除
+-- 関連Issue: #557
+-- ============================================
+--
+-- 経緯:
+--   - 初期版で `setting_key VARCHAR(100) NOT NULL UNIQUE` で作成した単独 unique 制約が
+--     Hibernate 自動生成名 `uknm18l4pyovtvd8y3b3x0l2y64` で本番DBに残存していた。
+--   - `migration_organization.sql` で `system_settings_setting_key_key` /
+--     `uk_system_settings_setting_key` の名前で DROP を試みたが実際の名前と一致せず、
+--     `(setting_key, organization_id)` 複合 unique を追加した結果、単独 unique も生き残った。
+--   - これにより別団体で同じ setting_key を保存しようとすると重複違反になる。
+--
+-- また、複合 unique も `uk_system_settings_key_org` と Hibernate 自動生成名
+-- `uk3uukkredspdgpq65rggt9l5m4` の2つに重複しているため自動生成名側を削除する。
+
+ALTER TABLE system_settings
+  DROP CONSTRAINT IF EXISTS uknm18l4pyovtvd8y3b3x0l2y64;
+
+ALTER TABLE system_settings
+  DROP CONSTRAINT IF EXISTS uk3uukkredspdgpq65rggt9l5m4;

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -314,10 +314,13 @@ Entity Layer (JPA Entity)
 | カラム名 | 型 | 制約 | 説明 |
 |---------|-----|------|------|
 | id | BIGINT | PK, AUTO_INCREMENT | 設定ID |
-| setting_key | VARCHAR(100) | NOT NULL, UNIQUE | 設定キー |
+| setting_key | VARCHAR(100) | NOT NULL | 設定キー |
 | setting_value | VARCHAR(255) | NOT NULL | 設定値 |
+| organization_id | BIGINT | NOT NULL, FK | 団体ID |
 | updated_at | DATETIME | NOT NULL | 更新日時 |
 | updated_by | BIGINT | | 更新者ID |
+
+一意制約: `(setting_key, organization_id)`
 
 **初期データ**:
 - `lottery_deadline_days_before` = `0`（締切日数：月初から何日前。0=前月末日の0時）

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1527,10 +1527,13 @@ venues ──< venue_match_schedules (venueId)
 | カラム | 型 | 制約 | 説明 |
 |---|---|---|---|
 | id | BIGINT | PK, AUTO | — |
-| setting_key | VARCHAR(100) | NOT NULL, UNIQUE | 設定キー |
+| setting_key | VARCHAR(100) | NOT NULL | 設定キー |
 | setting_value | VARCHAR(255) | NOT NULL | 設定値 |
+| organization_id | BIGINT | NOT NULL, FK | 団体ID |
 | updated_at | TIMESTAMP | NOT NULL | — |
 | updated_by | BIGINT | — | 更新者ID |
+
+一意制約: `(setting_key, organization_id)`
 
 初期データ: `lottery_deadline_days_before` = `0`
 


### PR DESCRIPTION
## Summary
- `system_settings` に残存していた `setting_key` 単独 unique 制約 (`uknm18l4pyovtvd8y3b3x0l2y64`) を削除
- 重複していた複合 unique 制約 (`uk3uukkredspdgpq65rggt9l5m4`) も削除（`uk_system_settings_key_org` と完全に同じ列構成）
- `docs/DESIGN.md` / `docs/SPECIFICATION.md` の `system_settings` スキーマ記述に `organization_id` と複合 unique を反映

## Bug
Fixes #557

旧スキーマで `setting_key` に単独 unique を作っていた制約が、Hibernate 自動生成名で本番DBに残存していた。
`migration_organization.sql` は別の制約名で DROP を試みたため一致せず削除されず、別団体で同じ setting_key を保存しようとすると違反していた。

## DB 適用
**本番DB適用が必要。** マージ前後のいずれかで以下を実行する:

    PGPASSWORD='<password>' psql -h <host> -U <user> -d <dbname> -f database/drop_legacy_system_settings_unique.sql

`DROP CONSTRAINT IF EXISTS` のため冪等で、複数回実行しても安全。

## Test plan
- [ ] 本番DBに SQL 適用後、`\d system_settings` で `uknm18l4pyovtvd8y3b3x0l2y64` と `uk3uukkredspdgpq65rggt9l5m4` が消え、`uk_system_settings_key_org` のみが残ることを確認
- [ ] システム設定画面で、設定がまだ保存されていない団体を選んで「締め切りなし」をチェックして保存 → 成功すること
- [ ] 既存設定がある団体で値を更新 → 成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)