### PR TITLE
fix(densuke-sync): 「登録して再同期」で新規ユーザーの参加情報が読み込まれない不具合を修正

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeImportService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeImportService.java
@@ -870,6 +870,12 @@ public class DensukeImportService {
             log.info("Auto-registered player: {} (org: {})", name, organizationId);
         }
         log.info("Registered {} new players, now re-syncing from densuke", created);
+        // playerRepository.save() を直接使っているため PlayerService の @CacheEvict が効かない。
+        // 直後の importFromDensuke() で findAllPlayersRaw() がキャッシュ済みの古いリストを返し
+        // 新規プレイヤーが playerNameMap にヒットしない不具合を防ぐため、明示的にキャッシュを破棄する。
+        if (created > 0) {
+            playerService.evictPlayersCache();
+        }
         return importFromDensuke(url, targetDate, createdBy, organizationId);
     }
 

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PlayerService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PlayerService.java
@@ -110,6 +110,19 @@ public class PlayerService {
     }
 
     /**
+     * playersキャッシュを明示的にクリアする。
+     *
+     * PlayerService.createPlayer/updatePlayer/... を経由せず、
+     * playerRepository.save() で直接プレイヤーを保存・更新したパスから呼び出すこと。
+     * 例: DensukeImportService.registerAndSync() が伝助同期由来で新規プレイヤーを作成した直後、
+     * 同一トランザクション内で findAllPlayersRaw() を呼ぶ前にキャッシュを破棄する必要がある。
+     */
+    @CacheEvict(value = "players", allEntries = true)
+    public void evictPlayersCache() {
+        // AOP の @CacheEvict によるキャッシュ破棄のみが目的。本体は no-op。
+    }
+
+    /**
      * アクティブな選手数を取得
      */
     public long countActivePlayers() {

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeImportServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeImportServiceTest.java
@@ -277,6 +277,39 @@ class DensukeImportServiceTest {
         assertThat(savedPlayer.getRequirePasswordChange()).isTrue();
         assertThat(savedPlayer.getRole()).isEqualTo(Player.Role.PLAYER);
         verify(organizationService).ensurePlayerBelongsToOrganization(savedPlayer.getId(), 1L);
+        // Issue #601: 新規プレイヤー作成後は importFromDensuke() 内の findAllPlayersRaw() が
+        // 古いキャッシュを返さないよう、明示的に players キャッシュを破棄する必要がある。
+        verify(playerService).evictPlayersCache();
+    }
+
+    @Test
+    @DisplayName("registerAndSyncで全員が既存の場合はキャッシュ破棄を行わない")
+    void testRegisterAndSync_allExisting_noCacheEviction() throws IOException {
+        DensukeData data = createSampleData();
+
+        Player existing = Player.builder().id(99L).name("新人")
+                .role(Player.Role.PLAYER).build();
+
+        when(densukeScraper.scrape(anyString(), anyInt())).thenReturn(data);
+        when(playerRepository.findByNameAndActive("新人")).thenReturn(Optional.of(existing));
+        when(playerService.findAllPlayersRaw()).thenReturn(List.of(player1, player2));
+        when(venueRepository.findAll()).thenReturn(Collections.emptyList());
+        when(practiceSessionRepository.findBySessionDateAndOrganizationId(any(), eq(1L))).thenReturn(Optional.empty());
+        when(practiceSessionRepository.save(any())).thenAnswer(inv -> {
+            PracticeSession s = inv.getArgument(0);
+            s.setId(1L);
+            return s;
+        });
+        when(lotteryDeadlineHelper.getDeadlineType(1L)).thenReturn(DeadlineType.MONTHLY);
+        when(lotteryDeadlineHelper.isBeforeDeadline(2026, 4, 1L)).thenReturn(true);
+        when(practiceParticipantRepository.findBySessionIdAndMatchNumber(anyLong(), anyInt()))
+                .thenReturn(Collections.emptyList());
+
+        densukeImportService.registerAndSync(List.of("新人"), "http://example.com", null, 10L, 1L);
+
+        // 既存プレイヤーのみ → playerRepository.save() も evictPlayersCache() も呼ばれない
+        verify(playerRepository, never()).save(any());
+        verify(playerService, never()).evictPlayersCache();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `DensukeImportService.registerAndSync()` で新規プレイヤーを `playerRepository.save()` で直接保存していたため、`PlayerService` の `@CacheEvict` が発火せず、直後の `importFromDensuke()` 内 `findAllPlayersRaw()`（`@Cacheable("players")` TTL 60秒）が古いキャッシュを返していた
- 結果として新規プレイヤーが `playerNameMap` にヒットせず、伝助上の○（参加）が `practice_participants` に登録されなかった
- 直前の「同期実行」でキャッシュが populate された後60秒以内に「登録して再同期」を押すと再現する時間依存バグ
- `PlayerService.evictPlayersCache()` を追加し、`registerAndSync` で新規プレイヤー作成があった場合のみ明示的にキャッシュを破棄する

## Bug
Fixes #601

## Test plan
- [x] `DensukeImportServiceTest` — 既存の `testRegisterAndSync` に `evictPlayersCache()` 呼び出しの検証を追加
- [x] `testRegisterAndSync_allExisting_noCacheEviction` を新規追加（既存ユーザーのみのときはキャッシュ破棄しないことを検証）
- [x] `PlayerServiceTest` / `DensukeSyncServiceTest` / `DensukeImportServiceMonthFilterTest` / `DensukeImportServicePhaseCoverageTest` のリグレッションなし
- [ ] 本番環境で「同期実行」→「登録して再同期」の動作確認（新規ユーザーの参加日が反映されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)