### PR TITLE
test: PracticeSessionServiceTest を JST 基準に統一して UTC CI フレークを修正

### DIFF
--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeSessionServiceTest.java
@@ -19,6 +19,7 @@ import com.karuta.matchtracker.repository.PlayerRepository;
 import com.karuta.matchtracker.repository.DensukeUrlRepository;
 import com.karuta.matchtracker.repository.VenueMatchScheduleRepository;
 import com.karuta.matchtracker.repository.VenueRepository;
+import com.karuta.matchtracker.util.JstDateTimeUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -93,7 +94,11 @@ class PracticeSessionServiceTest {
 
     @BeforeEach
     void setUp() {
-        today = LocalDate.now();
+        // production コード (PracticeSessionService) は JstDateTimeUtil.today() を使うため、
+        // テスト側も JST 基準の今日を取得しないと UTC 15:00〜23:59 (= JST 0:00〜8:59) の
+        // 時間帯で日付が1日ずれ、Mockito 厳格スタブが PotentialStubbingProblem を投げる
+        // (Issue #575)。
+        today = JstDateTimeUtil.today();
         testSession = PracticeSession.builder()
                 .id(1L)
                 .sessionDate(today)


### PR DESCRIPTION
## Summary
- `PracticeSessionServiceTest.setUp()` の `today = LocalDate.now()` (= JVM デフォルト TZ) を `today = JstDateTimeUtil.today()` (= Asia/Tokyo) に置き換え
- production コード (`PracticeSessionService`) が `JstDateTimeUtil.today()` を使用しているのと揃え、UTC CI で UTC 15:00〜23:59 (= JST 0:00〜8:59) の時間帯に Mockito 厳格スタブが PotentialStubbingProblem を投げる問題を解消

## Bug
Fixes #575

## なぜ今表面化したか
PR #574 の CI が偶々 UTC 15:14 (JST 翌日 0:14) に走ったことで初めて検出された。本問題は毎日 9時間の窓で再発する深刻なフレーク。

## Test plan
- [x] ローカル (JST) で `./gradlew test --tests "com.karuta.matchtracker.service.PracticeSessionServiceTest"` 全 pass
- [ ] CI (UTC) で全テスト pass を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)