### PR TITLE
diag(kaderu): ログイン LOGIN_FAILED 原因切り分け用の診断ログ追加

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClient.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClient.java
@@ -32,9 +32,13 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * かでる2・7 会場のリバースプロキシ用 HTTP クライアント実装。
@@ -206,10 +210,17 @@ public class KaderuReservationClient implements VenueReservationClient {
     // ===== private steps =====
 
     private void login(ProxySession session, String userId, String password) {
+        // ===== 診断ログ (Issue #562, 切り分け後に撤去) =====
+        log.info("[#562] Kaderu login start: userIdLen={} passwordLen={}",
+                userId.length(), password.length());
+
         // ログインフォームへ初期 GET (PHPSESSID 取得 + 隠しフィールド取得を兼ねる)
         HttpGet initial = new HttpGet(venueConfig.baseUrl() + ENTRY_PATH);
-        executeForHtml(session, initial, VenueReservationProxyException.TRAY_NAVIGATION_FAILED,
+        String entryHtml = executeForHtml(session, initial,
+                VenueReservationProxyException.TRAY_NAVIGATION_FAILED,
                 "Failed to fetch kaderu entry page");
+        log.info("[#562] Entry GET: htmlLen={} hiddenFields={} cookies={}",
+                entryHtml.length(), extractHiddenFieldNames(entryHtml), cookieNames(session));
 
         // ログインフォーム POST。kaderu の gotoPage('my_page') 経由で到達するログイン画面の
         // <button name="loginBtn"> 押下と等価。
@@ -223,12 +234,62 @@ public class KaderuReservationClient implements VenueReservationClient {
         String body = executeForHtml(session, post, VenueReservationProxyException.LOGIN_FAILED,
                 "Kaderu login HTTP error");
 
+        boolean hasMyPage = body.contains("マイページ");
+        boolean hasLogout = body.contains("ログアウト");
+        log.info("[#562] Login POST response: htmlLen={} hasMyPage={} hasLogout={} cookies={}",
+                body.length(), hasMyPage, hasLogout, cookieNames(session));
+
         // ログイン成功検知 (open-reserve.js:107-110 と同等。"マイページ" or "ログアウト" が含まれる)
-        if (!body.contains("マイページ") && !body.contains("ログアウト")) {
+        if (!hasMyPage && !hasLogout) {
+            log.warn("[#562] Login failed body head (1000 chars): {}",
+                    truncateForLog(body, 1000));
             throw new VenueReservationProxyException(
                     VenueReservationProxyException.LOGIN_FAILED, VenueId.KADERU,
                     "Kaderu login failed (response did not show マイページ/ログアウト)");
         }
+    }
+
+    // ===== 診断ヘルパー (Issue #562, 切り分け後に撤去) =====
+
+    /** name属性が type の前/後どちらでも拾えるよう2パターンの正規表現で hidden field 名を抽出。 */
+    private static final Pattern HIDDEN_PATTERN_TYPE_FIRST = Pattern.compile(
+            "<input[^>]*type=[\"']hidden[\"'][^>]*name=[\"']([^\"']+)[\"']",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern HIDDEN_PATTERN_NAME_FIRST = Pattern.compile(
+            "<input[^>]*name=[\"']([^\"']+)[\"'][^>]*type=[\"']hidden[\"']",
+            Pattern.CASE_INSENSITIVE);
+
+    private static List<String> extractHiddenFieldNames(String html) {
+        if (html == null || html.isEmpty()) {
+            return List.of();
+        }
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        Matcher m1 = HIDDEN_PATTERN_TYPE_FIRST.matcher(html);
+        while (m1.find()) {
+            names.add(m1.group(1));
+        }
+        Matcher m2 = HIDDEN_PATTERN_NAME_FIRST.matcher(html);
+        while (m2.find()) {
+            names.add(m2.group(1));
+        }
+        return new ArrayList<>(names);
+    }
+
+    private static List<String> cookieNames(ProxySession session) {
+        if (session == null || session.getCookies() == null) {
+            return List.of();
+        }
+        return session.getCookies().getCookies().stream()
+                .map(c -> c.getName())
+                .collect(Collectors.toList());
+    }
+
+    private static String truncateForLog(String s, int max) {
+        if (s == null) {
+            return "";
+        }
+        String collapsed = s.replaceAll("\\s+", " ");
+        return collapsed.length() > max ? collapsed.substring(0, max) : collapsed;
     }
 
     private void navigateMyPage(ProxySession session) {


### PR DESCRIPTION
## Summary
- Issue #562 (PR #560 デプロイ後も かでる2・7 ログインで `LOGIN_FAILED`) の原因切り分け用の一時的な診断ログを追加
- 原因特定後にロジック修正と一緒に撤去する想定

## Bug
Refs #562

## 追加するログ
`KaderuReservationClient.login()` に以下を追加:

- ログイン開始時の `userId.length()` / `password.length()` （実値は出さない）
- 初期 GET 応答の `htmlLength` / hidden field 名一覧 / 保存された Cookie 名一覧
- ログイン POST 応答の `htmlLength` / `hasMyPage` / `hasLogout` / Cookie 名一覧
- ログイン失敗時 (LOGIN_FAILED 直前) のレスポンス body 先頭 1000 文字（空白圧縮）

## セキュリティ考慮
- パスワードや ID の実値はログに出さない（長さのみ）
- Cookie の値はログに出さない（名前のみ）
- LOGIN_FAILED 時の body 先頭はログインフォーム or エラーページの想定で個人情報は含まれないが、運用後すぐ撤去する

## 切り分け後のフロー
1. このPR をマージ → Render デプロイ
2. ユーザーに「隣室を予約」を1回再現してもらう
3. Render ログから原因を特定
4. 別PRで本修正＋診断ログ撤去

## Test plan
- [ ] PR マージ・デプロイ後、再現1回
- [ ] Render ログで上記4項目が出力されていること
- [ ] 既存の `KaderuReservationClientTest` が引き続きグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)