### PR TITLE
fix(kaderu): use op parameter for reservation proxy navigation

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2562,7 +2562,7 @@ Entity Layer (JPA Entity)
 
 公開 API は `POST /api/venue-reservation-proxy/session`、`GET /api/venue-reservation-proxy/view?token=...`、`ANY /api/venue-reservation-proxy/fetch/**?token=...`。いずれも ADMIN+ のみ利用可能。
 
-Kaderu の Phase 1 実装は `https://k2.p-kashikan.jp/kaderu27/index.php` に対する form 等価 POST で、`p=my_page` ログイン、`p=srch_sst` 空き状況、`p=date_select` 日付/スロット選択、`p=rsv_search` 申込トレイ遷移を行う。申込完了検知は URL / Location の `p=rsv_comp`、`p=fix_comp`、`/complete` と、本文の「申込みを受け付けました」「申込番号」「予約を受付ました」「予約完了」を陽性条件にする。
+Kaderu の Phase 1 実装は `https://k2.p-kashikan.jp/kaderu27/index.php` に対する form 等価 POST で、実サイトの `gotoPage(op)` と同じく `op=my_page` ログイン、`op=srch_sst` 空き状況、`op=date_select` 日付/スロット選択、`op=rsv_search` 申込トレイ遷移を行う。申込完了検知は URL / Location の `op=rsv_comp` / `p=rsv_comp`、`op=fix_comp` / `p=fix_comp`、`/complete` と、本文の「申込みを受け付けました」「申込番号」「予約を受付ました」「予約完了」を陽性条件にする。
 
 ### 7.8 かでる予約 → 練習日自動登録フロー
 

--- a/docs/features/venue-reservation-proxy/venues/kaderu.md
+++ b/docs/features/venue-reservation-proxy/venues/kaderu.md
@@ -23,12 +23,12 @@
 
 | # | ステップ | 概要 |
 |---|---------|-----|
-| 1 | ログイン | `GET /kaderu27/index.php` で `PHPSESSID` を取得し、`p=my_page`, `loginID`, `loginPwd`, `loginBtn=ログイン` を `POST /kaderu27/index.php` に送信。本文に「マイページ」または「ログアウト」があれば成功 |
-| 2 | マイページ遷移 | `p=my_page` を `POST /kaderu27/index.php` に送信 |
-| 3 | 空き状況ページ遷移 | `p=srch_sst`, `UseYM=YYYYMM` を `POST /kaderu27/index.php` に送信。本文に対象部屋名が含まれることを確認 |
-| 4 | 月合わせ | `p=srch_sst`, `UseYear=YYYY`, `UseMonth=MM` を `POST /kaderu27/index.php` に送信 |
-| 5 | 日付クリック | `p=date_select`, `UseDate=YYYYMMDD` を `POST /kaderu27/index.php` に送信。本文に対象部屋名が含まれることを確認 |
-| 6 | スロット選択 + 申込トレイへ | `p=date_select`, `setAppStatus=1`, `facilityCode`, `useDate=YYYY/MM/DD`, `slotIndex`, `timeRange` を送信後、`p=rsv_search`, `requestBtn=申込トレイに入れる` を送信。本文に「申込トレイ」があれば成功 |
+| 1 | ログイン | `GET /kaderu27/index.php` で `PHPSESSID` を取得し、実サイトの `gotoPage('my_page')` と同じく hidden field の `op` を `my_page` に上書きして、`loginID`, `loginPwd`, `loginBtn=ログイン` とともに `POST /kaderu27/index.php` に送信。本文に「マイページ」または「ログアウト」があれば成功 |
+| 2 | マイページ遷移 | `op=my_page` を `POST /kaderu27/index.php` に送信 |
+| 3 | 空き状況ページ遷移 | `op=srch_sst`, `UseYM=YYYYMM` を `POST /kaderu27/index.php` に送信。本文に対象部屋名が含まれることを確認 |
+| 4 | 月合わせ | `op=srch_sst`, `UseYear=YYYY`, `UseMonth=MM` を `POST /kaderu27/index.php` に送信 |
+| 5 | 日付クリック | `op=date_select`, `UseDate=YYYYMMDD` を `POST /kaderu27/index.php` に送信。本文に対象部屋名が含まれることを確認 |
+| 6 | スロット選択 + 申込トレイへ | `op=date_select`, `setAppStatus=1`, `facilityCode`, `useDate=YYYY/MM/DD`, `slotIndex`, `timeRange` を送信後、`op=rsv_search`, `requestBtn=申込トレイに入れる` を送信。本文に「申込トレイ」があれば成功 |
 
 **省略するステップ**: 旧 Playwright 実装にあった「スロット状態確認」の DOM verification は行わない。会場側がスロット選択時に返すエラー文言で `NOT_AVAILABLE` を判定する。
 
