### PR TITLE
ci: grant checks:write so dorny/test-reporter can post check runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # dorny/test-reporter は GitHub Checks API で check run を作成するため checks: write が必須。
+    # リポジトリ設定の workflow permissions がデフォルトの "Read repository contents and packages permissions"
+    # の場合、permissions ブロック未指定だと GITHUB_TOKEN に checks: write が付与されず、
+    # "Generate test report" ステップが silent に失敗する。
+    permissions:
+      contents: read
+      checks: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- `.github/workflows/test.yml` の `test` job に最小権限の `permissions:` ブロック (`contents: read` + `checks: write`) を明示
- これにより `dorny/test-reporter@v1` が GitHub Checks API で check run を作成できるようになる

## 背景・原因
- リポジトリ設定の workflow permissions が 2023 年以降のデフォルトである "Read repository contents and packages permissions" の場合、`permissions:` ブロックを workflow に書かないと `GITHUB_TOKEN` に `checks:write` が付与されない
- `dorny/test-reporter@v1` は `octokit.checks.create()` で check run を投稿するため、上記の状態だと silent に失敗 (ログが `git ls-files -z` 直後で打ち切られる) し、ジョブ全体が fail 扱いになっていた
- 直近 main の Java CI が連続失敗していたのはこれが原因。`Run tests` ステップ自体は `BUILD SUCCESSFUL` だった

## 検証
このPRのCI実行で `Generate test report` ステップが green になることをもって動作確認とする。

## Test plan
- [ ] このPRのCI (Java CI with Gradle) が「Generate test report」を含めて全 step success
- [ ] マージ後、main の次回 CI も同様に success

🤖 Generated with [Claude Code](https://claude.com/claude-code)