### PR TITLE
fix(venue-reservation-proxy): 申込トレイの確定→トップ戻り問題の診断ログ追加 + ヘッダ skip 拡張

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/VenueReservationProxyService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/proxy/VenueReservationProxyService.java
@@ -99,12 +99,19 @@ public class VenueReservationProxyService {
      * Referer をどうしても付けたい場合は、ブラウザ値ではなくサーバ側で
      * {@code currentUpstreamUrl} を改めて設定するのが安全。</p>
      *
-     * <p>{@code user-agent} はサーバ側ログインから申込トレイ準備、ユーザのフォーム送信まで
-     * 一貫した値を会場サイトに見せるために除去する。Kaderu はセッションを UA に紐付けて
-     * 検証するため、サーバ側 (Chrome デスクトップ UA) で確立したセッションに
-     * Mobile Safari など別 UA で POST すると Kaderu がセッションを無効化してログイン画面に
-     * 飛ばす (Issue #577)。除去すると HttpClient が {@code setUserAgent} で設定済みの
-     * Chrome デスクトップ UA をデフォルトとして使うため、UA がブレなくなる。</p>
+     * <p>{@code user-agent} / {@code sec-ch-ua-*} はサーバ側ログインから申込トレイ準備、
+     * ユーザのフォーム送信まで一貫したクライアント情報を会場サイトに見せるために除去する。
+     * Kaderu はセッションを UA に紐付けて検証するため、サーバ側 (Chrome デスクトップ UA) で
+     * 確立したセッションに Mobile Safari など別 UA で POST すると Kaderu がセッションを
+     * 無効化してログイン画面に飛ばす (Issue #577)。除去すると HttpClient が
+     * {@code setUserAgent} で設定済みの Chrome デスクトップ UA をデフォルトとして使うため、
+     * UA がブレなくなる。Chromium 系ブラウザは {@code Sec-CH-UA-*} (Client Hints) で
+     * モバイル/プラットフォームを別経路で開示するため、これらも合わせて除去する (Issue #579)。</p>
+     *
+     * <p>{@code cache-control} / {@code pragma} / {@code if-modified-since} / {@code if-none-match}
+     * は条件付きリクエスト系ヘッダで、ブラウザ側の状態 (戻る/進むナビゲーションキャッシュ等)
+     * に依存して値が変動する。会場サイトに送ると 304 Not Modified が返ってきたり、
+     * セッション状態と矛盾するキャッシュ判定が行われる可能性があるため除去する。</p>
      */
     private static final Set<String> REQUEST_HEADERS_SKIP = Set.of(
             "host",
@@ -119,7 +126,23 @@ public class VenueReservationProxyService {
             "sec-fetch-mode",
             "sec-fetch-dest",
             "sec-fetch-user",
-            "user-agent"
+            "user-agent",
+            "sec-ch-ua",
+            "sec-ch-ua-mobile",
+            "sec-ch-ua-platform",
+            "sec-ch-ua-platform-version",
+            "sec-ch-ua-arch",
+            "sec-ch-ua-bitness",
+            "sec-ch-ua-full-version",
+            "sec-ch-ua-full-version-list",
+            "sec-ch-ua-model",
+            "sec-ch-ua-wow64",
+            "cache-control",
+            "pragma",
+            "if-modified-since",
+            "if-none-match",
+            "save-data",
+            "dnt"
     );
 
     private static final Set<String> RESPONSE_HEADERS_SKIP = Set.of(
@@ -297,9 +320,18 @@ public class VenueReservationProxyService {
 
         HttpUriRequest upstreamRequest = buildUpstreamRequest(request, venueConfig);
 
+        // 申込トレイの確定 POST が Kaderu トップページに redirect されるバグ (Issue #579)
+        // の原因切り分けのため、fetch のリクエスト/レスポンス概要を INFO で記録する。
+        // 申込フローの所要時間中だけ流れるログ量なので運用負荷は許容範囲。
+        // 根本原因が判明したら DEBUG に戻すことを検討する。
+        long startNanos = System.nanoTime();
+        logUpstreamRequest(session, request, upstreamRequest);
         try (CloseableHttpResponse upstreamResponse =
                      clientFor(venue).fetch(session, upstreamRequest)) {
-            return toResponseEntity(session, venueConfig, rewriteStrategy, upstreamRequest, upstreamResponse);
+            ResponseEntity<byte[]> response = toResponseEntity(
+                    session, venueConfig, rewriteStrategy, upstreamRequest, upstreamResponse);
+            logUpstreamResponse(session, upstreamRequest, upstreamResponse, response, startNanos);
+            return response;
         } catch (IOException e) {
             throw new VenueReservationProxyException(
                     VenueReservationProxyException.SCRIPT_ERROR,
@@ -307,6 +339,64 @@ public class VenueReservationProxyService {
                     "Failed to read venue response",
                     e);
         }
+    }
+
+    private static void logUpstreamRequest(ProxySession session, HttpServletRequest request,
+                                           HttpUriRequest upstreamRequest) {
+        String contentType = request.getContentType();
+        long contentLength = request.getContentLengthLong();
+        log.info("VRP fetch upstream request: token={} venue={} method={} url={} contentType={} contentLength={}",
+                tokenPrefix(session.getToken()),
+                session.getVenue(),
+                upstreamRequest.getMethod(),
+                upstreamRequest.getURI(),
+                contentType,
+                contentLength);
+    }
+
+    private static void logUpstreamResponse(ProxySession session,
+                                            HttpUriRequest upstreamRequest,
+                                            HttpResponse upstreamResponse,
+                                            ResponseEntity<byte[]> response,
+                                            long startNanos) {
+        int status = upstreamResponse.getStatusLine() == null
+                ? -1 : upstreamResponse.getStatusLine().getStatusCode();
+        String location = firstHeaderValue(upstreamResponse, HttpHeaders.LOCATION);
+        String contentType = firstHeaderValue(upstreamResponse, HttpHeaders.CONTENT_TYPE);
+        boolean completed = "true".equalsIgnoreCase(response.getHeaders().getFirst(COMPLETED_HEADER));
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+        int bodySize = response.getBody() == null ? 0 : response.getBody().length;
+        // 完了検知なしで 3xx が返ったらトップ戻り疑いのため WARN レベルで強調する。
+        boolean redirectSuspect = !completed && status >= 300 && status < 400;
+        if (redirectSuspect) {
+            log.warn("VRP fetch upstream redirect (likely top-page bounce): token={} venue={} method={} url={} status={} location={} contentType={} bodyBytes={} elapsedMs={}",
+                    tokenPrefix(session.getToken()),
+                    session.getVenue(),
+                    upstreamRequest.getMethod(),
+                    upstreamRequest.getURI(),
+                    status,
+                    location,
+                    contentType,
+                    bodySize,
+                    elapsedMs);
+        } else {
+            log.info("VRP fetch upstream response: token={} venue={} method={} url={} status={} location={} contentType={} bodyBytes={} completed={} elapsedMs={}",
+                    tokenPrefix(session.getToken()),
+                    session.getVenue(),
+                    upstreamRequest.getMethod(),
+                    upstreamRequest.getURI(),
+                    status,
+                    location,
+                    contentType,
+                    bodySize,
+                    completed,
+                    elapsedMs);
+        }
+    }
+
+    private static String tokenPrefix(String token) {
+        if (token == null) return "null";
+        return token.length() > 8 ? token.substring(0, 8) : token;
     }
 
     private ResponseEntity<byte[]> toResponseEntity(ProxySession session,


### PR DESCRIPTION
## Summary

- かでる申込トレイの「確定」ボタン押下時に Kaderu トップページへ戻される問題 (Issue #579) の対応。
- PR #574 (POST body) / #578 (User-Agent) のマージ後も再現するため、以下 2 点で対応する:
  - `/fetch/**` のリクエスト/レスポンス概要を INFO ログに出すことでログから根本原因を切り分け可能に
  - Chromium 系ブラウザの `Sec-CH-UA-*` (Client Hints) と Cache 系ヘッダを上流転送スキップ対象に追加

## Bug

Fixes #579

## 実装の意図

### 1. 診断ログ
現状 `/fetch/**` には INFO ログがなく、利用者の確定ボタン押下時にサーバ側で何が起きたか追えない。本 PR で以下を記録する。

**INFO (通常時)**
```
VRP fetch upstream request:  token=… method=POST url=…/index.php contentType=application/x-www-form-urlencoded contentLength=123
VRP fetch upstream response: token=… status=200 location=null contentType=text/html bodyBytes=10000 completed=false elapsedMs=350
```

**WARN (完了検知なしで 3xx 応答が返ったとき)**
```
VRP fetch upstream redirect (likely top-page bounce): token=… status=302 location=…/index.php …
```

これで「ブラウザから来たリクエストの body が空か」「Kaderu が 302 で何処に飛ばしているか」を一発で確認できる。

### 2. 追加スキップヘッダ

| ヘッダ | 理由 |
|--------|-----|
| `Sec-CH-UA`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Full-Version-List`, `Sec-CH-UA-Model`, `Sec-CH-UA-Wow64` | Chrome の Client Hints。User-Agent を統一しても `Sec-CH-UA-Mobile=?1` 等で別経路でモバイルがバレてセッション無効化される可能性を塞ぐ。Issue #577 の延長線。 |
| `Cache-Control`, `Pragma`, `If-Modified-Since`, `If-None-Match` | 戻る/進むナビゲーションで変動するキャッシュ系。上流に渡すと 304 が返ったりキャッシュ判定で挙動がブレる。 |
| `Save-Data`, `DNT` | 同種のクライアント状態依存ヘッダ。 |

これは **#578 のディフェンシブな延長** で、これ単体で原因が確定するわけではない。本命は (1) のログから決定する。

## Test plan

- [ ] Render デプロイ完了を確認
- [ ] スマホで実機再現してもらい、Render の app log で以下を確認:
  - 利用者の `/fetch/**` リクエストが届いているか (= ブラウザ→サーバの経路が正常か)
  - 「確定」押下時の status / location / bodyBytes
  - 上記 WARN ログが出るか
- [ ] ログから根本原因を特定し、必要なら追加 PR で修正

## 既存テストへの影響

`REQUEST_HEADERS_SKIP` の拡張のみで挙動破壊はなし (skip 対象が増える方向)。既存ロジックは無変更。診断ログは新規追加のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)