@@ -76,8 +76,8 @@ Kaderu の form は hidden field が少ない (0-2個程度。CSRF token 等)。
 ## 5. 申込完了検知 (KaderuCompletionStrategy)
 
 ### 5.1 URL 条件
-- リクエスト URL または `Location` ヘッダに `p=rsv_comp` を含む
-- リクエスト URL または `Location` ヘッダに `p=fix_comp` を含む
+- リクエスト URL または `Location` ヘッダに `op=rsv_comp` または `p=rsv_comp` を含む
+- リクエスト URL または `Location` ヘッダに `op=fix_comp` または `p=fix_comp` を含む
 - リクエスト URL または `Location` ヘッダに `/complete` を含む
 
 ### 5.2 HTML 文言条件

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuCompletionStrategy.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuCompletionStrategy.java
@@ -16,10 +16,10 @@ import java.util.regex.Pattern;
  *   <li>レスポンス HTML 本文に完了画面固有の文言を含む</li>
  * </ul>
  *
- * <p>誤陽性を避けるため、申込フォーム画面 (例: {@code ?p=apply}) と区別できるパターンのみを採用する。
+ * <p>誤陽性を避けるため、申込フォーム画面 (例: {@code ?op=apply}) と区別できるパターンのみを採用する。
  * 文言判定では「完了」単体のような一般語は使わない。
  * URL/本文ともに word-boundary を考慮した正規表現で照合し、
- * {@code p=rsv_completion} のような関連性のないパターンや、本文中の単独の「申込番号」ラベルだけでは
+ * {@code op=rsv_completion} のような関連性のないパターンや、本文中の単独の「申込番号」ラベルだけでは
  * 陽性にしない。</p>
  *
  * <p><strong>本パターンは暫定値。</strong> Phase 1 の実機検証 (E2E ステップで実申込を1回完走させる) で
