### PR TITLE
fix(waitlist): キャンセル待ち機能（伝助/アプリ/LINE通知横断）改修 9件 (#589)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1438,7 +1438,7 @@ Entity Layer (JPA Entity)
 
 #### POST /api/lottery/decline-waitlist
 **説明**: キャンセル待ち辞退（セッション単位）。辞退後、後続のキャンセル待ち番号を自動繰り上げ。
-**権限**: SUPER_ADMIN, ADMIN, PLAYER（PLAYERは自分のみ）
+**権限**: SUPER_ADMIN, ADMIN, PLAYER（PLAYERは自分のみ。ADMINは自団体セッションのみ — `AdminScopeValidator` で検証、不一致は 403）
 **リクエスト**:
 ```json
 { "sessionId": 100, "playerId": 10 }
@@ -1450,7 +1450,7 @@ Entity Layer (JPA Entity)
 
 #### POST /api/lottery/rejoin-waitlist
 **説明**: キャンセル待ち復帰（セッション単位）。復帰時のキャンセル待ち番号は最後尾。
-**権限**: SUPER_ADMIN, ADMIN, PLAYER（PLAYERは自分のみ）
+**権限**: SUPER_ADMIN, ADMIN, PLAYER（PLAYERは自分のみ。ADMINは自団体セッションのみ — `AdminScopeValidator` で検証、不一致は 403）
 **リクエスト**:
 ```json
 { "sessionId": 100, "playerId": 10 }
@@ -1461,7 +1461,7 @@ Entity Layer (JPA Entity)
 ```
 
 #### PUT /api/lottery/admin/edit-participants
-**説明**: 管理者による参加者手動編集。WON→CANCELLEDへのステータス変更時は繰り上げフローが自動発動（当日は除く）。
+**説明**: 管理者による参加者手動編集。WON→CANCELLED へのステータス変更時は通常キャンセル経路（`/api/lottery/cancel`）の `cancelParticipationSuppressed` に委譲し、当日12:00を境界に通常繰り上げ／当日補充フローへ自動分岐する。
 **権限**: SUPER_ADMIN, ADMIN
 **リクエスト**: `AdminEditParticipantsRequest`
 
@@ -2329,14 +2329,15 @@ Entity Layer (JPA Entity)
    - 通知トグル: sameDayConfirmation
 
 [当日キャンセル→補充フェーズ — WaitlistPromotionService.cancelParticipation() / dispatchSameDayCancelNotifications()]
-1. 12:00以降にWON参加者がキャンセル
+1. 12:00以降にWON参加者がキャンセル（管理者手動編集 `editParticipants` 経由を含む）
    ↓
 2. LotteryDeadlineHelper.isAfterSameDayNoon() で12:00以降判定
    ↓
 3. cancelParticipationInternal が SameDayCancelContext 付き AdminWaitlistNotificationData を返却
    ↓
-4. 呼び出し元（LotteryController / DensukeImportService / cancelParticipation 単体版）で
+4. 呼び出し元（LotteryController / DensukeImportService / LotteryService.editParticipants）で
    (sessionId, playerId) 単位に集約し、afterCommit で handleSameDayCancelAndRecruitBatch を実行
+   - editParticipants は `cancelParticipationSuppressed` に委譲し、通常キャンセル経路と同じ三分岐ロジックに揃える（WON→CANCELLED 直書き経路は廃止）
    ↓
 5. キャンセル発生通知（統合版）: 「〇〇さんが今日の1、3試合目をキャンセルしました」
    - 同一セッション×同一プレイヤーの複数試合は1通にまとまる（通知トグル: sameDayCancel）
@@ -2348,6 +2349,17 @@ Entity Layer (JPA Entity)
    ↓
 7. 管理者通知: sendBatchedAdminWaitlistNotifications
    - セッション単位で1通にまとまる
+
+【トランザクション境界の契約】
+WaitlistPromotionService の `*Suppressed` 系メソッド（`cancelParticipationSuppressed` /
+`respondToOfferDeclineSuppressed` / `expireOfferSuppressed` / `demoteToWaitlistSuppressed`）は
+`@Transactional`（伝播 `REQUIRED`）で宣言されているが、個別コミットは保証しない：
+- `DensukeImportService` / `LotteryService.editParticipants` などインポート/編集TX配下から
+  呼ぶ場合、上流TXに参加して整合性を保つ（失敗時はキャンセル含めロールバック）
+- ループ内で1件ずつコミットしたい呼び出し元（`LotteryController#cancelParticipation` など）は
+  呼び出し元側に `@Transactional` を付けてはならない。付与するとループ全件が単一TXに化け、
+  途中の例外で全件ロールバックされる
+- `LotteryControllerCancelTest` にメソッド単位 `@Transactional` 不在のセンチネルテストあり
 
 [先着参加フェーズ — LINEボタン or アプリ]
 1. LINEボタンpostback → LineWebhookController（same_day_joinアクション）

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -524,7 +524,10 @@ SUPER_ADMIN のみ操作可能。
 - **応答期限**: min(通知から24時間, 練習日前日23:59) の早い方。期限超過後の応答はバックエンドで拒否される
 - **短期限オファー注意喚起**: 応答期限まで12時間未満の場合、LINE・アプリ内通知に「※ 応答期限まで残りわずかです。お早めにご回答ください。」を付加
 - **タイムゾーン**: 全ての日時判定（期限チェック、当日判定、タイムスタンプ記録）はJST（Asia/Tokyo）で統一。`JstDateTimeUtil` ユーティリティクラスにより、サーバーのデフォルトタイムゾーンに依存しない
-- **管理者手動編集時の繰り上げ**: `editParticipants` で WON→CANCELLED にステータス変更した場合、当日でなければ自動的に繰り上げフローが発動
+- **管理者手動編集時のキャンセル動作**: `editParticipants` で WON→CANCELLED にステータス変更した場合、通常キャンセル経路（`/api/lottery/cancel`）と同じ三分岐ロジックに揃える：
+  - 当日でない / 当日12:00前 → 通常繰り上げ + 管理者バッチ通知 + プレイヤー向けオファー統合通知
+  - 当日12:00以降 → `SameDayCancelContext` 経由で当日補充フロー（キャンセル発生通知 + 空き募集通知 + 管理者通知）が `afterCommit` 登録される
+- **キャンセル待ち辞退/復帰の団体スコープ**: `POST /api/lottery/decline-waitlist` `POST /api/lottery/rejoin-waitlist` は ADMIN ロールに対し対象セッションの `organizationId` 一致を強制（`AdminScopeValidator`）。SUPER_ADMIN は全団体可、PLAYER は自己のみ可
 
 #### 3.7.3 抽選関連エンティティ
 

--- a/docs/features/waitlist-cross-channel-fixes/fix-implementation-plan.md
+++ b/docs/features/waitlist-cross-channel-fixes/fix-implementation-plan.md
@@ -17,7 +17,7 @@ status: completed
 ---
 
 ### タスク2: `getWaitlistStatus` のN+1解消（[#5]）
-- [ ] 完了
+- [x] 完了
 - **概要:** `LotteryController.getWaitlistStatus` で各 participant ごとに `findById` していた `practiceSessionRepository` 呼び出しを `findAllById(sessionIds)` の1回にまとめる。
 - **変更対象ファイル:**
   - `karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java` — `getWaitlistStatus` を `Set<Long>` 抽出 → `findAllById` → `Map<Long, PracticeSession>` 化 → ループ参照に変更
@@ -27,7 +27,7 @@ status: completed
 ---
 
 ### タスク3: `renumberRemainingWaitlist` の `saveAll` 化（[#6]）
-- [ ] 完了
+- [x] 完了
 - **概要:** 個別 `save()` ループを `saveAll` に置換する。Hibernate のバッチ更新設定（`hibernate.jdbc.batch_size` および `order_updates`）も確認し、未設定なら `application.yml` に追加する。
 - **変更対象ファイル:**
   - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java` — `renumberRemainingWaitlist` 内で番号差分があるレコードを `dirtyList` に蓄積し、ループ後に `practiceParticipantRepository.saveAll(dirtyList)` を1回呼ぶ
@@ -38,7 +38,7 @@ status: completed
 ---
 
 ### タスク4: `*Suppressed` 系メソッドのトランザクション境界をJavadocで明記（[#3]）
-- [ ] 完了
+- [x] 完了
 - **概要:** `cancelParticipationSuppressed` / `respondToOfferDeclineSuppressed` / `expireOfferSuppressed` / `demoteToWaitlistSuppressed` の Javadoc に「呼び出し元のTX境界を引き継ぐ（個別コミットには非依存）」「個別コミットが必要な場合は呼び出し元側で `@Transactional` を付けないこと」を明記する。`LotteryController.cancelParticipation` のコメントも、なぜこのメソッドに `@Transactional` を付けてはならないかを補足する形に書き換える。
 - **変更対象ファイル:**
   - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java` — 4メソッドの Javadoc 更新
@@ -49,7 +49,7 @@ status: completed
 ---
 
 ### タスク5: `LotteryController.cancelParticipation` の個別TX保証テスト追加（[#3]）
-- [ ] 完了
+- [x] 完了
 - **概要:** 複数 participantId のうち1件で例外が発生しても他のキャンセルが確定（個別コミット）することを検証する統合テストを追加。これにより上流に `@Transactional` が誤って付与された場合に CI で検出できる。
 - **変更対象ファイル:**
   - `karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LotteryControllerCancelTest.java` — 既存テストに「3件中1件で例外 → 残り2件は CANCELLED に確定」のケースを追加
@@ -59,7 +59,7 @@ status: completed
 ---
 
 ### タスク6: `editParticipants` の WON→CANCELLED を `cancelParticipationSuppressed` 委譲に変更（[#1]）
-- [ ] 完了
+- [x] 完了
 - **概要:** `LotteryService.editParticipants` 内の `statusChanges` ループで、WON→CANCELLED の場合に既存の独自実装（直接 `setStatus` + `promoteNextWaitlisted` + `!isToday` ガード）を撤去し、`waitlistPromotionService.cancelParticipationSuppressed(participantId, null, null)` を呼び出す形に置き換える。返り値の `AdminWaitlistNotificationData` を蓄積し、`dispatchSameDayCancelNotifications` で当日分を分離してから、残った通常分を `sendBatchedAdminWaitlistNotifications` + プレイヤー向け統合通知でディスパッチする。
 - **変更対象ファイル:**
   - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/LotteryService.java` — `editParticipants` の `statusChanges` ループ内の WON→CANCELLED 分岐を書き換え。`!isToday` ガードを撤去。当日12:00以降の `SameDayCancelContext` は `dispatchSameDayCancelNotifications` 内で afterCommit 登録される
@@ -69,7 +69,7 @@ status: completed
 ---
 
 ### タスク7: `editParticipants` の当日分岐テスト追加（[#1]）
-- [ ] 完了
+- [x] 完了
 - **概要:** `editParticipants` の WON→CANCELLED について以下3ケースをカバーするテストを追加：
   - (a) 当日でないセッション → 通常繰り上げが発動
   - (b) 当日12:00前 → 通常繰り上げが発動
@@ -82,7 +82,7 @@ status: completed
 ---
 
 ### タスク8: `WaitlistStatus.jsx` のエラーバナー表示（[#8]）
-- [ ] 完了
+- [x] 完了
 - **概要:** `fetchStatus` の catch 節で `error` ステートをセットし、JSX 上部にエラーバナーを表示する。
 - **変更対象ファイル:**
   - `karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx` — `useState(null)` で error ステート追加、catch でセット、JSX に `{error && <div className="bg-red-50 border border-red-200 text-red-700 p-3 rounded mb-3">{error}</div>}` を追加
@@ -92,7 +92,7 @@ status: completed
 ---
 
 ### タスク9: ドキュメント更新
-- [ ] 完了
+- [x] 完了
 - **概要:** 改修内容を以下のドキュメントに反映する。
   - `docs/SPECIFICATION.md` 3.7（抽選結果操作）に「管理者手動編集の WON→CANCELLED 時、当日12:00を境界に通常繰り上げ／当日補充フローに分岐する」旨を追記
   - `docs/SPECIFICATION.md` セキュリティ表に「`/decline-waitlist` `/rejoin-waitlist` は ADMIN 団体スコープ検証あり」を追記

--- a/docs/features/waitlist-cross-channel-fixes/fix-implementation-plan.md
+++ b/docs/features/waitlist-cross-channel-fixes/fix-implementation-plan.md
@@ -1,0 +1,120 @@
+---
+status: completed
+---
+# キャンセル待ち機能（伝助/アプリ/LINE通知横断） 改修実装手順書
+
+## 実装タスク
+
+### タスク1: `decline-waitlist` / `rejoin-waitlist` のADMIN団体スコープ検証追加（[#2]）
+- [x] 完了
+- **概要:** `LotteryController.declineWaitlist` / `rejoinWaitlist` で、ADMIN ロール時に対象セッションの `organizationId` と ADMIN の管理団体IDを `AdminScopeValidator.validateScope` で照合し、不一致なら 403 を返す。PLAYER の自己判定は現状維持。
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java` — `declineWaitlist`/`rejoinWaitlist` の冒頭で `practiceSessionRepository.findById(sessionId)` してセッション取得 → ADMIN なら `AdminScopeValidator.validateScope(role, adminOrgId, session.getOrganizationId(), "他団体のキャンセル待ちは操作できません")` を呼ぶ
+  - `karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LotteryControllerDeclineWaitlistTest.java`（新規 or 既存に追加） — ADMINが他団体セッション宛に呼んだ場合 403、自団体は 200 のテスト
+- **依存タスク:** なし
+- **対応Issue:** #590
+
+---
+
+### タスク2: `getWaitlistStatus` のN+1解消（[#5]）
+- [ ] 完了
+- **概要:** `LotteryController.getWaitlistStatus` で各 participant ごとに `findById` していた `practiceSessionRepository` 呼び出しを `findAllById(sessionIds)` の1回にまとめる。
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java` — `getWaitlistStatus` を `Set<Long>` 抽出 → `findAllById` → `Map<Long, PracticeSession>` 化 → ループ参照に変更
+- **依存タスク:** なし
+- **対応Issue:** #591
+
+---
+
+### タスク3: `renumberRemainingWaitlist` の `saveAll` 化（[#6]）
+- [ ] 完了
+- **概要:** 個別 `save()` ループを `saveAll` に置換する。Hibernate のバッチ更新設定（`hibernate.jdbc.batch_size` および `order_updates`）も確認し、未設定なら `application.yml` に追加する。
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java` — `renumberRemainingWaitlist` 内で番号差分があるレコードを `dirtyList` に蓄積し、ループ後に `practiceParticipantRepository.saveAll(dirtyList)` を1回呼ぶ
+  - `karuta-tracker/src/main/resources/application.yml` または `application-*.yml` — `spring.jpa.properties.hibernate.jdbc.batch_size: 50` および `hibernate.order_updates: true` を未設定なら追加（要既存設定確認）
+- **依存タスク:** なし
+- **対応Issue:** #592
+
+---
+
+### タスク4: `*Suppressed` 系メソッドのトランザクション境界をJavadocで明記（[#3]）
+- [ ] 完了
+- **概要:** `cancelParticipationSuppressed` / `respondToOfferDeclineSuppressed` / `expireOfferSuppressed` / `demoteToWaitlistSuppressed` の Javadoc に「呼び出し元のTX境界を引き継ぐ（個別コミットには非依存）」「個別コミットが必要な場合は呼び出し元側で `@Transactional` を付けないこと」を明記する。`LotteryController.cancelParticipation` のコメントも、なぜこのメソッドに `@Transactional` を付けてはならないかを補足する形に書き換える。
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java` — 4メソッドの Javadoc 更新
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java` — `cancelParticipation` 冒頭コメントの更新
+- **依存タスク:** なし
+- **対応Issue:** #593
+
+---
+
+### タスク5: `LotteryController.cancelParticipation` の個別TX保証テスト追加（[#3]）
+- [ ] 完了
+- **概要:** 複数 participantId のうち1件で例外が発生しても他のキャンセルが確定（個別コミット）することを検証する統合テストを追加。これにより上流に `@Transactional` が誤って付与された場合に CI で検出できる。
+- **変更対象ファイル:**
+  - `karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LotteryControllerCancelTest.java` — 既存テストに「3件中1件で例外 → 残り2件は CANCELLED に確定」のケースを追加
+- **依存タスク:** タスク4（#593）
+- **対応Issue:** #594
+
+---
+
+### タスク6: `editParticipants` の WON→CANCELLED を `cancelParticipationSuppressed` 委譲に変更（[#1]）
+- [ ] 完了
+- **概要:** `LotteryService.editParticipants` 内の `statusChanges` ループで、WON→CANCELLED の場合に既存の独自実装（直接 `setStatus` + `promoteNextWaitlisted` + `!isToday` ガード）を撤去し、`waitlistPromotionService.cancelParticipationSuppressed(participantId, null, null)` を呼び出す形に置き換える。返り値の `AdminWaitlistNotificationData` を蓄積し、`dispatchSameDayCancelNotifications` で当日分を分離してから、残った通常分を `sendBatchedAdminWaitlistNotifications` + プレイヤー向け統合通知でディスパッチする。
+- **変更対象ファイル:**
+  - `karuta-tracker/src/main/java/com/karuta/matchtracker/service/LotteryService.java` — `editParticipants` の `statusChanges` ループ内の WON→CANCELLED 分岐を書き換え。`!isToday` ガードを撤去。当日12:00以降の `SameDayCancelContext` は `dispatchSameDayCancelNotifications` 内で afterCommit 登録される
+- **依存タスク:** タスク4（#593: Javadoc更新）
+- **対応Issue:** #595
+
+---
+
+### タスク7: `editParticipants` の当日分岐テスト追加（[#1]）
+- [ ] 完了
+- **概要:** `editParticipants` の WON→CANCELLED について以下3ケースをカバーするテストを追加：
+  - (a) 当日でないセッション → 通常繰り上げが発動
+  - (b) 当日12:00前 → 通常繰り上げが発動
+  - (c) 当日12:00以降 → `SameDayCancelContext` 経由で当日補充フローが afterCommit 登録される
+- **変更対象ファイル:**
+  - `karuta-tracker/src/test/java/com/karuta/matchtracker/service/LotteryServiceEditParticipantsTest.java`（既存ファイル名は要確認）にケース追加、または `LotteryServiceTest` に追加
+- **依存タスク:** タスク6（#595）
+- **対応Issue:** #596
+
+---
+
+### タスク8: `WaitlistStatus.jsx` のエラーバナー表示（[#8]）
+- [ ] 完了
+- **概要:** `fetchStatus` の catch 節で `error` ステートをセットし、JSX 上部にエラーバナーを表示する。
+- **変更対象ファイル:**
+  - `karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx` — `useState(null)` で error ステート追加、catch でセット、JSX に `{error && <div className="bg-red-50 border border-red-200 text-red-700 p-3 rounded mb-3">{error}</div>}` を追加
+- **依存タスク:** なし
+- **対応Issue:** #597
+
+---
+
+### タスク9: ドキュメント更新
+- [ ] 完了
+- **概要:** 改修内容を以下のドキュメントに反映する。
+  - `docs/SPECIFICATION.md` 3.7（抽選結果操作）に「管理者手動編集の WON→CANCELLED 時、当日12:00を境界に通常繰り上げ／当日補充フローに分岐する」旨を追記
+  - `docs/SPECIFICATION.md` セキュリティ表に「`/decline-waitlist` `/rejoin-waitlist` は ADMIN 団体スコープ検証あり」を追記
+  - `docs/DESIGN.md` の `WaitlistPromotionService` 周辺に `cancelParticipationSuppressed` の TX境界契約を1行追記
+- **変更対象ファイル:**
+  - `docs/SPECIFICATION.md`
+  - `docs/DESIGN.md`
+- **依存タスク:** タスク1〜8（実装が確定してから記述）
+- **対応Issue:** #598
+
+---
+
+## 実装順序
+
+1. **タスク1**（独立・小規模）: ADMIN スコープ検証 → 動作確認しやすい
+2. **タスク2**（独立・小規模）: N+1解消
+3. **タスク3**（独立・小規模）: `saveAll` 化
+4. **タスク4**（独立）: Javadoc/コメント更新
+5. **タスク5**（タスク4依存）: 個別TX保証テスト追加
+6. **タスク6**（タスク4依存）: `editParticipants` 委譲リファクタ
+7. **タスク7**（タスク6依存）: 当日分岐テスト追加
+8. **タスク8**（独立・フロントエンド）: WaitlistStatus.jsx エラー表示
+9. **タスク9**（最後）: ドキュメント反映
+
+タスク1, 2, 3, 4, 8 は完全に独立しており並行実装可能。タスク5, 7 は対応するリファクタ完了後に追加。タスク9 は最後にまとめて。

--- a/docs/features/waitlist-cross-channel-fixes/fix-requirements.md
+++ b/docs/features/waitlist-cross-channel-fixes/fix-requirements.md
@@ -1,0 +1,245 @@
+---
+status: completed
+audit_source: 会話内レポート（2026-04-27 /audit-feature キャンセル待ち機能）
+selected_items: [1, 2, 3, 5, 6, 8]
+---
+
+# キャンセル待ち機能（伝助/アプリ/LINE通知横断） 改修要件定義書
+
+## 1. 改修概要
+
+### 対象機能
+キャンセル待ち（`WAITLISTED`/`OFFERED`）に関わる以下の一連のフロー：
+- アプリ・伝助・LINE postback 経由のキャンセル → 繰り上げオファー
+- 当日12:00確定／12:00以降キャンセル補充フロー
+- キャンセル待ち辞退／復帰
+- オファー応答（承諾／辞退／期限切れ）
+
+### 改修の背景
+2026-04-27 の `/audit-feature` 監査で、複数チャネルにまたがる本機能について12件の懸念事項を検出。うち高優先度3件（バグ・セキュリティ）と中優先度3件（パフォーマンス・UX）を本改修のスコープとする。
+
+### 改修スコープ
+監査レポート推奨アクション #1, #2, #3, #5, #6, #8 の6件。
+
+| # | 監査優先度 | 概要 | 種別 |
+|---|---|---|---|
+| 1 | 高 | `LotteryService.editParticipants` の当日キャンセル分岐を統一 | bug |
+| 2 | 高 | `decline-waitlist`/`rejoin-waitlist` の ADMIN 団体スコープ検証 | bug（セキュリティ） |
+| 3 | 高 | `*Suppressed` 系メソッドのトランザクション境界の明確化 | improvement |
+| 5 | 中 | `getWaitlistStatus` の N+1 解消 | improvement |
+| 6 | 中 | `renumberRemainingWaitlist` の `saveAll` 化 | improvement |
+| 8 | 中 | `WaitlistStatus.jsx` の fetch エラー表示 | improvement |
+
+スコープ外（別タスク扱い）：#4（ドキュメント整理）、#7（大規模リファクタ）、#9〜#12（緊急性低）。
+
+---
+
+## 2. 改修内容
+
+### 2.1 [#1] `editParticipants` の当日 WON→CANCELLED ロジック整合性
+
+**現状の問題:**
+[LotteryService.java:1010](karuta-tracker/src/main/java/com/karuta/matchtracker/service/LotteryService.java#L1010) の管理者手動編集経路で、WON→CANCELLED 時に「当日全体（午前午後問わず）」を繰り上げ対象から除外している：
+```java
+if (session != null && !lotteryDeadlineHelper.isToday(session.getSessionDate())) {
+    // 繰り上げ発動
+}
+```
+一方、通常キャンセル経路 [WaitlistPromotionService.cancelParticipationInternal:233](karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java#L233) は `isAfterSameDayNoon()` で12:00を境界に分岐し、午前は通常繰り上げ、12:00以降は当日補充フロー（`SameDayCancelContext`）を起動する。
+
+結果、**管理者が当日午前中に WON→CANCELLED 編集すると繰り上げが発動せず、12:00以降に編集すると当日補充通知も飛ばない**という静かな不具合がある。
+
+**修正方針:**
+`editParticipants` の WON→CANCELLED 分岐を、通常キャンセル経路と同じ三分岐ロジックに揃える。実装方法は2案：
+
+- **案A（推奨）**: `editParticipants` から既存の `cancelParticipationSuppressed(participantId, null, null)` を呼び出して通知データを取得し、`dispatchSameDayCancelNotifications` に流す。当日12:00分岐・通常繰り上げ分岐・通知集約の全てが共通化される。
+- 案B: `editParticipants` 内で `isAfterSameDayNoon` を判定し、当日12:00以降は `registerSameDayCancelAfterCommit` を呼び、それ以前は現状通り `promoteNextWaitlisted` を呼ぶ。
+
+採用：**案A**。理由は監査レポート 5b の指摘通り、通知集約パターンを一本化することで重複ロジックを削減できるため。`editParticipants` 内で重複していた `setStatus(CANCELLED)` / `setDirty(true)` / `save` の3行も内部実装に委ねられる。
+
+**修正後のあるべき姿:**
+- 当日午前のキャンセル → 通常繰り上げ + 管理者バッチ通知 + プレイヤー向けオファー統合通知
+- 当日12:00以降のキャンセル → `SameDayCancelContext` を介した当日補充フロー（キャンセル発生通知 + 空き募集通知 + 管理者通知）
+- 当日以外のキャンセル → 通常繰り上げ + 管理者バッチ通知 + プレイヤー向けオファー統合通知
+
+---
+
+### 2.2 [#2] `decline-waitlist` / `rejoin-waitlist` の ADMIN 団体スコープ検証
+
+**現状の問題:**
+[LotteryController.java:534](karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java#L534) `declineWaitlist` および同557 `rejoinWaitlist` は `body.get("playerId")` を信用しており、ADMIN/SUPER_ADMIN は他団体のプレイヤーのキャンセル待ちを操作できる。PLAYERは自分のみに制限されているが、ADMIN は無制限。`AdminScopeValidator` パターンが他エンドポイント（`/monthly-applicants` など）で適用されているのに、ここだけ抜けている。
+
+**修正方針:**
+両エンドポイントで以下を実施：
+1. `sessionId` から `PracticeSession` を取得
+2. `session.getOrganizationId()` を ADMIN の管理団体IDと照合
+3. ADMIN の場合のみ `AdminScopeValidator.validateScope(role, adminOrgId, session.getOrganizationId(), "他団体のキャンセル待ちは操作できません")` を呼ぶ
+4. SUPER_ADMIN は従来通り全団体OK
+5. PLAYER は従来通り `playerId == currentUserId` チェックを残す
+
+**修正後のあるべき姿:**
+ADMIN は自団体のセッションに対する `decline-waitlist` / `rejoin-waitlist` のみ実行可能。他団体セッションには `403 ForbiddenException`。
+
+---
+
+### 2.3 [#3] `*Suppressed` 系メソッドのトランザクション境界の明確化
+
+**現状の問題:**
+[LotteryController.java:292](karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java#L292) のコメントは「`cancelParticipationSuppressed` は個別 TX でコミットされる」と謳う。実装上 `cancelParticipationSuppressed` は `@Transactional`（デフォルト=`REQUIRED`）で、コントローラ自体は `@Transactional` 無しのため、結果的に1呼び出し1TXとなり**現状は意図通り動作**している。
+
+ただし上流（コントローラまたは他の呼び出し元）に `@Transactional` が後から追加された瞬間、`REQUIRED` は既存TXに参加するため**ループ全件が単一TXに化け、途中で例外が出ると全件ロールバック**する。コメントの想定が崩れる潜在バグ。
+
+なお同種の `*Suppressed` メソッドは `DensukeImportService`（`@Transactional` 配下）からも呼ばれており、こちらは**意図的にインポートTXに参加させて整合性を保っている**（インポート失敗時はキャンセル含めロールバック）。`REQUIRES_NEW` への一律変更は伝助同期の整合性を破壊するためNG。
+
+**修正方針:**
+`@Transactional` の伝播種別を一律で変えるのではなく、**呼び出し元の契約を契約として明示する**：
+
+1. `LotteryController.cancelParticipation` のコメントを更新し、「このメソッドに `@Transactional` を付けてはならない理由」を明記する。
+2. `WaitlistPromotionService` の `cancelParticipationSuppressed` / `respondToOfferDeclineSuppressed` / `expireOfferSuppressed` / `demoteToWaitlistSuppressed` の Javadoc に、「呼び出し元のTX境界を引き継ぐ（個別コミットには非依存）」「個別コミットが必要な場合は呼び出し元側で `@Transactional` を付けないこと」を明記する。
+3. `LotteryController.cancelParticipation` の単体テストとして、複数 participantId のうち1件で例外が起きても他のキャンセルは確定する（個別TX）ことを検証する統合テストを追加する。これにより上流に `@Transactional` を付与した場合の意図せぬ挙動変更が CI で検出される。
+
+**修正後のあるべき姿:**
+- メソッドの契約と実装の意図がコメントで一致
+- 上流に `@Transactional` を不用意に付けた場合、テストが失敗して気付ける
+
+---
+
+### 2.4 [#5] `getWaitlistStatus` の N+1 解消
+
+**現状の問題:**
+[LotteryController.java:499-527](karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java#L499-L527) `getWaitlistStatus` で、プレイヤーの WAITLISTED/OFFERED 件数ぶん `practiceSessionRepository.findById(p.getSessionId())` を発行している。10件待ちなら10回SELECT。
+
+**修正方針:**
+1. `waitlisted` から `sessionId` の集合を抽出
+2. `practiceSessionRepository.findAllById(sessionIds)` で一括取得（Spring Data JPA 標準メソッド）
+3. `Map<Long, PracticeSession>` に詰めて `entries` ループで参照
+
+`PracticeSessionRepository` には `findAllById` が `JpaRepository` 経由で既に存在するため新規メソッド追加不要。
+
+**修正後のあるべき姿:**
+セッション件数Nに対し、SELECT は2回（参加者一覧 + セッション一括）に固定される。
+
+---
+
+### 2.5 [#6] `renumberRemainingWaitlist` の `saveAll` 化
+
+**現状の問題:**
+[WaitlistPromotionService.java:1390-1402](karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java#L1390-L1402) で WAITLISTED/OFFERED の番号差分があるレコードを個別に `save()` ループ呼び出ししている。容量拡張時など大量再採番でN回UPDATEが発行される。
+
+**修正方針:**
+1. ループで番号変更が必要なレコードを `List<PracticeParticipant> dirtyList` に蓄積
+2. ループ後に `practiceParticipantRepository.saveAll(dirtyList)` で1回だけバッチ保存
+
+`saveAll` は内部的にループするが、Hibernate のバッチ更新設定（`hibernate.jdbc.batch_size`）が有効ならまとめてフラッシュされる。設定確認は調査タスクに含める。
+
+**修正後のあるべき姿:**
+番号変更件数Nに対し、`save()` 呼び出しは1回（`saveAll`）に集約される。
+
+---
+
+### 2.6 [#8] `WaitlistStatus.jsx` の fetch エラー表示
+
+**現状の問題:**
+[WaitlistStatus.jsx:14-28](karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx#L14-L28) の `fetchStatus()` は API エラー時 `console.error` のみで `setEntries([])` のまま。ユーザーには「キャンセル待ちはありません」と表示され、500エラーで誤認する。
+
+**修正方針:**
+1. `error` ステートを追加（`useState(null)`）
+2. catch 節で `setError('キャンセル待ち情報の取得に失敗しました。時間をおいて再度お試しください。')` をセット
+3. JSX で `{error && <div className="bg-red-50 border border-red-200 text-red-700 p-3 rounded mb-3">{error}</div>}` を表示
+4. 再試行ボタン（任意）はスコープ外
+
+**修正後のあるべき姿:**
+500エラー時、画面上部に赤色のエラーバナーが表示され、ユーザーが状態を正しく認識できる。
+
+---
+
+## 3. 技術設計
+
+### 3.1 API 変更
+**新規エンドポイント:** なし
+**既存エンドポイントの変更:** なし（戻り値・リクエスト形式とも変更なし）
+**振る舞い変更:**
+- `PUT /api/lottery/admin/edit-participants`: 当日キャンセル時の通知が発火するようになる（従来は無音）
+- `POST /api/lottery/decline-waitlist` `POST /api/lottery/rejoin-waitlist`: ADMIN が他団体プレイヤーを操作した場合 `403` を返す
+
+### 3.2 DB 変更
+なし。
+
+### 3.3 フロントエンド変更
+| ファイル | 変更内容 |
+|---|---|
+| [karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx](karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx) | `error` ステート追加、catch 節でエラーメッセージ設定、JSX にエラーバナー表示を追加 |
+
+### 3.4 バックエンド変更
+| ファイル | 変更内容 |
+|---|---|
+| [karuta-tracker/src/main/java/com/karuta/matchtracker/service/LotteryService.java](karuta-tracker/src/main/java/com/karuta/matchtracker/service/LotteryService.java) | `editParticipants` 内の WON→CANCELLED 処理を `waitlistPromotionService.cancelParticipationSuppressed` 委譲に変更し、通知集約は `dispatchSameDayCancelNotifications` 経由でディスパッチ |
+| [karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java](karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java) | `declineWaitlist`/`rejoinWaitlist` に `AdminScopeValidator.validateScope` 追加。`getWaitlistStatus` を `findAllById` でN+1解消。`cancelParticipation` のコメントを更新 |
+| [karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java](karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java) | `renumberRemainingWaitlist` を `saveAll` 化。`*Suppressed` 系4メソッドの Javadoc に契約を明記 |
+| 新規テスト: `LotteryControllerCancelTest`（既存）に「ループ途中で例外が出ても他件は確定する」テスト追加 | 個別TX保証の検証 |
+| 新規テスト: `LotteryControllerDeclineWaitlistTest`（新規 or 既存に追加）に ADMIN スコープ違反 → 403 のテスト | スコープ検証 |
+| 新規テスト: `LotteryServiceEditParticipantsTest` または既存テストに「当日午前キャンセルで繰り上げ」「当日午後キャンセルで補充通知」のテスト | 当日分岐の整合性検証 |
+
+### Controller / Service / Repository / Entity / DTO の変更まとめ
+- **Controller**: `LotteryController` の3エンドポイント
+- **Service**: `LotteryService.editParticipants`, `WaitlistPromotionService.renumberRemainingWaitlist`
+- **Repository**: 変更なし（既存メソッドのみ利用）
+- **Entity**: 変更なし
+- **DTO**: 変更なし
+
+---
+
+## 4. 影響範囲
+
+### 4.1 影響を受ける既存機能
+
+| 機能 | 影響内容 |
+|---|---|
+| 抽選結果管理画面（`LotteryManagement.jsx` の「抽選確定後の参加者編集」） | 当日キャンセル時に通知が発火するようになる（従来は無音）。管理者UX改善 |
+| 当日キャンセル補充フロー | `editParticipants` 経由のキャンセルでも 12:00 以降は当日補充フローが走る。LINE通知件数が増える可能性あり |
+| キャンセル待ち辞退/復帰（PLAYER経路） | 振る舞い変更なし。PLAYERは引き続き自分のみ操作可能 |
+| キャンセル待ち辞退/復帰（管理者経路） | ADMIN は自団体のみ操作可能に制限される。SUPER_ADMINは従来通り |
+| キャンセル待ち状況画面 (`/lottery/waitlist`) | 表示性能改善（N+1解消）+ エラー時にメッセージ表示 |
+| 容量拡張時の昇格（`promoteWaitlistedAfterCapacityIncrease`） | `renumberRemainingWaitlist` の `saveAll` 化で大量再採番時の性能改善 |
+| 伝助同期（DensukeImportService）からの cancelParticipationSuppressed 呼び出し | 振る舞い変更なし（`@Transactional` 配下で `REQUIRED` 維持。Javadoc明記のみ） |
+| 通常キャンセル経路（`/api/lottery/cancel`） | 振る舞い変更なし。コメント更新のみ |
+
+### 4.2 共通コンポーネント・ユーティリティへの影響
+- `AdminScopeValidator`: 既存ユーティリティを使うのみ。本体変更なし
+- `lotteryDeadlineHelper`: 既存メソッド `isAfterSameDayNoon` を使うのみ。本体変更なし
+- `dispatchSameDayCancelNotifications`: 既存メソッドを `editParticipants` から呼ぶのみ。本体変更なし
+
+### 4.3 API・DBスキーマの互換性
+- **API**: 破壊的変更なし。リクエスト/レスポンス形式は不変
+- **DB**: スキーマ変更なし。`database/*.sql` の追加なし
+- **フロントエンド契約**: WaitlistStatus.jsx は内部UI追加のみで API クライアントへの影響なし
+
+### 4.4 デグレード懸念と緩和策
+| 懸念 | 緩和策 |
+|---|---|
+| `editParticipants` の通知発火追加で大量LINE通知 | 既存のバッチ通知パターン（`sendBatchedAdminWaitlistNotifications`）を使うため、セッション×プレイヤー単位で集約済み |
+| `cancelParticipationSuppressed` 委譲で `editParticipants` の処理順が変わる | 既存の追加処理（addition / waitlistReorders）は `editParticipants` 内で先後関係を維持。`statusChanges` 内の処理だけが `cancelParticipationSuppressed` に置き換わる |
+| ADMIN のスコープ検証追加で、運用上必要だった操作が止まる | 現状 ADMIN が他団体のキャンセル待ちを操作する運用は無いと判断（要ユーザー確認）。万が一必要なら SUPER_ADMIN を使う運用に切り替え |
+| `saveAll` 化で Hibernate バッチ設定が無効だと逆に遅くなる可能性 | `application.yml` の `hibernate.jdbc.batch_size` を確認し、未設定なら明示的に追加（実装タスク内で対応） |
+
+---
+
+## 5. 設計判断の根拠
+
+### 5.1 #1 を「案A: cancelParticipationSuppressed 委譲」とした理由
+監査レポートでも `WaitlistPromotionService` の通知集約パターンは「`*Suppressed` メソッドが通知データを返す → 呼び出し元で集約 → `sendBatched...` で1通送信」と一貫していると評価されている。`editParticipants` だけが独自実装で `setStatus(CANCELLED)` を直書きしているため、ここを既存パターンに揃えることで仕様乖離も将来の保守コストも同時に減らせる。
+
+### 5.2 #3 で `REQUIRES_NEW` に変更しない理由
+`DensukeImportService`（`@Transactional` 配下）が `cancelParticipationSuppressed`/`demoteToWaitlistSuppressed`/`respondToOfferDeclineSuppressed` を呼んでおり、現状は **意図的にインポートTXに参加して整合性を保っている**（インポート失敗時にキャンセルもロールバック）。`REQUIRES_NEW` に一律変更すると、伝助同期の途中で失敗した場合にキャンセルだけが先行コミットされてしまい、データ整合性が崩れる。コントローラ側のループは現状で個別TXとして動作しているため、契約をJavadoc/コメントで明示し、テストで保証する方針を採る。
+
+### 5.3 #6 で `saveAll` を選び HQL UPDATE を選ばない理由
+`renumberRemainingWaitlist` は対象レコードのうち番号差分があるものだけを更新する条件分岐がある。HQL `UPDATE` で同等の条件（`waitlist_number = newNumber WHERE id = ? AND waitlist_number != newNumber`）を一括発行するには、CASE WHEN や複数クエリが必要で複雑化する。`saveAll` + Hibernate バッチでも実用上十分な性能改善が見込めるため、シンプルな選択肢を採る。
+
+### 5.4 #8 のスコープを最小限にした理由
+監査レポートでは「再試行ボタン」の追加も提案されたが、過去のフロントエンド改修方針（`PR #449` などのパターン）に倣い、まずはエラー認識を確実にすることを優先。再試行ボタンや自動リトライは別UXタスクで扱う。
+
+### 5.5 監査レポート #4 / #7 / #9 / #10 / #11 / #12 をスコープ外にした理由
+- #4（ドキュメント整合）: 実装PRと別に「ドキュメント整理」PRで一括対応するほうが見通しが良い
+- #7（`WaitlistPromotionService` 分割）: 1,404行のリファクタは別PRで設計議論が必要
+- #9（DTO化）/ #10（分散ロック）/ #12（一括チェック）: 緊急性が低く、現状で問題が顕在化していない
+- #11（キャンセル理由の管理者UI）: 機能追加に該当し、別途要望ヒアリングが必要

--- a/karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx
+++ b/karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx
@@ -10,6 +10,7 @@ export default function WaitlistStatus() {
   const { currentPlayer } = useAuth();
   const [entries, setEntries] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (currentPlayer?.id) fetchStatus();
@@ -17,11 +18,14 @@ export default function WaitlistStatus() {
 
   const fetchStatus = async () => {
     setLoading(true);
+    setError(null);
     try {
       const res = await lotteryAPI.getWaitlistStatus();
       setEntries(res.data.entries || []);
     } catch (err) {
       console.error('Failed to fetch waitlist status:', err);
+      setError('キャンセル待ち情報の取得に失敗しました。時間をおいて再度お試しください。');
+      setEntries([]);
     } finally {
       setLoading(false);
     }
@@ -39,6 +43,12 @@ export default function WaitlistStatus() {
   return (
     <div className="max-w-2xl mx-auto p-4">
       <h1 className="text-xl font-bold mb-4">キャンセル待ち状況</h1>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 p-3 rounded mb-3">
+          {error}
+        </div>
+      )}
 
       {loading ? (
         <LoadingScreen />

--- a/karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx
+++ b/karuta-tracker-ui/src/pages/lottery/WaitlistStatus.jsx
@@ -52,7 +52,7 @@ export default function WaitlistStatus() {
 
       {loading ? (
         <LoadingScreen />
-      ) : entries.length === 0 ? (
+      ) : error ? null : entries.length === 0 ? (
         <div className="text-center py-8 text-gray-500">
           キャンセル待ちはありません
         </div>

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java
@@ -535,6 +535,7 @@ public class LotteryController {
             @RequestBody Map<String, Long> body, HttpServletRequest httpRequest) {
         Long currentUserId = (Long) httpRequest.getAttribute("currentUserId");
         Role currentUserRole = Role.valueOf((String) httpRequest.getAttribute("currentUserRole"));
+        Long adminOrgId = (Long) httpRequest.getAttribute("adminOrganizationId");
         Long sessionId = body.get("sessionId");
         Long playerId = body.get("playerId");
 
@@ -542,6 +543,9 @@ public class LotteryController {
         if (currentUserRole == Role.PLAYER && !playerId.equals(currentUserId)) {
             throw new ForbiddenException("他の参加者のキャンセル待ちは辞退できません");
         }
+
+        // ADMINは自団体のセッションのみ操作可能
+        validateWaitlistAdminScope(sessionId, currentUserRole, adminOrgId);
 
         int count = waitlistPromotionService.declineWaitlistBySession(sessionId, playerId);
         return ResponseEntity.ok(Map.of(
@@ -558,6 +562,7 @@ public class LotteryController {
             @RequestBody Map<String, Long> body, HttpServletRequest httpRequest) {
         Long currentUserId = (Long) httpRequest.getAttribute("currentUserId");
         Role currentUserRole = Role.valueOf((String) httpRequest.getAttribute("currentUserRole"));
+        Long adminOrgId = (Long) httpRequest.getAttribute("adminOrganizationId");
         Long sessionId = body.get("sessionId");
         Long playerId = body.get("playerId");
 
@@ -566,10 +571,21 @@ public class LotteryController {
             throw new ForbiddenException("他の参加者のキャンセル待ちは復帰できません");
         }
 
+        // ADMINは自団体のセッションのみ操作可能
+        validateWaitlistAdminScope(sessionId, currentUserRole, adminOrgId);
+
         int count = waitlistPromotionService.rejoinWaitlistBySession(sessionId, playerId);
         return ResponseEntity.ok(Map.of(
                 "rejoinedCount", count,
                 "message", "キャンセル待ちに復帰しました（" + count + "件）"));
+    }
+
+    private void validateWaitlistAdminScope(Long sessionId, Role role, Long adminOrgId) {
+        if (role != Role.ADMIN) return;
+        PracticeSession session = practiceSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResourceNotFoundException("PracticeSession", sessionId));
+        AdminScopeValidator.validateScope(role.name(), adminOrgId, session.getOrganizationId(),
+                "他団体のキャンセル待ちは操作できません");
     }
 
     /**

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/LotteryController.java
@@ -289,8 +289,13 @@ public class LotteryController {
         List<String> results = new ArrayList<>();
         List<AdminWaitlistNotificationData> rawList = new ArrayList<>();
 
-        // cancelParticipationSuppressed は個別 TX でコミットされるため、
-        // ループ途中で例外が起きても先に成功した分の DB 更新は既にコミット済みになる。
+        // cancelParticipationSuppressed は @Transactional(REQUIRED) のため、
+        // 上流TXが無い場合のみ 1件1TX で動作する（個別コミット）。
+        // このメソッド自体に @Transactional を付けてはならない:
+        // 付与するとループ全件が単一TXに化け、途中の例外で全件ロールバックされ、
+        // 成功した分のキャンセルが消える（cancelParticipationSuppressed の Javadoc 参照）。
+        // 個別コミット契約は LotteryControllerCancelTest で CI 検出される。
+        // ループ途中で例外が起きても先に成功した分の DB 更新は既にコミット済みになるため、
         // 成功分の当日キャンセル通知・繰り上げ通知が取りこぼされないよう、
         // 通知集約処理は finally 節で必ず実行する。
         try {
@@ -504,10 +509,15 @@ public class LotteryController {
                         || p.getStatus() == ParticipantStatus.OFFERED)
                 .collect(Collectors.toList());
 
-        List<WaitlistStatusDto.WaitlistEntry> entries = new ArrayList<>();
+        Set<Long> sessionIds = waitlisted.stream()
+                .map(PracticeParticipant::getSessionId)
+                .collect(Collectors.toSet());
+        Map<Long, PracticeSession> sessionMap = practiceSessionRepository.findAllById(sessionIds).stream()
+                .collect(Collectors.toMap(PracticeSession::getId, s -> s));
 
+        List<WaitlistStatusDto.WaitlistEntry> entries = new ArrayList<>();
         for (PracticeParticipant p : waitlisted) {
-            PracticeSession session = practiceSessionRepository.findById(p.getSessionId()).orElse(null);
+            PracticeSession session = sessionMap.get(p.getSessionId());
             if (session == null) continue;
 
             entries.add(WaitlistStatusDto.WaitlistEntry.builder()

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LotteryService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/LotteryService.java
@@ -971,8 +971,15 @@ public class LotteryService {
      * 管理者による参加者手動編集
      *
      * - 参加者追加
-     * - ステータス変更（WON→CANCELLEDの場合は繰り上げフローを発動）
+     * - ステータス変更（WON→CANCELLEDの場合は通常キャンセル経路と同じ三分岐に委譲）
      * - キャンセル待ち順番変更
+     *
+     * <p>WON→CANCELLED時は {@code cancelParticipationSuppressed} に委譲することで、
+     * 通常キャンセル経路（{@code /api/lottery/cancel}）と完全に同じロジックで分岐する：
+     * <ul>
+     *   <li>当日12:00前 / 当日でない → 通常繰り上げ + 管理者バッチ通知 + プレイヤー向けオファー統合通知</li>
+     *   <li>当日12:00以降 → {@code SameDayCancelContext} 経由で当日補充フローが afterCommit 登録される</li>
+     * </ul>
      */
     @Transactional
     public void editParticipants(AdminEditParticipantsRequest request) {
@@ -996,35 +1003,35 @@ public class LotteryService {
                 PracticeParticipant p = practiceParticipantRepository.findById(change.getParticipantId())
                         .orElseThrow(() -> new ResourceNotFoundException("PracticeParticipant", change.getParticipantId()));
                 ParticipantStatus oldStatus = p.getStatus();
+
+                // WON → CANCELLED は通常キャンセル経路に委譲し、当日12:00分岐・通常繰り上げを統一する。
+                // 委譲側で setStatus(CANCELLED) / setDirty / save と昇格判定を行うため、ここでは何もしない。
+                if (oldStatus == ParticipantStatus.WON && change.getNewStatus() == ParticipantStatus.CANCELLED) {
+                    AdminWaitlistNotificationData notifData = waitlistPromotionService
+                            .cancelParticipationSuppressed(change.getParticipantId(), null, null);
+                    if (notifData != null) {
+                        promotionDataList.add(notifData);
+                    }
+                    continue;
+                }
+
                 p.setStatus(change.getNewStatus());
                 p.setDirty(true);
                 if (change.getWaitlistNumber() != null) {
                     p.setWaitlistNumber(change.getWaitlistNumber());
                 }
                 practiceParticipantRepository.save(p);
-
-                // WON → CANCELLED の場合、繰り上げフローを発動（当日は除く）
-                if (oldStatus == ParticipantStatus.WON && change.getNewStatus() == ParticipantStatus.CANCELLED) {
-                    PracticeSession session = practiceSessionRepository.findById(p.getSessionId())
-                            .orElse(null);
-                    if (session != null && !lotteryDeadlineHelper.isToday(session.getSessionDate())) {
-                        Optional<PracticeParticipant> promoted = waitlistPromotionService.promoteNextWaitlisted(
-                                p.getSessionId(), p.getMatchNumber(), session.getSessionDate());
-                        promotionDataList.add(AdminWaitlistNotificationData.builder()
-                                .triggerAction("キャンセル")
-                                .triggerPlayerId(p.getPlayerId())
-                                .sessionId(p.getSessionId())
-                                .matchNumber(p.getMatchNumber())
-                                .promotedParticipant(promoted.orElse(null))
-                                .build());
-                    }
-                }
             }
         }
 
+        // 当日キャンセル分は dispatchSameDayCancelNotifications 内で afterCommit 登録され、
+        // 戻り値には通常繰り上げ分（同期送信対象）のみが残る。
+        List<AdminWaitlistNotificationData> normalNotifications =
+                waitlistPromotionService.dispatchSameDayCancelNotifications(promotionDataList);
+
         // 管理者通知＋プレイヤー向けオファー統合通知をバッチ送信
-        if (!promotionDataList.isEmpty()) {
-            promotionDataList.stream()
+        if (!normalNotifications.isEmpty()) {
+            normalNotifications.stream()
                     .collect(Collectors.groupingBy(AdminWaitlistNotificationData::getSessionId))
                     .forEach((sid, dataList) -> {
                         PracticeSession session = practiceSessionRepository.findById(sid).orElse(null);

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/WaitlistPromotionService.java
@@ -91,6 +91,19 @@ public class WaitlistPromotionService {
      * WON → WAITLISTED（最後尾）に降格する（通知抑制版）。
      * 呼び出し元で複数件分をまとめて sendBatchedAdminWaitlistNotifications に渡す用途。
      *
+     * <p><b>トランザクション境界の契約:</b><br>
+     * このメソッドは {@code @Transactional}（伝播 {@code REQUIRED}）で宣言されているが、
+     * <em>個別コミットは保証しない</em>。呼び出し元に既存トランザクションがあれば
+     * それに参加し、無ければ新しいTXを開始する。
+     * <ul>
+     *   <li>{@code DensukeImportService} などインポートTX配下から呼ぶ場合は、
+     *       インポート全体と整合性を保ちたいので参加する設計（このまま使う）。</li>
+     *   <li>ループ内で1件ずつコミットしたい呼び出し元（{@code LotteryController#cancelParticipation} など）は
+     *       <strong>呼び出し元側に {@code @Transactional} を付けてはならない</strong>。
+     *       上流TXが存在すると本メソッドはそれに参加し、ループ全件が単一TXに化けて
+     *       途中の例外で全件ロールバックされる。</li>
+     * </ul>
+     *
      * @param participantId 参加者レコードID
      * @return 通知データ
      */
@@ -183,14 +196,26 @@ public class WaitlistPromotionService {
     }
 
     /**
-     * 当選者が参加をキャンセルする（通知抑制オプション付き）。
-     * suppressNotification=true の場合、管理者通知を送信せず通知データを返す。
+     * 当選者が参加をキャンセルする（通知抑制版）。
+     * 管理者通知は送信せず、通知データを返す。
      * 呼び出し元で複数件分をまとめて sendBatchedAdminWaitlistNotifications に渡す用途。
+     *
+     * <p><b>トランザクション境界の契約:</b><br>
+     * このメソッドは {@code @Transactional}（伝播 {@code REQUIRED}）で宣言されているが、
+     * <em>個別コミットは保証しない</em>。呼び出し元に既存トランザクションがあれば
+     * それに参加し、無ければ新しいTXを開始する。
+     * <ul>
+     *   <li>{@code DensukeImportService} などインポートTX配下から呼ぶ場合は、
+     *       インポート全体と整合性を保ちたいので参加する設計（このまま使う）。</li>
+     *   <li>ループ内で1件ずつコミットしたい呼び出し元（{@code LotteryController#cancelParticipation} など）は
+     *       <strong>呼び出し元側に {@code @Transactional} を付けてはならない</strong>。
+     *       上流TXが存在すると本メソッドはそれに参加し、ループ全件が単一TXに化けて
+     *       途中の例外で全件ロールバックされる。</li>
+     * </ul>
      *
      * @param participantId      参加者レコードID
      * @param cancelReason       キャンセル理由コード
      * @param cancelReasonDetail キャンセル理由詳細
-     * @param suppressNotification true=通知を送信しない
      * @return 通知データ（通知不要の場合はnull）
      */
     @Transactional
@@ -793,6 +818,19 @@ public class WaitlistPromotionService {
      * LINE通知（繰り上げ先・管理者）を送信せず、通知データを返す。
      * DensukeImportServiceでバッチ処理する用途。
      *
+     * <p><b>トランザクション境界の契約:</b><br>
+     * このメソッドは {@code @Transactional}（伝播 {@code REQUIRED}）で宣言されているが、
+     * <em>個別コミットは保証しない</em>。呼び出し元に既存トランザクションがあれば
+     * それに参加し、無ければ新しいTXを開始する。
+     * <ul>
+     *   <li>{@code DensukeImportService} などインポートTX配下から呼ぶ場合は、
+     *       インポート全体と整合性を保ちたいので参加する設計（このまま使う）。</li>
+     *   <li>ループ内で1件ずつコミットしたい呼び出し元は
+     *       <strong>呼び出し元側に {@code @Transactional} を付けてはならない</strong>。
+     *       上流TXが存在すると本メソッドはそれに参加し、ループ全件が単一TXに化けて
+     *       途中の例外で全件ロールバックされる。</li>
+     * </ul>
+     *
      * @param participantId 参加者レコードID
      * @return 通知データ（繰り上げ結果 + 管理者通知データ）
      */
@@ -1116,6 +1154,17 @@ public class WaitlistPromotionService {
      * LINE通知（繰り上げ先・管理者）を送信せず、通知データを返す。
      * OfferExpirySchedulerでバッチ処理する用途。
      *
+     * <p><b>トランザクション境界の契約:</b><br>
+     * このメソッドは {@code @Transactional}（伝播 {@code REQUIRED}）で宣言されているが、
+     * <em>個別コミットは保証しない</em>。呼び出し元に既存トランザクションがあれば
+     * それに参加し、無ければ新しいTXを開始する。
+     * <ul>
+     *   <li>{@code OfferExpiryScheduler} など個別ループから呼ぶ場合、上流TXが無い前提で
+     *       1件1TXとなるよう、<strong>呼び出し元側に {@code @Transactional} を付けてはならない</strong>。
+     *       上流TXが存在すると本メソッドはそれに参加し、ループ全件が単一TXに化けて
+     *       途中の例外で全件ロールバックされる。</li>
+     * </ul>
+     *
      * @param participant 期限切れのOFFERED参加者
      * @return 通知データ（繰り上げ結果 + 管理者通知データ）。OFFERED以外の場合はnull
      */
@@ -1392,13 +1441,17 @@ public class WaitlistPromotionService {
                 .findBySessionIdAndMatchNumberAndStatusInOrderByWaitlistNumberAsc(
                         sessionId, matchNumber,
                         List.of(ParticipantStatus.WAITLISTED, ParticipantStatus.OFFERED));
+        List<PracticeParticipant> dirty = new ArrayList<>();
         for (int i = 0; i < remaining.size(); i++) {
             PracticeParticipant p = remaining.get(i);
             int newNumber = i + 1;
             if (!Integer.valueOf(newNumber).equals(p.getWaitlistNumber())) {
                 p.setWaitlistNumber(newNumber);
-                practiceParticipantRepository.save(p);
+                dirty.add(p);
             }
+        }
+        if (!dirty.isEmpty()) {
+            practiceParticipantRepository.saveAll(dirty);
         }
     }
 }

--- a/karuta-tracker/src/main/resources/application.properties
+++ b/karuta-tracker/src/main/resources/application.properties
@@ -28,6 +28,11 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+# Batch INSERT/UPDATE: saveAll() などでフラッシュ時にまとめてJDBCに送る件数。
+# WaitlistPromotionService#renumberRemainingWaitlist など多件同時保存処理の往復回数を削減する。
+spring.jpa.properties.hibernate.jdbc.batch_size=50
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.order_inserts=true
 
 # Server Configuration
 server.port=${PORT:8080}

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LotteryControllerCancelTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LotteryControllerCancelTest.java
@@ -5,6 +5,8 @@ import com.karuta.matchtracker.dto.CancelRequest;
 import com.karuta.matchtracker.dto.SameDayCancelContext;
 import com.karuta.matchtracker.entity.Player.Role;
 import com.karuta.matchtracker.entity.PracticeSession;
+import org.springframework.transaction.annotation.Transactional;
+import java.lang.reflect.Method;
 import com.karuta.matchtracker.repository.LotteryExecutionRepository;
 import com.karuta.matchtracker.repository.NotificationRepository;
 import com.karuta.matchtracker.repository.PracticeParticipantRepository;
@@ -147,5 +149,64 @@ class LotteryControllerCancelTest {
                 ArgumentCaptor.forClass(List.class);
         verify(waitlistPromotionService).dispatchSameDayCancelNotifications(captor.capture());
         assertThat(captor.getValue()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("3件中2件目で例外でも、1件目と3件目相当の通知集約は finally で実行される")
+    void cancelParticipation_threeItemsMiddleFailure_dispatchesSuccessful() {
+        when(request.getAttribute("currentUserId")).thenReturn(1L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.SUPER_ADMIN.name());
+
+        PracticeSession session = PracticeSession.builder()
+                .id(100L).sessionDate(LocalDate.of(2026, 4, 15)).capacity(6).build();
+        SameDayCancelContext ctx1 = SameDayCancelContext.builder()
+                .session(session).playerId(10L).playerName("選手A").matchNumber(1).build();
+        AdminWaitlistNotificationData d1 = AdminWaitlistNotificationData.builder()
+                .triggerAction("キャンセル（当日補充）").triggerPlayerId(10L)
+                .sessionId(100L).matchNumber(1).sameDayCancelContext(ctx1).build();
+
+        // 1件目成功 → 2件目で例外 → 3件目はそもそも呼ばれない（ループが中断するため）
+        // 個別TX契約が守られていれば 1件目の DB 更新は確定する。
+        // 通知集約処理は finally で必ず実行され、成功分のみが渡る。
+        when(waitlistPromotionService.cancelParticipationSuppressed(101L, "HEALTH", null))
+                .thenReturn(d1);
+        when(waitlistPromotionService.cancelParticipationSuppressed(102L, "HEALTH", null))
+                .thenThrow(new RuntimeException("DB error"));
+        when(waitlistPromotionService.dispatchSameDayCancelNotifications(anyList()))
+                .thenReturn(List.of());
+
+        CancelRequest req = CancelRequest.builder()
+                .participantIds(List.of(101L, 102L, 103L))
+                .cancelReason("HEALTH")
+                .build();
+
+        assertThatThrownBy(() -> controller.cancelParticipation(req, request))
+                .isInstanceOf(RuntimeException.class);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<AdminWaitlistNotificationData>> captor =
+                ArgumentCaptor.forClass(List.class);
+        verify(waitlistPromotionService).dispatchSameDayCancelNotifications(captor.capture());
+        assertThat(captor.getValue()).hasSize(1);
+        assertThat(captor.getValue().get(0).getMatchNumber()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("cancelParticipation には @Transactional を付けてはならない（個別TX契約のセンチネル）")
+    void cancelParticipation_mustNotHaveTransactionalAnnotation() throws NoSuchMethodException {
+        // 個別TXコミットの契約は、本メソッドに @Transactional が付与されていないことに依存する。
+        // 上流TXが存在すると cancelParticipationSuppressed が REQUIRED で参加し、ループ全件が
+        // 単一TXに化けて途中の例外で全件ロールバックされる（成功分のキャンセルが消える）。
+        // この sentinel テストにより、誤って @Transactional を付けた変更が CI で即検出される。
+        Method method = LotteryController.class.getMethod(
+                "cancelParticipation", CancelRequest.class,
+                jakarta.servlet.http.HttpServletRequest.class);
+        assertThat(method.isAnnotationPresent(Transactional.class))
+                .as("LotteryController#cancelParticipation must NOT be @Transactional " +
+                        "(see WaitlistPromotionService#cancelParticipationSuppressed Javadoc)")
+                .isFalse();
+        assertThat(LotteryController.class.isAnnotationPresent(Transactional.class))
+                .as("LotteryController class must NOT be @Transactional")
+                .isFalse();
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LotteryControllerDeclineWaitlistTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/LotteryControllerDeclineWaitlistTest.java
@@ -1,0 +1,198 @@
+package com.karuta.matchtracker.controller;
+
+import com.karuta.matchtracker.entity.Player.Role;
+import com.karuta.matchtracker.entity.PracticeSession;
+import com.karuta.matchtracker.exception.ForbiddenException;
+import com.karuta.matchtracker.exception.ResourceNotFoundException;
+import com.karuta.matchtracker.repository.LotteryExecutionRepository;
+import com.karuta.matchtracker.repository.NotificationRepository;
+import com.karuta.matchtracker.repository.PracticeParticipantRepository;
+import com.karuta.matchtracker.repository.PracticeSessionRepository;
+import com.karuta.matchtracker.repository.VenueRepository;
+import com.karuta.matchtracker.service.LineNotificationService;
+import com.karuta.matchtracker.service.LotteryDeadlineHelper;
+import com.karuta.matchtracker.service.LotteryService;
+import com.karuta.matchtracker.service.NotificationService;
+import com.karuta.matchtracker.service.WaitlistPromotionService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LotteryController キャンセル待ち辞退/復帰のADMINスコープ検証")
+class LotteryControllerDeclineWaitlistTest {
+
+    @Mock private LotteryService lotteryService;
+    @Mock private WaitlistPromotionService waitlistPromotionService;
+    @Mock private LineNotificationService lineNotificationService;
+    @Mock private NotificationService notificationService;
+    @Mock private PracticeParticipantRepository practiceParticipantRepository;
+    @Mock private PracticeSessionRepository practiceSessionRepository;
+    @Mock private LotteryExecutionRepository lotteryExecutionRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private VenueRepository venueRepository;
+    @Mock private LotteryDeadlineHelper lotteryDeadlineHelper;
+
+    @InjectMocks
+    private LotteryController controller;
+
+    @Mock
+    private HttpServletRequest request;
+
+    private static final Long SESSION_ID = 100L;
+    private static final Long PLAYER_ID = 200L;
+    private static final Long ADMIN_ORG_ID = 1L;
+    private static final Long OTHER_ORG_ID = 2L;
+
+    private Map<String, Long> body() {
+        Map<String, Long> body = new HashMap<>();
+        body.put("sessionId", SESSION_ID);
+        body.put("playerId", PLAYER_ID);
+        return body;
+    }
+
+    private PracticeSession sessionForOrg(Long orgId) {
+        return PracticeSession.builder()
+                .id(SESSION_ID)
+                .organizationId(orgId)
+                .build();
+    }
+
+    @Test
+    @DisplayName("decline-waitlist: ADMINが他団体セッションを指定した場合 403")
+    void declineWaitlist_adminCrossOrg_throwsForbidden() {
+        when(request.getAttribute("currentUserId")).thenReturn(999L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.ADMIN.name());
+        when(request.getAttribute("adminOrganizationId")).thenReturn(ADMIN_ORG_ID);
+        when(practiceSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(sessionForOrg(OTHER_ORG_ID)));
+
+        assertThatThrownBy(() -> controller.declineWaitlist(body(), request))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("他団体のキャンセル待ちは操作できません");
+
+        verify(waitlistPromotionService, never()).declineWaitlistBySession(any(), any());
+    }
+
+    @Test
+    @DisplayName("decline-waitlist: ADMINが自団体セッションなら成功")
+    void declineWaitlist_adminSameOrg_succeeds() {
+        when(request.getAttribute("currentUserId")).thenReturn(999L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.ADMIN.name());
+        when(request.getAttribute("adminOrganizationId")).thenReturn(ADMIN_ORG_ID);
+        when(practiceSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(sessionForOrg(ADMIN_ORG_ID)));
+        when(waitlistPromotionService.declineWaitlistBySession(SESSION_ID, PLAYER_ID)).thenReturn(2);
+
+        ResponseEntity<Map<String, Object>> response = controller.declineWaitlist(body(), request);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).containsEntry("declinedCount", 2);
+        verify(waitlistPromotionService).declineWaitlistBySession(SESSION_ID, PLAYER_ID);
+    }
+
+    @Test
+    @DisplayName("decline-waitlist: SUPER_ADMINは団体スコープ検証なしで成功（セッション取得不要）")
+    void declineWaitlist_superAdmin_skipsScopeCheck() {
+        when(request.getAttribute("currentUserId")).thenReturn(1L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.SUPER_ADMIN.name());
+        when(waitlistPromotionService.declineWaitlistBySession(SESSION_ID, PLAYER_ID)).thenReturn(1);
+
+        ResponseEntity<Map<String, Object>> response = controller.declineWaitlist(body(), request);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        verify(practiceSessionRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("decline-waitlist: PLAYERが自分以外を指定した場合 403（スコープ検証より前）")
+    void declineWaitlist_playerOther_throwsForbidden() {
+        when(request.getAttribute("currentUserId")).thenReturn(999L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.PLAYER.name());
+
+        assertThatThrownBy(() -> controller.declineWaitlist(body(), request))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("他の参加者のキャンセル待ちは辞退できません");
+
+        verify(practiceSessionRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("decline-waitlist: ADMINが存在しないセッションを指定した場合 ResourceNotFound")
+    void declineWaitlist_adminMissingSession_throwsNotFound() {
+        when(request.getAttribute("currentUserId")).thenReturn(999L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.ADMIN.name());
+        when(request.getAttribute("adminOrganizationId")).thenReturn(ADMIN_ORG_ID);
+        when(practiceSessionRepository.findById(SESSION_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.declineWaitlist(body(), request))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(waitlistPromotionService, never()).declineWaitlistBySession(any(), any());
+    }
+
+    @Test
+    @DisplayName("rejoin-waitlist: ADMINが他団体セッションを指定した場合 403")
+    void rejoinWaitlist_adminCrossOrg_throwsForbidden() {
+        when(request.getAttribute("currentUserId")).thenReturn(999L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.ADMIN.name());
+        when(request.getAttribute("adminOrganizationId")).thenReturn(ADMIN_ORG_ID);
+        when(practiceSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(sessionForOrg(OTHER_ORG_ID)));
+
+        assertThatThrownBy(() -> controller.rejoinWaitlist(body(), request))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("他団体のキャンセル待ちは操作できません");
+
+        verify(waitlistPromotionService, never()).rejoinWaitlistBySession(any(), any());
+    }
+
+    @Test
+    @DisplayName("rejoin-waitlist: ADMINが自団体セッションなら成功")
+    void rejoinWaitlist_adminSameOrg_succeeds() {
+        when(request.getAttribute("currentUserId")).thenReturn(999L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.ADMIN.name());
+        when(request.getAttribute("adminOrganizationId")).thenReturn(ADMIN_ORG_ID);
+        when(practiceSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(sessionForOrg(ADMIN_ORG_ID)));
+        when(waitlistPromotionService.rejoinWaitlistBySession(SESSION_ID, PLAYER_ID)).thenReturn(1);
+
+        ResponseEntity<Map<String, Object>> response = controller.rejoinWaitlist(body(), request);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).containsEntry("rejoinedCount", 1);
+        verify(waitlistPromotionService).rejoinWaitlistBySession(SESSION_ID, PLAYER_ID);
+    }
+
+    @Test
+    @DisplayName("rejoin-waitlist: PLAYERが自分以外を指定した場合 403")
+    void rejoinWaitlist_playerOther_throwsForbidden() {
+        when(request.getAttribute("currentUserId")).thenReturn(999L);
+        when(request.getAttribute("currentUserRole")).thenReturn(Role.PLAYER.name());
+
+        assertThatThrownBy(() -> controller.rejoinWaitlist(body(), request))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("他の参加者のキャンセル待ちは復帰できません");
+
+        verify(practiceSessionRepository, never()).findById(any());
+    }
+
+    private static <T> T any() {
+        return org.mockito.ArgumentMatchers.any();
+    }
+}

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LotteryServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/LotteryServiceTest.java
@@ -1,5 +1,8 @@
 package com.karuta.matchtracker.service;
 
+import com.karuta.matchtracker.dto.AdminEditParticipantsRequest;
+import com.karuta.matchtracker.dto.AdminWaitlistNotificationData;
+import com.karuta.matchtracker.dto.SameDayCancelContext;
 import com.karuta.matchtracker.entity.LotteryExecution;
 import com.karuta.matchtracker.entity.ParticipantStatus;
 import com.karuta.matchtracker.entity.PracticeParticipant;
@@ -9,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,6 +25,11 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -231,5 +240,138 @@ class LotteryServiceTest {
         LotteryExecution result = lotteryService.reExecuteLottery(sessionId, 1L, null);
 
         assertThat(result.getPriorityPlayerIds()).containsExactlyInAnyOrder(10L, 20L);
+    }
+
+    // -------- editParticipants の WON→CANCELLED 分岐テスト ([#1]) --------
+
+    private PracticeParticipant wonParticipant(long id, long playerId) {
+        return PracticeParticipant.builder()
+                .id(id)
+                .playerId(playerId)
+                .sessionId(100L)
+                .matchNumber(MATCH)
+                .status(ParticipantStatus.WON)
+                .build();
+    }
+
+    private AdminEditParticipantsRequest cancelRequest(long participantId) {
+        AdminEditParticipantsRequest.StatusChange change = new AdminEditParticipantsRequest.StatusChange();
+        change.setParticipantId(participantId);
+        change.setNewStatus(ParticipantStatus.CANCELLED);
+        AdminEditParticipantsRequest req = new AdminEditParticipantsRequest();
+        req.setSessionId(100L);
+        req.setMatchNumber(MATCH);
+        req.setStatusChanges(List.of(change));
+        return req;
+    }
+
+    @Test
+    @DisplayName("editParticipants WON→CANCELLED: cancelParticipationSuppressed に委譲する")
+    void editParticipants_wonToCancelled_delegatesToCancelParticipationSuppressed() {
+        PracticeParticipant p = wonParticipant(501L, 10L);
+        when(practiceParticipantRepository.findById(501L)).thenReturn(Optional.of(p));
+
+        AdminWaitlistNotificationData notif = AdminWaitlistNotificationData.builder()
+                .triggerAction("キャンセル")
+                .triggerPlayerId(10L)
+                .sessionId(100L)
+                .matchNumber(MATCH)
+                .build();
+        when(waitlistPromotionService.cancelParticipationSuppressed(501L, null, null))
+                .thenReturn(notif);
+        when(waitlistPromotionService.dispatchSameDayCancelNotifications(anyList()))
+                .thenReturn(List.of(notif));
+        when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session(6)));
+
+        lotteryService.editParticipants(cancelRequest(501L));
+
+        // setStatus / save は委譲側で行うため、editParticipants 自体では呼ばない
+        verify(practiceParticipantRepository, never()).save(any());
+        verify(waitlistPromotionService).cancelParticipationSuppressed(501L, null, null);
+    }
+
+    @Test
+    @DisplayName("editParticipants 通常分（当日でない）: dispatchSameDayCancelNotifications が normal 分を返し、バッチ通知が送られる")
+    void editParticipants_normalCancel_sendsBatchedAdminNotification() {
+        PracticeParticipant p = wonParticipant(601L, 11L);
+        when(practiceParticipantRepository.findById(601L)).thenReturn(Optional.of(p));
+
+        AdminWaitlistNotificationData notif = AdminWaitlistNotificationData.builder()
+                .triggerAction("キャンセル")
+                .triggerPlayerId(11L)
+                .sessionId(100L)
+                .matchNumber(MATCH)
+                .build();
+        when(waitlistPromotionService.cancelParticipationSuppressed(601L, null, null))
+                .thenReturn(notif);
+        when(waitlistPromotionService.dispatchSameDayCancelNotifications(anyList()))
+                .thenReturn(List.of(notif));
+        PracticeSession sess = session(6);
+        when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(sess));
+
+        lotteryService.editParticipants(cancelRequest(601L));
+
+        verify(waitlistPromotionService).sendBatchedAdminWaitlistNotifications(List.of(notif), sess);
+    }
+
+    @Test
+    @DisplayName("editParticipants 当日12:00以降キャンセル: dispatchSameDayCancelNotifications が空を返し、バッチ通知は送られない（afterCommit 登録に委譲）")
+    void editParticipants_sameDayAfternoonCancel_skipsNormalBatchNotification() {
+        PracticeParticipant p = wonParticipant(701L, 12L);
+        when(practiceParticipantRepository.findById(701L)).thenReturn(Optional.of(p));
+
+        // SameDayCancelContext 付きの通知データを返す（当日12:00以降のキャンセル想定）
+        PracticeSession sess = session(6);
+        SameDayCancelContext ctx = SameDayCancelContext.builder()
+                .session(sess).playerId(12L).playerName("選手").matchNumber(MATCH).build();
+        AdminWaitlistNotificationData notif = AdminWaitlistNotificationData.builder()
+                .triggerAction("キャンセル（当日補充）")
+                .triggerPlayerId(12L)
+                .sessionId(100L)
+                .matchNumber(MATCH)
+                .sameDayCancelContext(ctx)
+                .build();
+        when(waitlistPromotionService.cancelParticipationSuppressed(701L, null, null))
+                .thenReturn(notif);
+        // 当日キャンセル分は dispatch 内で afterCommit 登録され、normal リストは空が返る
+        when(waitlistPromotionService.dispatchSameDayCancelNotifications(anyList()))
+                .thenReturn(List.of());
+
+        lotteryService.editParticipants(cancelRequest(701L));
+
+        // dispatch には全件渡される
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<AdminWaitlistNotificationData>> captor = ArgumentCaptor.forClass(List.class);
+        verify(waitlistPromotionService).dispatchSameDayCancelNotifications(captor.capture());
+        assertThat(captor.getValue()).hasSize(1);
+
+        // 当日分のみなので通常バッチ通知は呼ばれない
+        verify(waitlistPromotionService, never()).sendBatchedAdminWaitlistNotifications(anyList(), any());
+    }
+
+    @Test
+    @DisplayName("editParticipants WON→CANCELLED 以外（WAITLISTED→WON など）: 既存の直接 setStatus + save 経路")
+    void editParticipants_otherStatusChange_directSave() {
+        PracticeParticipant p = PracticeParticipant.builder()
+                .id(801L).playerId(13L).sessionId(100L).matchNumber(MATCH)
+                .status(ParticipantStatus.WAITLISTED).waitlistNumber(1).build();
+        when(practiceParticipantRepository.findById(801L)).thenReturn(Optional.of(p));
+        when(waitlistPromotionService.dispatchSameDayCancelNotifications(anyList()))
+                .thenReturn(List.of());
+
+        AdminEditParticipantsRequest.StatusChange change = new AdminEditParticipantsRequest.StatusChange();
+        change.setParticipantId(801L);
+        change.setNewStatus(ParticipantStatus.WON);
+        AdminEditParticipantsRequest req = new AdminEditParticipantsRequest();
+        req.setSessionId(100L);
+        req.setMatchNumber(MATCH);
+        req.setStatusChanges(List.of(change));
+
+        lotteryService.editParticipants(req);
+
+        // 通常経路では setStatus + save が呼ばれる
+        verify(practiceParticipantRepository).save(p);
+        // 委譲メソッドは呼ばれない
+        verify(waitlistPromotionService, never()).cancelParticipationSuppressed(any(), any(), any());
     }
 }


### PR DESCRIPTION
## Summary

2026-04-27 の `/audit-feature` 監査で検出された キャンセル待ち（`WAITLISTED`/`OFFERED`）機能の改修を一括対応。バグ・セキュリティ修正3件＋パフォーマンス・UX改善3件＋テスト・ドキュメント整備3件。

### バグ・セキュリティ修正
- **#590**: `decline-waitlist` / `rejoin-waitlist` に ADMIN 団体スコープ検証を追加（他団体プレイヤーへの操作を 403）
- **#595**: `editParticipants` の WON→CANCELLED を `cancelParticipationSuppressed` 委譲に書き換え。当日12:00を境界とする通常キャンセル経路と同じ三分岐ロジックに統一（従来は当日午前で繰り上げが発動しない静かなバグ）
- **#593** / **#594**: `*Suppressed` 系4メソッドの TX 境界契約を Javadoc に明記。`LotteryController.cancelParticipation` に メソッド単位 `@Transactional` 不在のセンチネルテストを追加し、上流TX付与時に CI で即検出

### パフォーマンス改善
- **#591**: `getWaitlistStatus` の N+1 を `findAllById` で1回SELECTに集約
- **#592**: `renumberRemainingWaitlist` を `saveAll` でバッチ化。`hibernate.jdbc.batch_size=50` / `order_updates=true` / `order_inserts=true` を `application.properties` に追加

### UX改善
- **#597**: `WaitlistStatus.jsx` に fetch エラー時の赤色バナー表示を追加（500エラーで「キャンセル待ちはありません」と誤認する問題を解消）

### ドキュメント
- **#598**: `docs/SPECIFICATION.md` §3.7.2 と `docs/DESIGN.md` API章 / WaitlistPromotionService 章に、当日分岐統一・ADMIN 団体スコープ・TX境界契約を反映

## Related Issues

Closes #589

## Test plan

- [x] `LotteryControllerDeclineWaitlistTest`（新規8テスト）パス
- [x] `LotteryControllerCancelTest`（既存2 + 新規2 = 4テスト）パス
- [x] `LotteryServiceTest`（既存 + 新規4テスト）パス
- [x] `WaitlistPromotionServiceTest` / `WaitlistPromotionServiceAdditionalTest` 既存パス
- [x] フロント ESLint パス
- [ ] PostgreSQL TestContainers が動く環境での integration test 実行（このブランチでは Docker 未起動のためローカル未実施 → CI で確認）
- [ ] 動作確認: ADMIN 他団体への decline/rejoin リクエストが 403、自団体は 200
- [ ] 動作確認: 抽選結果管理画面で当日午前に WON→CANCELLED 変更 → 通常繰り上げ通知発火
- [ ] 動作確認: 当日12:00以降に WON→CANCELLED 変更 → 当日補充フローが afterCommit で起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)