### PR TITLE
fix: かでる予約プロキシでフォーム送信時に POST body が消費される問題

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/VenueReservationProxyController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/VenueReservationProxyController.java
@@ -21,6 +21,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 /**
  * 会場予約リバースプロキシのエンドポイント。
  *
@@ -72,10 +75,41 @@ public class VenueReservationProxyController {
     /**
      * 会場サイトへの中継エンドポイント。
      * 認可は {@code token} (capability) のみ。{@code @RequireRole} は付けない。
+     *
+     * <p><strong>token は {@link #extractTokenFromQuery} で URL クエリ文字列から手動で抽出する</strong>。
+     * {@code @RequestParam} を使うと Spring が {@code request.getParameterValues("token")} を呼び、
+     * Tomcat が {@code application/x-www-form-urlencoded} POST のリクエストボディをパースして
+     * parameter map に統合してしまう。これによりリクエストボディの InputStream が枯渇し、
+     * 後続の {@link com.karuta.matchtracker.service.proxy.VenueReservationProxyService#fetch}
+     * 内の {@code readRequestBody} が空 body を読み取り、Kaderu に空 POST が転送されて
+     * トップ画面に飛ばされる (Issue #573)。</p>
      */
     @RequestMapping("/fetch/**")
-    public ResponseEntity<byte[]> fetch(@RequestParam String token, HttpServletRequest request) {
+    public ResponseEntity<byte[]> fetch(HttpServletRequest request) {
+        String token = extractTokenFromQuery(request.getQueryString());
         return venueReservationProxyService.fetch(token, request);
+    }
+
+    /**
+     * クエリ文字列から {@code token} の値を取り出す。
+     * {@code request.getParameter*} 系メソッドはリクエストボディの parsing を誘発するので
+     * 使ってはいけない。
+     */
+    static String extractTokenFromQuery(String queryString) {
+        if (queryString == null || queryString.isBlank()) {
+            return null;
+        }
+        for (String pair : queryString.split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq < 0) {
+                continue;
+            }
+            String key = pair.substring(0, eq);
+            if ("token".equals(URLDecoder.decode(key, StandardCharsets.UTF_8))) {
+                return URLDecoder.decode(pair.substring(eq + 1), StandardCharsets.UTF_8);
+            }
+        }
+        return null;
     }
 
     @ExceptionHandler(VenueReservationProxyException.class)

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/VenueReservationProxyControllerTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/VenueReservationProxyControllerTest.java
@@ -142,9 +142,8 @@ class VenueReservationProxyControllerTest {
 
         // 会場 HTML 内の <link href> や <script src> はブラウザ自動 GET になり認可ヘッダーが付かない。
         // token があれば 200 を返すこと。
-        mockMvc.perform(get("/api/venue-reservation-proxy/fetch/kaderu27/index.php")
-                        .param("token", TOKEN)
-                        .param("p", "apply"))
+        // token はクエリ文字列に含めて渡す (controller は queryString から手動抽出するため)。
+        mockMvc.perform(get("/api/venue-reservation-proxy/fetch/kaderu27/index.php?token=" + TOKEN + "&p=apply"))
                 .andExpect(status().isOk())
                 .andExpect(header().string("X-VRP-Completed", "true"))
                 .andExpect(content().bytes(body));
@@ -162,9 +161,9 @@ class VenueReservationProxyControllerTest {
                         .contentType(MediaType.TEXT_HTML)
                         .body(body));
 
-        mockMvc.perform(post("/api/venue-reservation-proxy/fetch/kaderu27/index.php")
-                        .param("token", TOKEN)
-                        .param("p", "apply")
+        // POST 時は token をクエリ文字列で渡す。controller が parameter map (= body parsing 経由)
+        // を介さずに token を取得することで、リクエストボディが消費されないまま下流に渡る (Issue #573)。
+        mockMvc.perform(post("/api/venue-reservation-proxy/fetch/kaderu27/index.php?token=" + TOKEN + "&p=apply")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .content("name=value"))
                 .andExpect(status().isOk())
@@ -172,6 +171,29 @@ class VenueReservationProxyControllerTest {
                 .andExpect(content().bytes(body));
 
         verify(venueReservationProxyService).fetch(eq(TOKEN), any(HttpServletRequest.class));
+    }
+
+    @Test
+    @DisplayName("extractTokenFromQuery: token 値抽出のエッジケース")
+    void extractTokenFromQuery_edgeCases() {
+        org.assertj.core.api.Assertions.assertThat(VenueReservationProxyController.extractTokenFromQuery(null))
+                .isNull();
+        org.assertj.core.api.Assertions.assertThat(VenueReservationProxyController.extractTokenFromQuery(""))
+                .isNull();
+        org.assertj.core.api.Assertions.assertThat(VenueReservationProxyController.extractTokenFromQuery("token=abc"))
+                .isEqualTo("abc");
+        org.assertj.core.api.Assertions.assertThat(VenueReservationProxyController.extractTokenFromQuery("p=apply&token=abc&x=1"))
+                .isEqualTo("abc");
+        org.assertj.core.api.Assertions.assertThat(VenueReservationProxyController.extractTokenFromQuery("p=apply&x=1"))
+                .isNull();
+        org.assertj.core.api.Assertions.assertThat(VenueReservationProxyController.extractTokenFromQuery("token=a%20b"))
+                .isEqualTo("a b");
+        // 末尾区切り
+        org.assertj.core.api.Assertions.assertThat(VenueReservationProxyController.extractTokenFromQuery("token=abc&"))
+                .isEqualTo("abc");
+        // 値なし key (=なし) は無視
+        org.assertj.core.api.Assertions.assertThat(VenueReservationProxyController.extractTokenFromQuery("token&p=apply"))
+                .isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `VenueReservationProxyController.fetch()` の `@RequestParam String token` が原因で、Tomcat が form-urlencoded POST のリクエストボディをパースして parameter map に統合してしまっていた
- これにより後続の `readRequestBody()` が空 body を読み取り、Kaderu に空 POST が転送 → Kaderu はトップ画面に飛ばすという挙動になっていた
- 修正: token を `request.getQueryString()` から手動でパースする小さな関数を追加し、`@RequestParam` を排除してパラメータパースが発火しないようにする
- 既存テストは MockMvc の `.param("token", ...)` が `getQueryString()` を populate しないため URL に組み込む形に修正、新たに `extractTokenFromQuery` の単体テストを追加

## Bug
Fixes #573

## なぜこのタイミングで表面化したか
- PR #571 / #572 で CORS チェックを通せるようにしたことで初めてフォーム POST がコントローラ本体まで到達するようになった
- それ以前は CORS 拒否で controller まで来ていなかったため、本問題は埋もれていた

## Test plan
- [x] `VenueReservationProxyControllerTest` 全 pass
- [ ] 本 PR デプロイ後、かでる予約プロキシ画面で「情報を入力」ボタン押下 → Kaderu 利用情報入力画面に遷移できること
- [ ] 引き続き静的リソース (CSS, JS, image) の GET も透過されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)