### PR TITLE
fix(kaderu): use CookieSpecs.STANDARD to accept 4-digit year expires

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClient.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClient.java
@@ -8,6 +8,7 @@ import com.karuta.matchtracker.service.proxy.VenueReservationProxyException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -94,10 +95,16 @@ public class KaderuReservationClient implements VenueReservationClient {
     @PostConstruct
     void initHttpClient() {
         int timeoutMs = proxyConfig.getRequestTimeoutSeconds() * 1000;
+        // CookieSpecs.STANDARD (RFC6265 lax) を明示指定。
+        // デフォルトの DefaultCookieSpec は expires 属性付き Set-Cookie を NetscapeDraftSpec
+        // (2桁年: "EEE, dd-MMM-yy HH:mm:ss z") で処理するため、kaderu が返す
+        // expires=Wed, 19 Aug 2082 22:51:22 GMT のような4桁年・RFC1123 形式を拒否し、
+        // セッション Cookie (ARKADERU27PC) を保存できず LOGIN_FAILED となる (Issue #559)。
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectTimeout(timeoutMs)
                 .setSocketTimeout(timeoutMs)
                 .setConnectionRequestTimeout(timeoutMs)
+                .setCookieSpec(CookieSpecs.STANDARD)
                 .build();
         this.httpClient = HttpClientBuilder.create()
                 .setDefaultRequestConfig(requestConfig)

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClientTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClientTest.java
@@ -199,6 +199,48 @@ class KaderuReservationClientTest {
     }
 
     @Test
+    @DisplayName("回帰テスト (Issue #559): 4桁年・遠い未来の expires 属性付き Cookie も拒否されず保存される")
+    void prepareReservationTray_persistsCookieWithFarFutureExpires() {
+        // 実機 kaderu が返すのと同じ形式の Set-Cookie (RFC1123 4桁年 + Max-Age + secure + HttpOnly)。
+        // Apache HttpClient のデフォルト Cookie spec (DefaultCookieSpec→NetscapeDraftSpec) は
+        // 2桁年のみ受け付けるため、CookieSpecs.STANDARD への切替で初めて保存される。
+        wireMock.stubFor(get(urlPathEqualTo(ENTRY_PATH))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Set-Cookie",
+                                "ARKADERU27PC=k6pss2v5nbdeko4hi5nrpcrrd2; "
+                                + "expires=Wed, 19 Aug 2082 22:51:22 GMT; "
+                                + "Max-Age=1777204541; path=/; secure; HttpOnly")
+                        .withBody("<html><body>ログインページ</body></html>")));
+        wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
+                .withRequestBody(matching(".*loginID=testuser.*"))
+                .atPriority(1)
+                .willReturn(aResponse().withStatus(200).withBody(LOGGED_IN_HTML)));
+        wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
+                .withRequestBody(matching(".*requestBtn=.*"))
+                .atPriority(1)
+                .willReturn(aResponse().withStatus(200).withBody(TRAY_HTML)));
+        wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
+                .withRequestBody(matching(".*setAppStatus=1.*"))
+                .atPriority(1)
+                .willReturn(aResponse().withStatus(200).withBody(AVAILABILITY_HTML)));
+        wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
+                .atPriority(10)
+                .willReturn(aResponse().withStatus(200).withBody(LOGGED_IN_HTML
+                        + "<table><tr><td>" + ROOM_NAME + "</td></tr></table>")));
+
+        ProxySession session = newSession();
+        client.prepareReservationTray(session);
+
+        boolean hasArKaderuCookie = session.getCookies().getCookies().stream()
+                .anyMatch(c -> "ARKADERU27PC".equals(c.getName())
+                        && "k6pss2v5nbdeko4hi5nrpcrrd2".equals(c.getValue()));
+        assertThat(hasArKaderuCookie)
+                .as("Cookie with 4-digit-year expires must be parsed and stored")
+                .isTrue();
+    }
+
+    @Test
     @DisplayName("ログイン失敗 → LOGIN_FAILED")
     void prepareReservationTray_loginFailed_throwsLoginFailed() {
         // 初期 GET は成功


### PR DESCRIPTION
## Summary
- `KaderuReservationClient` の `RequestConfig` に `setCookieSpec(CookieSpecs.STANDARD)` を追加し、RFC6265 lax (`LaxExpiresHandler`) でクッキーを処理するよう切り替え
- 実機 kaderu の Set-Cookie 形式 (`expires=Wed, 19 Aug 2082 22:51:22 GMT; Max-Age=...`) で再現する回帰テストを追加

## Bug
Fixes #559

「隣室を予約」ボタンを押すと真っ白な画面で `LOGIN_FAILED` になる。原因は、Apache HttpClient のデフォルト Cookie spec (`DefaultCookieSpec`) が `expires` 属性付き Set-Cookie を `NetscapeDraftSpec` (`EEE, dd-MMM-yy HH:mm:ss z` = 2桁年) で処理するため、kaderu が返す4桁年 RFC1123 形式の expires を拒否し、セッション Cookie (`ARKADERU27PC`) が CookieStore に保存されず、後続のログイン POST にセッションが付与されずログイン未確立扱いになっていたこと。

## Test plan
- [x] `KaderuReservationClientTest` 全グリーン (新テスト含む)
- [ ] 本番デプロイ後、カレンダーから「隣室を予約」ボタンで実際に申込トレイ画面が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)