### PR TITLE
fix(kaderu): ログインフォームの hidden field を POST に含めて LOGIN_FAILED を解消

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClient.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClient.java
@@ -32,13 +32,13 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * かでる2・7 会場のリバースプロキシ用 HTTP クライアント実装。
@@ -210,86 +210,91 @@ public class KaderuReservationClient implements VenueReservationClient {
     // ===== private steps =====
 
     private void login(ProxySession session, String userId, String password) {
-        // ===== 診断ログ (Issue #562, 切り分け後に撤去) =====
-        log.info("[#562] Kaderu login start: userIdLen={} passwordLen={}",
-                userId.length(), password.length());
-
-        // ログインフォームへ初期 GET (PHPSESSID 取得 + 隠しフィールド取得を兼ねる)
+        // ログインフォームへ初期 GET (PHPSESSID 取得 + hidden フィールド取得を兼ねる)
         HttpGet initial = new HttpGet(venueConfig.baseUrl() + ENTRY_PATH);
         String entryHtml = executeForHtml(session, initial,
                 VenueReservationProxyException.TRAY_NAVIGATION_FAILED,
                 "Failed to fetch kaderu entry page");
-        log.info("[#562] Entry GET: htmlLen={} hiddenFields={} cookies={}",
-                entryHtml.length(), extractHiddenFieldNames(entryHtml), cookieNames(session));
 
         // ログインフォーム POST。kaderu の gotoPage('my_page') 経由で到達するログイン画面の
         // <button name="loginBtn"> 押下と等価。
-        List<NameValuePair> form = new ArrayList<>();
-        form.add(new BasicNameValuePair("p", PAGE_MY_PAGE));
-        form.add(new BasicNameValuePair("loginID", userId));
-        form.add(new BasicNameValuePair("loginPwd", password));
-        form.add(new BasicNameValuePair("loginBtn", "ログイン"));
+        // フォームの hidden field (op など) はブラウザ submit と同様にすべて転送する。
+        // これを送らないとサーバはログインを拒否してフォーム画面を返す (Issue #562)。
+        List<NameValuePair> form = new ArrayList<>(extractHiddenFields(entryHtml));
+        upsertField(form, "p", PAGE_MY_PAGE);
+        upsertField(form, "loginID", userId);
+        upsertField(form, "loginPwd", password);
+        upsertField(form, "loginBtn", "ログイン");
 
         HttpPost post = newFormPost(venueConfig.baseUrl() + ENTRY_PATH, form);
         String body = executeForHtml(session, post, VenueReservationProxyException.LOGIN_FAILED,
                 "Kaderu login HTTP error");
 
-        boolean hasMyPage = body.contains("マイページ");
-        boolean hasLogout = body.contains("ログアウト");
-        log.info("[#562] Login POST response: htmlLen={} hasMyPage={} hasLogout={} cookies={}",
-                body.length(), hasMyPage, hasLogout, cookieNames(session));
-
         // ログイン成功検知 (open-reserve.js:107-110 と同等。"マイページ" or "ログアウト" が含まれる)
-        if (!hasMyPage && !hasLogout) {
-            log.warn("[#562] Login failed body head (1000 chars): {}",
-                    truncateForLog(body, 1000));
+        if (!body.contains("マイページ") && !body.contains("ログアウト")) {
             throw new VenueReservationProxyException(
                     VenueReservationProxyException.LOGIN_FAILED, VenueId.KADERU,
                     "Kaderu login failed (response did not show マイページ/ログアウト)");
         }
     }
 
-    // ===== 診断ヘルパー (Issue #562, 切り分け後に撤去) =====
+    // ===== HTML フォームヘルパー =====
 
-    /** name属性が type の前/後どちらでも拾えるよう2パターンの正規表現で hidden field 名を抽出。 */
-    private static final Pattern HIDDEN_PATTERN_TYPE_FIRST = Pattern.compile(
-            "<input[^>]*type=[\"']hidden[\"'][^>]*name=[\"']([^\"']+)[\"']",
-            Pattern.CASE_INSENSITIVE);
-    private static final Pattern HIDDEN_PATTERN_NAME_FIRST = Pattern.compile(
-            "<input[^>]*name=[\"']([^\"']+)[\"'][^>]*type=[\"']hidden[\"']",
-            Pattern.CASE_INSENSITIVE);
+    /** {@code <input ...>} タグ全体を1キャプチャグループで切り出す。 */
+    private static final Pattern INPUT_TAG_PATTERN = Pattern.compile(
+            "<input\\b([^>]*?)/?>", Pattern.CASE_INSENSITIVE);
 
-    private static List<String> extractHiddenFieldNames(String html) {
+    /** input タグ内の {@code key="value"} / {@code key='value'} 属性を抽出する。 */
+    private static final Pattern INPUT_ATTR_PATTERN = Pattern.compile(
+            "(\\w+)\\s*=\\s*[\"']([^\"']*)[\"']", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * HTML 内の {@code <input type="hidden" name="..." value="...">} を全部抽出する。
+     * 属性順 (type/name/value のどれが先か) に依存せず取り出せる。
+     * 同じ name が複数回出現した場合は最初に登場したものを採用する。
+     */
+    static List<NameValuePair> extractHiddenFields(String html) {
         if (html == null || html.isEmpty()) {
             return List.of();
         }
-        LinkedHashSet<String> names = new LinkedHashSet<>();
-        Matcher m1 = HIDDEN_PATTERN_TYPE_FIRST.matcher(html);
-        while (m1.find()) {
-            names.add(m1.group(1));
+        LinkedHashMap<String, String> nameToValue = new LinkedHashMap<>();
+        Matcher tagMatcher = INPUT_TAG_PATTERN.matcher(html);
+        while (tagMatcher.find()) {
+            Map<String, String> attrs = parseAttributes(tagMatcher.group(1));
+            if (!"hidden".equalsIgnoreCase(attrs.get("type"))) {
+                continue;
+            }
+            String name = attrs.get("name");
+            if (name == null || name.isEmpty()) {
+                continue;
+            }
+            nameToValue.putIfAbsent(name, attrs.getOrDefault("value", ""));
         }
-        Matcher m2 = HIDDEN_PATTERN_NAME_FIRST.matcher(html);
-        while (m2.find()) {
-            names.add(m2.group(1));
+        List<NameValuePair> result = new ArrayList<>(nameToValue.size());
+        for (Map.Entry<String, String> e : nameToValue.entrySet()) {
+            result.add(new BasicNameValuePair(e.getKey(), e.getValue()));
         }
-        return new ArrayList<>(names);
+        return result;
     }
 
-    private static List<String> cookieNames(ProxySession session) {
-        if (session == null || session.getCookies() == null) {
-            return List.of();
+    private static Map<String, String> parseAttributes(String attrFragment) {
+        Map<String, String> attrs = new HashMap<>();
+        Matcher m = INPUT_ATTR_PATTERN.matcher(attrFragment);
+        while (m.find()) {
+            attrs.put(m.group(1).toLowerCase(Locale.ROOT), m.group(2));
         }
-        return session.getCookies().getCookies().stream()
-                .map(c -> c.getName())
-                .collect(Collectors.toList());
+        return attrs;
     }
 
-    private static String truncateForLog(String s, int max) {
-        if (s == null) {
-            return "";
+    /** form 内の同名フィールドがあれば値を上書き、なければ末尾に追加する。 */
+    private static void upsertField(List<NameValuePair> form, String name, String value) {
+        for (int i = 0; i < form.size(); i++) {
+            if (name.equals(form.get(i).getName())) {
+                form.set(i, new BasicNameValuePair(name, value));
+                return;
+            }
         }
-        String collapsed = s.replaceAll("\\s+", " ");
-        return collapsed.length() > max ? collapsed.substring(0, max) : collapsed;
+        form.add(new BasicNameValuePair(name, value));
     }
 
     private void navigateMyPage(ProxySession session) {

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClientTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClientTest.java
@@ -6,6 +6,7 @@ import com.karuta.matchtracker.config.VenueReservationProxyConfig;
 import com.karuta.matchtracker.service.proxy.ProxySession;
 import com.karuta.matchtracker.service.proxy.VenueId;
 import com.karuta.matchtracker.service.proxy.VenueReservationProxyException;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicCookieStore;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -524,5 +526,89 @@ class KaderuReservationClientTest {
     @DisplayName("KaderuVenueConfig: entryPath は /kaderu27/index.php を返す (相対URL解決の基準)")
     void venueConfig_entryPathIsKaderu27IndexPhp() {
         assertThat(venueConfig.entryPath()).isEqualTo("/kaderu27/index.php");
+    }
+
+    // ===== Issue #562 関連: hidden field 抽出とログイン POST への転送 =====
+
+    @Test
+    @DisplayName("回帰テスト (Issue #562): ログインフォームの hidden field (op など) がログイン POST に含まれる")
+    void prepareReservationTray_includesHiddenFieldsInLoginPost() {
+        // 初期 GET 応答に hidden field op を含むログインフォームHTMLを返す
+        String loginFormHtml =
+                "<html><body>"
+                + "<form name=\"form1\" method=\"post\" action=\"\">"
+                + "  <input type=\"hidden\" name=\"op\" value=\"login\">"
+                + "  <input type=\"text\" name=\"loginID\">"
+                + "  <input type=\"password\" name=\"loginPwd\">"
+                + "  <button name=\"loginBtn\">ログイン</button>"
+                + "</form></body></html>";
+
+        wireMock.stubFor(get(urlPathEqualTo(ENTRY_PATH))
+                .willReturn(aResponse().withStatus(200).withBody(loginFormHtml)));
+        wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
+                .withRequestBody(matching(".*loginID=testuser.*"))
+                .atPriority(1)
+                .willReturn(aResponse().withStatus(200).withBody(LOGGED_IN_HTML)));
+        wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
+                .withRequestBody(matching(".*requestBtn=.*"))
+                .atPriority(1)
+                .willReturn(aResponse().withStatus(200).withBody(TRAY_HTML)));
+        wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
+                .withRequestBody(matching(".*setAppStatus=1.*"))
+                .atPriority(1)
+                .willReturn(aResponse().withStatus(200).withBody(AVAILABILITY_HTML)));
+        wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
+                .atPriority(10)
+                .willReturn(aResponse().withStatus(200).withBody(LOGGED_IN_HTML
+                        + "<table><tr><td>" + ROOM_NAME + "</td></tr></table>")));
+
+        ProxySession session = newSession();
+        client.prepareReservationTray(session);
+
+        // ログイン POST に op=login と loginID=testuser の両方が含まれている
+        wireMock.verify(WireMock.postRequestedFor(urlPathEqualTo(ENTRY_PATH))
+                .withRequestBody(matching("(?s).*op=login.*"))
+                .withRequestBody(matching("(?s).*loginID=testuser.*")));
+    }
+
+    @Test
+    @DisplayName("extractHiddenFields: 属性順 type/name/value のいずれが先でも hidden を抽出できる")
+    void extractHiddenFields_variousAttributeOrders() {
+        String html =
+                "<input type='hidden' name='a' value='1'>"
+                + "<input name='b' type='hidden' value='2'>"
+                + "<input value='3' name='c' type='hidden'>"
+                + "<input type=\"text\" name=\"d\" value=\"4\">"; // hidden ではないので除外
+
+        List<NameValuePair> result = KaderuReservationClient.extractHiddenFields(html);
+
+        assertThat(result).extracting(NameValuePair::getName)
+                .containsExactly("a", "b", "c");
+        assertThat(result).extracting(NameValuePair::getValue)
+                .containsExactly("1", "2", "3");
+    }
+
+    @Test
+    @DisplayName("extractHiddenFields: value 属性なしは空文字、name なしは無視、同名は最初のみ採用")
+    void extractHiddenFields_edgeCases() {
+        String html =
+                "<input type='hidden' name='a'>"            // value なし → ""
+                + "<input type='hidden' value='nope'>"        // name なし → 無視
+                + "<input type='hidden' name='a' value='2'>"  // 同名 → 最初のみ採用
+                + "<input type='hidden' name='b' value=''>";  // 明示的に空
+
+        List<NameValuePair> result = KaderuReservationClient.extractHiddenFields(html);
+
+        assertThat(result).extracting(NameValuePair::getName)
+                .containsExactly("a", "b");
+        assertThat(result).extracting(NameValuePair::getValue)
+                .containsExactly("", "");
+    }
+
+    @Test
+    @DisplayName("extractHiddenFields: null / 空文字 は空リストを返す")
+    void extractHiddenFields_nullOrEmpty() {
+        assertThat(KaderuReservationClient.extractHiddenFields(null)).isEmpty();
+        assertThat(KaderuReservationClient.extractHiddenFields("")).isEmpty();
     }
 }


### PR DESCRIPTION
## Summary
- かでる2・7 のログインフォームに必須の hidden field (実機では `op`) を Java 版が送っていなかったため、サーバがログインを拒否してフォーム画面に戻し `LOGIN_FAILED` となっていた問題を修正
- ブラウザ submit と同じく、初期 GET 応答の `<input type=hidden>` をすべて抽出してログイン POST に転送
- PR #563 で追加した診断ログ (`[#562]` プレフィックス) を撤去

## Bug
Fixes #562

## 原因 (PR #563 で得た診断ログから確定)
```
[#562] Entry GET: htmlLen=14938 hiddenFields=[op] cookies=[ARKADERU27PC]
[#562] Login POST response: htmlLen=14938 hasMyPage=false hasLogout=false cookies=[ARKADERU27PC]
[#562] Login failed body head: <title>道民活動センター施設予約システム</title> ...
```
- 初期GET と ログインPOST の応答 HTML 長が完全一致 (14938) → サーバが**ログインフォームに戻している**
- 初期GETに hidden field `op` が存在 → これを送らないとサーバが拒否
- 応答bodyのタイトルもログイン前画面と一致

## 修正内容
- `KaderuReservationClient.login()`:
  - 初期 GET の HTML から `extractHiddenFields()` で hidden inputs を全部抽出
  - 抽出した hidden を form に追加し、`upsertField()` で `p`/`loginID`/`loginPwd`/`loginBtn` を上乗せ（hidden 側に同名があれば上書き）
- 新規ヘルパー (package-private):
  - `extractHiddenFields(html)` — 属性順 (type/name/value どれが先) に依存しない `<input>` パーサ
  - `parseAttributes(attrFragment)` / `upsertField(form, name, value)`
- PR #563 で追加した診断ログとヘルパーを撤去

## テスト
新規追加 (`KaderuReservationClientTest`):
- `prepareReservationTray_includesHiddenFieldsInLoginPost` — ログインフォームに `op=login` hidden を含めた WireMock レスポンス → POST に `op=login` と `loginID=testuser` が両方含まれる
- `extractHiddenFields_variousAttributeOrders` — `type/name/value` 各順序の hidden を抽出
- `extractHiddenFields_edgeCases` — value 属性なし／name なし／同名重複／空 value
- `extractHiddenFields_nullOrEmpty` — null / 空文字

`./gradlew test --tests "...KaderuReservationClientTest"` ローカル実行 BUILD SUCCESSFUL。

## Test plan
- [ ] 既存の WireMock テスト一式が引き続きグリーン
- [ ] デプロイ後、本番で「隣室を予約」を実行し申込トレイ画面が表示されること
- [ ] Render ログに `[#562]` プレフィックスのログが出なくなっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)