### PR TITLE
fix: かでる予約プロキシで Invalid CORS request 黒画面を返す問題

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1839,6 +1839,7 @@ UNIQUE制約: (player_id, organization_id)
 - レスポンス形式: JSON
 - 認証: `X-User-Id` / `X-User-Role` ヘッダー（プロトタイプ）
 - CORS: `app.cors.allowed-origins` プロパティで設定
+- リバースプロキシ配下デプロイ: `server.forward-headers-strategy=framework` を有効化し、`X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-Port` を解釈する。これがないと TLS 終端サービス (Render 等) 配下で `request.getScheme()` などが内部値を返し、会場予約プロキシ画面の same-origin form POST が CORS で誤拒否される。
 - エラーレスポンス: `{ "message": "エラーメッセージ" }`
 
 ### 7.2 選手管理 (`/api/players`)

--- a/karuta-tracker/src/main/resources/application.properties
+++ b/karuta-tracker/src/main/resources/application.properties
@@ -23,6 +23,11 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # Server Configuration
 server.port=${PORT:8080}
+# Render などの reverse proxy 配下では HTTPS が edge で終端され HTTP でコンテナへ転送される。
+# X-Forwarded-Proto / X-Forwarded-Host を解釈させ、request.getScheme()/getServerName()/getServerPort()
+# が公開URLの値を返すようにする。これをしないと same-origin の form POST (proxy view → fetch) で
+# Spring の CORS チェックが cross-origin と誤判定し "Invalid CORS request" になる (Issue #570)。
+server.forward-headers-strategy=framework
 
 # Disable open-in-view for API-only backend responses
 spring.jpa.open-in-view=false


### PR DESCRIPTION
## Summary
- Render など TLS 終端 reverse proxy 配下で `server.forward-headers-strategy=framework` が未設定のため、Spring がリクエスト自オリジンを内部 HTTP/内部ポートとして認識
- プロキシ view 画面 (API オリジン) からの same-origin form POST が CORS チェックで cross-origin と誤判定 → `Invalid CORS request`
- `application.properties` に `server.forward-headers-strategy=framework` を 1 行追加し、`X-Forwarded-Proto/Host/Port` を解釈させて修正
- `docs/SPECIFICATION.md` の API 共通仕様にも追記

## Bug
Fixes #570

## Test plan
- [ ] Render に本 PR をマージ → デプロイ完了後、かでる予約プロキシ画面でフォーム送信が `Invalid CORS request` にならず次画面に進めることを確認
- [ ] 既存 SPA → API の cross-origin リクエスト (ログイン等) が引き続き正常動作することを確認
- [ ] ローカル開発でも従来通り動作することを確認 (X-Forwarded-* が来ない環境では何も変わらない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)