@@ -32,16 +32,16 @@ public class KaderuCompletionStrategy implements VenueCompletionStrategy {
      * URL / Location ヘッダで完了画面と判定する正規表現パターン。
      * いずれか1つでもマッチすれば陽性。
      *
-     * <p>クエリは {@code (\?|&)p=...(&|$)} で word-boundary を強制し、
-     * {@code p=rsv_completion} のようなプレフィックス一致を排除する。
+     * <p>クエリは {@code (\?|&)(op|p)=...(&|$)} で word-boundary を強制し、
+     * {@code op=rsv_completion} のようなプレフィックス一致を排除する。
      * パスは前後を非英数字で区切る形で {@code complete} を照合し、
      * {@code /incomplete-page} のような substring 一致を排除する。</p>
      *
      * <p>暫定値: 実機検証で確定すること。</p>
      */
     private static final List<Pattern> URL_COMPLETION_PATTERNS = List.of(
-            Pattern.compile("(\\?|&)p=rsv_comp(&|$)"),
-            Pattern.compile("(\\?|&)p=fix_comp(&|$)"),
+            Pattern.compile("(\\?|&)(?:op|p)=rsv_comp(&|$)"),
+            Pattern.compile("(\\?|&)(?:op|p)=fix_comp(&|$)"),
             Pattern.compile("(?<![A-Za-z0-9])complete(?![A-Za-z0-9])")
     );
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClient.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClient.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
  * scripts/room-checker/open-reserve.js の Playwright 版 6 ステップを HTTP リクエストへ移植する。
  * 詳細は docs/features/venue-reservation-proxy/venues/kaderu.md §2 を参照。</p>
  *
- * <p>kaderu サイトはページ遷移を JavaScript の gotoPage(p) / showCalendar(y, m) /
+ * <p>kaderu サイトはページ遷移を JavaScript の gotoPage(op) / showCalendar(y, m) /
  * clickDay(d) / setAppStatus(...) で行うが、内部的には PHP の index.php に対する form POST に
  * 等価。本実装はこの form 等価 POST を直接組み立てて送信する。
  * 細部のフィールド名や順序は実機 E2E (Task 4 完了条件の手動検証) で確定する。</p>
@@ -59,7 +59,7 @@ public class KaderuReservationClient implements VenueReservationClient {
     /** kaderu サイトのエントリポイント パス (baseUrl 直下からの相対) */
     static final String ENTRY_PATH = "/kaderu27/index.php";
 
-    /** ページ識別子 (kaderu の gotoPage(p) と等価) */
+    /** ページ識別子 (kaderu の gotoPage(op) と等価) */
     static final String PAGE_LOGIN = "login";
     static final String PAGE_MY_PAGE = "my_page";
     static final String PAGE_AVAILABILITY = "srch_sst";
@@ -221,7 +221,7 @@ public class KaderuReservationClient implements VenueReservationClient {
         // フォームの hidden field (op など) はブラウザ submit と同様にすべて転送する。
         // これを送らないとサーバはログインを拒否してフォーム画面を返す (Issue #562)。
         List<NameValuePair> form = new ArrayList<>(extractHiddenFields(entryHtml));
-        upsertField(form, "p", PAGE_MY_PAGE);
+        upsertField(form, "op", PAGE_MY_PAGE);
         upsertField(form, "loginID", userId);
         upsertField(form, "loginPwd", password);
         upsertField(form, "loginBtn", "ログイン");
@@ -298,7 +298,7 @@ public class KaderuReservationClient implements VenueReservationClient {
     }
 
     private void navigateMyPage(ProxySession session) {
-        List<NameValuePair> form = List.of(new BasicNameValuePair("p", PAGE_MY_PAGE));
+        List<NameValuePair> form = List.of(new BasicNameValuePair("op", PAGE_MY_PAGE));
         HttpPost post = newFormPost(venueConfig.baseUrl() + ENTRY_PATH, form);
         executeForHtml(session, post, VenueReservationProxyException.TRAY_NAVIGATION_FAILED,
                 "Failed to navigate to kaderu my page");
@@ -308,7 +308,7 @@ public class KaderuReservationClient implements VenueReservationClient {
         // gotoPage('srch_sst') 等価。月パラメータは UseYM=YYYYMM。
         String useYm = String.format(Locale.ROOT, "%04d%02d", date.getYear(), date.getMonthValue());
         List<NameValuePair> form = List.of(
-                new BasicNameValuePair("p", PAGE_AVAILABILITY),
+                new BasicNameValuePair("op", PAGE_AVAILABILITY),
                 new BasicNameValuePair("UseYM", useYm)
         );
         HttpPost post = newFormPost(venueConfig.baseUrl() + ENTRY_PATH, form);
@@ -325,7 +325,7 @@ public class KaderuReservationClient implements VenueReservationClient {
         // showCalendar(y, m) 等価。既に同じ月であれば現状の HTML には対象月が表示されている前提で
         // POST 自体を省略してもよいが、ステートレスに毎回送って同月を再確認する方が安全。
         List<NameValuePair> form = List.of(
-                new BasicNameValuePair("p", PAGE_AVAILABILITY),
+                new BasicNameValuePair("op", PAGE_AVAILABILITY),
                 new BasicNameValuePair("UseYear", String.valueOf(date.getYear())),
                 new BasicNameValuePair("UseMonth", String.format(Locale.ROOT, "%02d", date.getMonthValue()))
         );
@@ -335,11 +335,11 @@ public class KaderuReservationClient implements VenueReservationClient {
     }
 
     private void clickDay(ProxySession session, LocalDate date) {
-        // clickDay(d) 等価。POST p=date_select + UseDate=YYYYMMDD
+        // clickDay(d) 等価。POST op=date_select + UseDate=YYYYMMDD
         String useDate = String.format(Locale.ROOT, "%04d%02d%02d",
                 date.getYear(), date.getMonthValue(), date.getDayOfMonth());
         List<NameValuePair> form = List.of(
-                new BasicNameValuePair("p", PAGE_DATE_SELECT),
+                new BasicNameValuePair("op", PAGE_DATE_SELECT),
                 new BasicNameValuePair("UseDate", useDate)
         );
         HttpPost post = newFormPost(venueConfig.baseUrl() + ENTRY_PATH, form);
@@ -359,7 +359,7 @@ public class KaderuReservationClient implements VenueReservationClient {
 
         // setAppStatus 等価。スロット選択フォーム送信。
         List<NameValuePair> selectForm = new ArrayList<>();
-        selectForm.add(new BasicNameValuePair("p", PAGE_DATE_SELECT));
+        selectForm.add(new BasicNameValuePair("op", PAGE_DATE_SELECT));
         selectForm.add(new BasicNameValuePair("setAppStatus", "1"));
         selectForm.add(new BasicNameValuePair("facilityCode", facilityCode));
         selectForm.add(new BasicNameValuePair("useDate", dateFormatted));
@@ -378,7 +378,7 @@ public class KaderuReservationClient implements VenueReservationClient {
 
         // requestBtn 押下等価。申込トレイ画面への遷移。
         List<NameValuePair> trayForm = List.of(
-                new BasicNameValuePair("p", PAGE_REQUEST_TRAY),
+                new BasicNameValuePair("op", PAGE_REQUEST_TRAY),
                 new BasicNameValuePair("requestBtn", "申込トレイに入れる")
         );
         HttpPost trayPost = newFormPost(venueConfig.baseUrl() + ENTRY_PATH, trayForm);

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuCompletionStrategyTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuCompletionStrategyTest.java
@@ -36,6 +36,13 @@ class KaderuCompletionStrategyTest {
         }
 
         @Test
+        @DisplayName("requestUrl 縺ｫ ?op=rsv_comp 繧貞性繧縺ｨ true")
+        void requestUrlRsvCompWithOp() {
+            String url = "https://k2.p-kashikan.jp/kaderu27/index.php?op=rsv_comp";
+            assertThat(strategy.isCompletion(url, null, null)).isTrue();
+        }
+
+        @Test
         @DisplayName("requestUrl に ?p=fix_comp を含むと true")
         void requestUrlFixComp() {
             String url = "https://k2.p-kashikan.jp/kaderu27/index.php?p=fix_comp";
@@ -53,6 +60,14 @@ class KaderuCompletionStrategyTest {
         @DisplayName("responseLocation に完了 URL を含むと true (リダイレクト経由)")
         void responseLocationMatches() {
             String location = "/kaderu27/index.php?p=rsv_comp&id=12345";
+            assertThat(strategy.isCompletion("https://k2.p-kashikan.jp/kaderu27/index.php", location, null))
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("responseLocation 縺ｫ op 螳御ｺ・URL 繧貞性繧縺ｨ true")
+        void responseLocationMatchesWithOp() {
+            String location = "/kaderu27/index.php?op=rsv_comp&id=12345";
             assertThat(strategy.isCompletion("https://k2.p-kashikan.jp/kaderu27/index.php", location, null))
                     .isTrue();
         }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClientTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/venue/kaderu/KaderuReservationClientTest.java
@@ -28,6 +28,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -143,9 +144,9 @@ class KaderuReservationClientTest {
                         .withStatus(200)
                         .withBody(AVAILABILITY_HTML)));
 
-        // ステップ 5: clickDay 等価 (p=date_select 単独)
+        // ステップ 5: clickDay 等価 (op=date_select 単独)
         wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
-                .withRequestBody(matching("p=date_select(?!.*setAppStatus).*"))
+                .withRequestBody(matching("op=date_select(?!.*setAppStatus).*"))
                 .atPriority(2)
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -167,7 +168,7 @@ class KaderuReservationClientTest {
                         .withStatus(200)
                         .withBody(AVAILABILITY_HTML)));
 
-        // ステップ 2: マイページ遷移 (p=my_page 単独。ログイン POST 後の汎用フォールバック)
+        // ステップ 2: マイページ遷移 (op=my_page 単独。ログイン POST 後の汎用フォールバック)
         wireMock.stubFor(post(urlPathEqualTo(ENTRY_PATH))
                 .atPriority(10)
                 .willReturn(aResponse()
@@ -531,13 +532,13 @@ class KaderuReservationClientTest {
     // ===== Issue #562 関連: hidden field 抽出とログイン POST への転送 =====
 
     @Test
-    @DisplayName("回帰テスト (Issue #562): ログインフォームの hidden field (op など) がログイン POST に含まれる")
-    void prepareReservationTray_includesHiddenFieldsInLoginPost() {
-        // 初期 GET 応答に hidden field op を含むログインフォームHTMLを返す
+    @DisplayName("回帰テスト (Issue #562): ログインフォームの hidden field op を my_page に上書きする")
+    void prepareReservationTray_overwritesHiddenOpWithMyPageInLoginPost() {
+        // 実サイトの初期 GET は hidden field op="" を返す。ブラウザは submit 前に op=my_page へ上書きする。
         String loginFormHtml =
                 "<html><body>"
                 + "<form name=\"form1\" method=\"post\" action=\"\">"
-                + "  <input type=\"hidden\" name=\"op\" value=\"login\">"
+                + "  <input type=\"hidden\" name=\"op\" value=\"\">"
                 + "  <input type=\"text\" name=\"loginID\">"
                 + "  <input type=\"password\" name=\"loginPwd\">"
                 + "  <button name=\"loginBtn\">ログイン</button>"
@@ -565,10 +566,11 @@ class KaderuReservationClientTest {
         ProxySession session = newSession();
         client.prepareReservationTray(session);
 
-        // ログイン POST に op=login と loginID=testuser の両方が含まれている
+        // ログイン POST は op=my_page を送り、旧実装の p=my_page は送らない。
         wireMock.verify(WireMock.postRequestedFor(urlPathEqualTo(ENTRY_PATH))
-                .withRequestBody(matching("(?s).*op=login.*"))
-                .withRequestBody(matching("(?s).*loginID=testuser.*")));
+                .withRequestBody(matching("(?s).*op=my_page.*"))
+                .withRequestBody(matching("(?s).*loginID=testuser.*"))
+                .withRequestBody(notMatching("(?s)(?:.*&)?p=my_page(?:&.*)?")));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Kaderu proxy navigation now sends the site?s actual `op` form parameter instead of leaving `op` blank and sending `p`
- Added regression coverage for overwriting hidden `op=""` with `op=my_page`, and accepted `op`-based completion URLs
- Updated Kaderu venue-proxy design docs to match the real form contract

## Bug
Fixes #562

## Test plan
- [x] `./gradlew test --tests "com.karuta.matchtracker.service.proxy.venue.kaderu.KaderuReservationClientTest" --tests "com.karuta.matchtracker.service.proxy.venue.kaderu.KaderuCompletionStrategyTest"`
- [x] `./gradlew test --tests "com.karuta.matchtracker.service.proxy.*" --tests "com.karuta.matchtracker.controller.VenueReservationProxyControllerTest"`
