### PR TITLE
fix: 会場予約プロキシ /view・/fetch パスを CORS 厳格チェックから除外

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/config/WebConfig.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/config/WebConfig.java
@@ -19,6 +19,31 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        // 会場予約プロキシ画面 (/view, /fetch/**) は API オリジンから直接表示される
+        // フルページ用エンドポイント。SPA からの cross-origin 呼び出しではなく、
+        // 表示後の form submit 等の same-origin リクエストとして使われる。
+        // 通常 same-origin なら Spring の CORS チェックは素通りするはずだが、Render の
+        // ように TLS を edge で終端する reverse proxy 配下だと request.getScheme()/
+        // getServerName()/getServerPort() が内部値を返し、Origin ヘッダと一致せず
+        // cross-origin と誤判定されることがある (Issue #570)。
+        // forward-headers-strategy=framework と併用しつつ defense-in-depth として、
+        // これらのパスに任意 Origin を許可するマッピングを /api/** より先に登録する
+        // (CorsRegistry は最初に一致したマッピングを使うため、より具体的な
+        // パターンを先に登録する必要がある)。
+        // /session は SPA から呼ばれるため /api/** 側 (allowedOrigins) のままにする。
+        registry.addMapping("/api/venue-reservation-proxy/view")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "HEAD", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(false)
+                .maxAge(3600);
+        registry.addMapping("/api/venue-reservation-proxy/fetch/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "HEAD", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(false)
+                .maxAge(3600);
+
         String[] origins = allowedOrigins.split(",");
         registry.addMapping("/api/**")
                 .allowedOrigins(origins)


### PR DESCRIPTION
## Summary
- PR #571 (forward-headers-strategy=framework) の root cause fix に加え、**defense-in-depth** として `/api/venue-reservation-proxy/view` と `/api/venue-reservation-proxy/fetch/**` 専用の CORS マッピングを追加
- 当該マッピングは `allowedOriginPatterns("*")` で任意 Origin を許可（同一オリジンの form POST しか実態としては来ない／token URL でアクセス制御済みのため安全）
- `/api/**` より前に登録することで、`CorsRegistry` (LinkedHashMap insertion order) のマッチで優先されるようにする
- `/session` は SPA からの cross-origin 呼び出し用なので意図的に除外（厳格 `allowedOrigins` のまま）

## Why this is needed in addition to PR #571
Render の deploy 切り替え中・あるいは reverse proxy が `X-Forwarded-*` を落とす環境で `forward-headers-strategy` が機能しないケースでも、`view` / `fetch` の form POST が `Invalid CORS request` で弾かれないようにする保険。実際 PR #571 マージ後も再現報告があったため追加対応する。

## Refs
Refs #570

## Test plan
- [ ] 本 PR デプロイ後、かでる予約プロキシ画面でフォーム送信が `Invalid CORS request` 黒画面にならず次画面に進めることを確認
- [ ] `/api/venue-reservation-proxy/session` (SPA → API の cross-origin POST) が引き続き正常動作することを確認
- [ ] LINE webhook (`/api/line/webhook/**`) 等の既存 CORS 例外が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)