### PR TITLE
fix: かでる予約プロキシでスマホ送信時に Kaderu セッションが切れる問題

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/VenueReservationProxyService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/VenueReservationProxyService.java
@@ -98,6 +98,13 @@ public class VenueReservationProxyService {
      * プロキシは server-to-server で通信するので、これらは除去する方が会場側の通常リクエストに近い。
      * Referer をどうしても付けたい場合は、ブラウザ値ではなくサーバ側で
      * {@code currentUpstreamUrl} を改めて設定するのが安全。</p>
+     *
+     * <p>{@code user-agent} はサーバ側ログインから申込トレイ準備、ユーザのフォーム送信まで
+     * 一貫した値を会場サイトに見せるために除去する。Kaderu はセッションを UA に紐付けて
+     * 検証するため、サーバ側 (Chrome デスクトップ UA) で確立したセッションに
+     * Mobile Safari など別 UA で POST すると Kaderu がセッションを無効化してログイン画面に
+     * 飛ばす (Issue #577)。除去すると HttpClient が {@code setUserAgent} で設定済みの
+     * Chrome デスクトップ UA をデフォルトとして使うため、UA がブレなくなる。</p>
      */
     private static final Set<String> REQUEST_HEADERS_SKIP = Set.of(
             "host",
@@ -111,7 +118,8 @@ public class VenueReservationProxyService {
             "sec-fetch-site",
             "sec-fetch-mode",
             "sec-fetch-dest",
-            "sec-fetch-user"
+            "sec-fetch-user",
+            "user-agent"
     );
 
     private static final Set<String> RESPONSE_HEADERS_SKIP = Set.of(

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/VenueReservationProxyServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/proxy/VenueReservationProxyServiceTest.java
@@ -376,6 +376,14 @@ class VenueReservationProxyServiceTest {
             request.addHeader("Sec-Fetch-Mode", "cors");
             request.addHeader("Sec-Fetch-Dest", "empty");
             request.addHeader("Sec-Fetch-User", "?1");
+            // ユーザのブラウザ UA は upstream に転送しない (Issue #577)。
+            // Kaderu はセッションを UA に紐付けて検証するため、サーバ側 Chrome デスクトップ UA で
+            // 確立したセッションに Mobile Safari の UA で POST すると Kaderu はセッションを
+            // 無効化してログイン画面に飛ばす。HttpClient の setUserAgent デフォルトに任せる。
+            request.addHeader("User-Agent",
+                    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) "
+                            + "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+                            + "Version/17.5 Mobile/15E148 Safari/604.1");
 
             ResponseEntity<byte[]> response = service.fetch(TOKEN, request);
 
@@ -397,6 +405,9 @@ class VenueReservationProxyServiceTest {
             assertThat(proxied.getFirstHeader("Sec-Fetch-Mode")).isNull();
             assertThat(proxied.getFirstHeader("Sec-Fetch-Dest")).isNull();
             assertThat(proxied.getFirstHeader("Sec-Fetch-User")).isNull();
+            assertThat(proxied.getFirstHeader("User-Agent"))
+                    .as("ユーザの UA は upstream に転送しない (Issue #577)")
+                    .isNull();
             assertThat(proxied).isInstanceOf(HttpEntityEnclosingRequest.class);
             String proxiedBody = EntityUtils.toString(
                     ((HttpEntityEnclosingRequest) proxied).getEntity(),


### PR DESCRIPTION
## Summary
- Kaderu の PHP がセッションを User-Agent と紐付けて検証している
- サーバ側は Chrome デスクトップ UA でログイン → 申込トレイ準備
- ユーザのフォーム送信時 proxy がブラウザの UA (iOS Safari など) をそのまま upstream に転送 → Kaderu が「別クライアント」と判定 → セッション無効化 → ログイン画面に強制送還
- `VenueReservationProxyService.REQUEST_HEADERS_SKIP` に `"user-agent"` を追加し、HttpClient のデフォルト UA (= サーバ側ログインで使った Chrome デスクトップ UA) で upstream に届けるように修正
- Mock を使った既存テストに UA 転送拒否の検証を追加

## Bug
Fixes #577

## 検証
本番に対して同一 token で UA だけ変えて POST した結果:
- Chrome デスクトップ UA → 申込トレイ HTML (`<form name="forma">`、`<input type="submit" name="applyBtn"...>`)
- iOS Safari UA → ログイン画面 HTML (`<input type="text" name="loginID">`、`<input type="password" name="loginPwd">`)

修正後はブラウザ UA が転送されないため、両ケースで同じ Chrome デスクトップ UA が Kaderu に届く。

## Test plan
- [x] `VenueReservationProxyServiceTest` 全 pass
- [ ] 本 PR デプロイ後、iOS Safari 等のスマホブラウザでもプロキシ画面の「情報を入力」が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)