### PR TITLE
fix(invite): 招待トークン生成時の organization_id 必須化

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -756,7 +756,7 @@ Entity Layer (JPA Entity)
 | id | BIGINT | PK, AUTO_INCREMENT | ID |
 | token | VARCHAR(36) | NOT NULL, UNIQUE | トークン文字列（UUID） |
 | type | ENUM | NOT NULL | MULTI_USE（グループ用）/ SINGLE_USE（個人用） |
-| organization_id | BIGINT | NOT NULL, FK → organizations(id) | 紐付ける団体ID（登録された選手はこの団体に所属） |
+| organization_id | BIGINT | NOT NULL | 紐付ける団体ID（登録された選手はこの団体に所属。DB FK は付与せず、`InviteTokenService` で `organizations.id` の存在検証を行う） |
 | expires_at | DATETIME | NOT NULL | 有効期限 |
 | used_at | DATETIME | | 使用日時（SINGLE_USEのみ） |
 | used_by | BIGINT | | 使用した選手ID（SINGLE_USEのみ） |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -919,7 +919,9 @@ Entity Layer (JPA Entity)
 - `organizationId`（紐付ける団体ID）
   - SUPER_ADMIN: 必須。クエリで指定された団体IDが採用される
   - ADMIN: 不要。サーバ側で発行者の所属団体（`adminOrganizationId`）が自動採用され、クエリ指定値は無視される
-**バリデーション**: `organizationId` 解決後に NULL を検証し、空の場合は 400 Bad Request を返す（ADMIN で `adminOrganizationId` 未設定の場合も同様）
+**バリデーション**:
+- `organizationId` 解決後に NULL を検証し、空の場合は 400 Bad Request を返す（ADMIN で `adminOrganizationId` 未設定の場合も同様）
+- 解決された `organizationId` が `organizations` テーブルに存在しない場合は 404 Not Found を返す（`ResourceNotFoundException`）
 **レスポンス**: `InviteTokenResponse`
 ```json
 {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -756,6 +756,7 @@ Entity Layer (JPA Entity)
 | id | BIGINT | PK, AUTO_INCREMENT | ID |
 | token | VARCHAR(36) | NOT NULL, UNIQUE | トークン文字列（UUID） |
 | type | ENUM | NOT NULL | MULTI_USE（グループ用）/ SINGLE_USE（個人用） |
+| organization_id | BIGINT | NOT NULL, FK → organizations(id) | 紐付ける団体ID（登録された選手はこの団体に所属） |
 | expires_at | DATETIME | NOT NULL | 有効期限 |
 | used_at | DATETIME | | 使用日時（SINGLE_USEのみ） |
 | used_by | BIGINT | | 使用した選手ID（SINGLE_USEのみ） |
@@ -909,15 +910,22 @@ Entity Layer (JPA Entity)
 
 ### 4.2.1 招待トークンAPI (`/api/invite-tokens`)
 
-#### POST /api/invite-tokens?type={type}&createdBy={id}
+#### POST /api/invite-tokens?type={type}&createdBy={id}&organizationId={orgId}
 **説明**: 招待トークン生成
 **権限**: ADMIN+
-**パラメータ**: `type`（MULTI_USE / SINGLE_USE）, `createdBy`（発行者ID）
+**パラメータ**:
+- `type`（MULTI_USE / SINGLE_USE）
+- `createdBy`（発行者ID）
+- `organizationId`（紐付ける団体ID）
+  - SUPER_ADMIN: 必須。クエリで指定された団体IDが採用される
+  - ADMIN: 不要。サーバ側で発行者の所属団体（`adminOrganizationId`）が自動採用され、クエリ指定値は無視される
+**バリデーション**: `organizationId` 解決後に NULL を検証し、空の場合は 400 Bad Request を返す（ADMIN で `adminOrganizationId` 未設定の場合も同様）
 **レスポンス**: `InviteTokenResponse`
 ```json
 {
   "token": "550e8400-e29b-41d4-a716-446655440000",
   "type": "MULTI_USE",
+  "organizationId": 1,
   "expiresAt": "2026-03-28T12:00:00",
   "createdAt": "2026-03-25T12:00:00"
 }

--- a/docs/SCREEN_LIST.md
+++ b/docs/SCREEN_LIST.md
@@ -77,7 +77,7 @@
 
 | # | パス | ページコンポーネント | 主要子コンポーネント | 権限 | 説明 |
 |---|------|---------------------|---------------------|------|------|
-| 21 | `/players` | `PlayerList.jsx` | 検索、段位ソート、ロールバッジ、招待リンク生成（グループ用/個人用） | SUPER_ADMIN | 選手一覧 |
+| 21 | `/players` | `PlayerList.jsx` | 検索、段位ソート、ロールバッジ、招待リンク生成（グループ用/個人用、SUPER_ADMINは招待先団体セレクタで指定／ADMINは自団体固定） | SUPER_ADMIN | 選手一覧 |
 | 22 | `/players/new` | `PlayerEdit.jsx` | — | SUPER_ADMIN | 選手新規作成 |
 | 23 | `/players/:id` | `PlayerDetail.jsx` | — | SUPER_ADMIN | 選手詳細 |
 | 24 | `/players/:id/edit` | `PlayerEdit.jsx` | ロールがADMINの場合に管理団体ドロップダウン表示（SUPER_ADMIN専用） | SUPER_ADMIN | 選手編集 |

--- a/docs/SCREEN_LIST.md
+++ b/docs/SCREEN_LIST.md
@@ -77,7 +77,7 @@
 
 | # | パス | ページコンポーネント | 主要子コンポーネント | 権限 | 説明 |
 |---|------|---------------------|---------------------|------|------|
-| 21 | `/players` | `PlayerList.jsx` | 検索、段位ソート、ロールバッジ、招待リンク生成（グループ用/個人用、SUPER_ADMINは招待先団体セレクタで指定／ADMINは自団体固定） | SUPER_ADMIN | 選手一覧 |
+| 21 | `/players` | `PlayerList.jsx` | 検索、段位ソート、ロールバッジ、招待リンク生成（グループ用/個人用、招待先団体セレクタで指定） | SUPER_ADMIN | 選手一覧 |
 | 22 | `/players/new` | `PlayerEdit.jsx` | — | SUPER_ADMIN | 選手新規作成 |
 | 23 | `/players/:id` | `PlayerDetail.jsx` | — | SUPER_ADMIN | 選手詳細 |
 | 24 | `/players/:id/edit` | `PlayerEdit.jsx` | ロールがADMINの場合に管理団体ドロップダウン表示（SUPER_ADMIN専用） | SUPER_ADMIN | 選手編集 |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1888,7 +1888,7 @@ UNIQUE制約: (player_id, organization_id)
 
 | メソッド | パス | 権限 | 説明 |
 |---|---|---|---|
-| POST | `/?type=&createdBy=` | ADMIN+ | 招待トークン生成（MULTI_USE / SINGLE_USE） |
+| POST | `/?type=&createdBy=&organizationId=` | ADMIN+ | 招待トークン生成（MULTI_USE / SINGLE_USE）。`organizationId` は SUPER_ADMIN は必須、ADMIN はサーバ側で自団体に固定される |
 | GET | `/validate/{token}` | Public | トークン有効性検証 |
 | POST | `/register` | Public | トークン付き公開登録 |
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1888,7 +1888,7 @@ UNIQUE制約: (player_id, organization_id)
 
 | メソッド | パス | 権限 | 説明 |
 |---|---|---|---|
-| POST | `/?type=&createdBy=&organizationId=` | ADMIN+ | 招待トークン生成（MULTI_USE / SINGLE_USE）。`organizationId` は SUPER_ADMIN は必須、ADMIN はサーバ側で自団体に固定される |
+| POST | `/?type=&createdBy=&organizationId=` | ADMIN+ | 招待トークン生成（MULTI_USE / SINGLE_USE）。`organizationId` は SUPER_ADMIN は必須、ADMIN はサーバ側で自団体に固定される。NULL の場合は 400、存在しない団体IDの場合は 404 を返す |
 | GET | `/validate/{token}` | Public | トークン有効性検証 |
 | POST | `/register` | Public | トークン付き公開登録 |
 

--- a/karuta-tracker-ui/src/api/invite.js
+++ b/karuta-tracker-ui/src/api/invite.js
@@ -2,8 +2,12 @@ import apiClient from './client';
 
 export const inviteAPI = {
   // 招待トークン生成（ADMIN以上）
-  createToken: (type, createdBy) =>
-    apiClient.post(`/invite-tokens?type=${type}&createdBy=${createdBy}`),
+  // organizationId: SUPER_ADMIN は必須、ADMIN は無視される（自団体固定）
+  createToken: (type, createdBy, organizationId) => {
+    const params = new URLSearchParams({ type, createdBy });
+    if (organizationId != null) params.set('organizationId', organizationId);
+    return apiClient.post(`/invite-tokens?${params.toString()}`);
+  },
 
   // トークン検証（認証不要）
   validateToken: (token) =>

--- a/karuta-tracker-ui/src/pages/players/PlayerList.jsx
+++ b/karuta-tracker-ui/src/pages/players/PlayerList.jsx
@@ -2,7 +2,9 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { playerAPI } from '../../api/players';
 import { inviteAPI } from '../../api/invite';
+import { organizationAPI } from '../../api/organizations';
 import { useAuth } from '../../context/AuthContext';
+import { isSuperAdmin } from '../../utils/auth';
 import { Search, UserPlus, ChevronRight, Link2, UserCheck, Copy, Check, X } from 'lucide-react';
 import { sortPlayersByRank } from '../../utils/playerSort';
 import LoadingScreen from '../../components/LoadingScreen';
@@ -17,9 +19,20 @@ const PlayerList = () => {
   const [error, setError] = useState('');
   const [inviteMessage, setInviteMessage] = useState(null);
   const [inviteGenerating, setInviteGenerating] = useState(null);
+  const adminOrgId = currentPlayer?.adminOrganizationId || currentPlayer?.organizationId || null;
+  const [organizations, setOrganizations] = useState([]);
+  const [selectedOrgId, setSelectedOrgId] = useState(adminOrgId);
 
   useEffect(() => {
     fetchPlayers();
+    if (isSuperAdmin()) {
+      organizationAPI.getAll()
+        .then(res => {
+          setOrganizations(res.data);
+          setSelectedOrgId(prev => prev || (res.data[0]?.id ?? null));
+        })
+        .catch(err => console.error('Failed to fetch organizations:', err));
+    }
   }, []);
 
   useEffect(() => {
@@ -70,11 +83,18 @@ const PlayerList = () => {
     return `${Math.floor(diffMonths / 12)}年前`;
   };
 
+  const targetOrgId = isSuperAdmin() ? selectedOrgId : adminOrgId;
+
   const generateInviteLink = async (type) => {
+    if (!targetOrgId) {
+      setInviteMessage({ text: '招待先の団体を選択してください', success: false });
+      setTimeout(() => setInviteMessage(null), 3000);
+      return;
+    }
     setInviteGenerating(type);
     setInviteMessage(null);
     try {
-      const response = await inviteAPI.createToken(type, currentPlayer.id);
+      const response = await inviteAPI.createToken(type, currentPlayer.id, targetOrgId);
       const url = `${window.location.origin}/register/${response.data.token}`;
       const label = type === 'MULTI_USE' ? 'グループ招待リンク' : '個人招待リンク';
       try {
@@ -134,10 +154,24 @@ const PlayerList = () => {
         {/* 招待リンク */}
         <div className="mb-3 bg-white rounded-xl shadow-sm p-3">
           <p className="text-xs text-[#6b7280] mb-2">招待リンクを発行してLINE等で共有</p>
+          {isSuperAdmin() && organizations.length > 0 && (
+            <div className="mb-2">
+              <label className="block text-[10px] text-[#6b7280] mb-1">招待先の団体</label>
+              <select
+                value={selectedOrgId || ''}
+                onChange={(e) => setSelectedOrgId(Number(e.target.value))}
+                className="w-full px-2 py-1.5 bg-white border border-[#d4ddd7] rounded text-xs text-[#374151] focus:outline-none focus:ring-2 focus:ring-[#4a6b5a]"
+              >
+                {organizations.map(org => (
+                  <option key={org.id} value={org.id}>{org.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
           <div className="flex gap-2">
             <button
               onClick={() => generateInviteLink('MULTI_USE')}
-              disabled={inviteGenerating}
+              disabled={inviteGenerating || !targetOrgId}
               className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 bg-[#f0f4f1] text-[#4a6b5a] rounded-lg hover:bg-[#e4ebe6] transition-colors text-xs font-medium disabled:opacity-50"
             >
               <Link2 className="w-3.5 h-3.5" />
@@ -145,7 +179,7 @@ const PlayerList = () => {
             </button>
             <button
               onClick={() => generateInviteLink('SINGLE_USE')}
-              disabled={inviteGenerating}
+              disabled={inviteGenerating || !targetOrgId}
               className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 bg-[#f0f4f1] text-[#4a6b5a] rounded-lg hover:bg-[#e4ebe6] transition-colors text-xs font-medium disabled:opacity-50"
             >
               <UserCheck className="w-3.5 h-3.5" />

--- a/karuta-tracker-ui/src/pages/players/PlayerList.jsx
+++ b/karuta-tracker-ui/src/pages/players/PlayerList.jsx
@@ -4,7 +4,6 @@ import { playerAPI } from '../../api/players';
 import { inviteAPI } from '../../api/invite';
 import { organizationAPI } from '../../api/organizations';
 import { useAuth } from '../../context/AuthContext';
-import { isSuperAdmin } from '../../utils/auth';
 import { Search, UserPlus, ChevronRight, Link2, UserCheck, Copy, Check, X } from 'lucide-react';
 import { sortPlayersByRank } from '../../utils/playerSort';
 import LoadingScreen from '../../components/LoadingScreen';
@@ -19,20 +18,17 @@ const PlayerList = () => {
   const [error, setError] = useState('');
   const [inviteMessage, setInviteMessage] = useState(null);
   const [inviteGenerating, setInviteGenerating] = useState(null);
-  const adminOrgId = currentPlayer?.adminOrganizationId || currentPlayer?.organizationId || null;
   const [organizations, setOrganizations] = useState([]);
-  const [selectedOrgId, setSelectedOrgId] = useState(adminOrgId);
+  const [selectedOrgId, setSelectedOrgId] = useState(null);
 
   useEffect(() => {
     fetchPlayers();
-    if (isSuperAdmin()) {
-      organizationAPI.getAll()
-        .then(res => {
-          setOrganizations(res.data);
-          setSelectedOrgId(prev => prev || (res.data[0]?.id ?? null));
-        })
-        .catch(err => console.error('Failed to fetch organizations:', err));
-    }
+    organizationAPI.getAll()
+      .then(res => {
+        setOrganizations(res.data);
+        setSelectedOrgId(prev => prev || (res.data[0]?.id ?? null));
+      })
+      .catch(err => console.error('Failed to fetch organizations:', err));
   }, []);
 
   useEffect(() => {
@@ -83,7 +79,7 @@ const PlayerList = () => {
     return `${Math.floor(diffMonths / 12)}年前`;
   };
 
-  const targetOrgId = isSuperAdmin() ? selectedOrgId : adminOrgId;
+  const targetOrgId = selectedOrgId;
 
   const generateInviteLink = async (type) => {
     if (!targetOrgId) {
@@ -154,7 +150,7 @@ const PlayerList = () => {
         {/* 招待リンク */}
         <div className="mb-3 bg-white rounded-xl shadow-sm p-3">
           <p className="text-xs text-[#6b7280] mb-2">招待リンクを発行してLINE等で共有</p>
-          {isSuperAdmin() && organizations.length > 0 && (
+          {organizations.length > 0 && (
             <div className="mb-2">
               <label className="block text-[10px] text-[#6b7280] mb-1">招待先の団体</label>
               <select

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/InviteTokenController.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/controller/InviteTokenController.java
@@ -31,6 +31,7 @@ public class InviteTokenController {
      *
      * @param type トークン種別（MULTI_USE / SINGLE_USE）
      * @param createdBy 発行者の選手ID
+     * @param organizationId 紐付ける団体ID（SUPER_ADMINは必須、ADMINはサーバ側で自団体を採用）
      * @return トークン情報
      */
     @PostMapping
@@ -45,6 +46,13 @@ public class InviteTokenController {
 
         // ADMINは自動で自団体、SUPER_ADMINはパラメータ指定
         Long targetOrgId = "ADMIN".equals(role) ? adminOrgId : organizationId;
+
+        if (targetOrgId == null) {
+            if ("ADMIN".equals(role)) {
+                throw new IllegalArgumentException("発行者の所属団体が設定されていないため、招待トークンを発行できません");
+            }
+            throw new IllegalArgumentException("organizationId は必須です");
+        }
 
         log.info("POST /api/invite-tokens - Creating token: type={}, createdBy={}, orgId={}", type, createdBy, targetOrgId);
         InviteTokenResponse response = inviteTokenService.createToken(type, createdBy, targetOrgId);

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/InviteTokenService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/InviteTokenService.java
@@ -10,6 +10,7 @@ import com.karuta.matchtracker.entity.PlayerOrganization;
 import com.karuta.matchtracker.exception.DuplicateResourceException;
 import com.karuta.matchtracker.exception.ResourceNotFoundException;
 import com.karuta.matchtracker.repository.InviteTokenRepository;
+import com.karuta.matchtracker.repository.OrganizationRepository;
 import com.karuta.matchtracker.repository.PlayerOrganizationRepository;
 import com.karuta.matchtracker.repository.PlayerRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class InviteTokenService {
     private final InviteTokenRepository inviteTokenRepository;
     private final PlayerRepository playerRepository;
     private final PlayerOrganizationRepository playerOrganizationRepository;
+    private final OrganizationRepository organizationRepository;
 
     /** グループ用トークンの有効期限（時間） */
     private static final int MULTI_USE_EXPIRY_HOURS = 72;
@@ -51,6 +53,10 @@ public class InviteTokenService {
     @Transactional
     public InviteTokenResponse createToken(TokenType type, Long createdBy, Long organizationId) {
         log.info("Creating invite token: type={}, createdBy={}, organizationId={}", type, createdBy, organizationId);
+
+        if (organizationId == null || !organizationRepository.existsById(organizationId)) {
+            throw new ResourceNotFoundException("Organization", organizationId);
+        }
 
         int expiryHours = type == TokenType.MULTI_USE ? MULTI_USE_EXPIRY_HOURS : SINGLE_USE_EXPIRY_HOURS;
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/InviteTokenControllerTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/controller/InviteTokenControllerTest.java
@@ -1,0 +1,128 @@
+package com.karuta.matchtracker.controller;
+
+import com.karuta.matchtracker.dto.InviteTokenResponse;
+import com.karuta.matchtracker.entity.InviteToken.TokenType;
+import com.karuta.matchtracker.entity.Player.Role;
+import com.karuta.matchtracker.service.InviteTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InviteTokenController 単体テスト")
+class InviteTokenControllerTest {
+
+    @Mock
+    private InviteTokenService inviteTokenService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @InjectMocks
+    private InviteTokenController controller;
+
+    @Nested
+    @DisplayName("POST /api/invite-tokens - createToken")
+    class CreateTokenTests {
+
+        @Test
+        @DisplayName("ADMIN: adminOrganizationIdが設定されていれば自団体IDでトークンを発行できる")
+        void createToken_admin_usesAdminOrganizationId() {
+            InviteTokenResponse expected = InviteTokenResponse.builder()
+                    .token("token-1")
+                    .type(TokenType.MULTI_USE.name())
+                    .organizationId(10L)
+                    .expiresAt(LocalDateTime.of(2026, 5, 10, 0, 0))
+                    .createdAt(LocalDateTime.of(2026, 5, 7, 0, 0))
+                    .build();
+
+            when(request.getAttribute("currentUserRole")).thenReturn(Role.ADMIN.name());
+            when(request.getAttribute("adminOrganizationId")).thenReturn(10L);
+            when(inviteTokenService.createToken(TokenType.MULTI_USE, 1L, 10L)).thenReturn(expected);
+
+            ResponseEntity<InviteTokenResponse> response =
+                    controller.createToken(TokenType.MULTI_USE, 1L, null, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            assertThat(response.getBody()).isEqualTo(expected);
+            verify(inviteTokenService).createToken(TokenType.MULTI_USE, 1L, 10L);
+        }
+
+        @Test
+        @DisplayName("ADMIN: クエリで渡されたorganizationIdは無視され、必ずadminOrganizationIdが採用される")
+        void createToken_admin_ignoresQueryOrganizationId() {
+            InviteTokenResponse expected = InviteTokenResponse.builder()
+                    .token("token-2").type(TokenType.SINGLE_USE.name()).organizationId(10L).build();
+
+            when(request.getAttribute("currentUserRole")).thenReturn(Role.ADMIN.name());
+            when(request.getAttribute("adminOrganizationId")).thenReturn(10L);
+            when(inviteTokenService.createToken(TokenType.SINGLE_USE, 1L, 10L)).thenReturn(expected);
+
+            ResponseEntity<InviteTokenResponse> response =
+                    controller.createToken(TokenType.SINGLE_USE, 1L, 999L, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            verify(inviteTokenService).createToken(TokenType.SINGLE_USE, 1L, 10L);
+        }
+
+        @Test
+        @DisplayName("ADMIN: adminOrganizationIdがNULLの場合はIllegalArgumentExceptionで400を返す")
+        void createToken_admin_throwsWhenAdminOrgIdMissing() {
+            when(request.getAttribute("currentUserRole")).thenReturn(Role.ADMIN.name());
+            when(request.getAttribute("adminOrganizationId")).thenReturn(null);
+
+            assertThatThrownBy(() ->
+                    controller.createToken(TokenType.MULTI_USE, 1L, null, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("発行者の所属団体が設定されていない");
+
+            verify(inviteTokenService, never()).createToken(any(TokenType.class), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("SUPER_ADMIN: organizationIdが指定されていればトークンを発行できる")
+        void createToken_superAdmin_usesQueryOrganizationId() {
+            InviteTokenResponse expected = InviteTokenResponse.builder()
+                    .token("token-3").type(TokenType.MULTI_USE.name()).organizationId(20L).build();
+
+            when(request.getAttribute("currentUserRole")).thenReturn(Role.SUPER_ADMIN.name());
+            when(inviteTokenService.createToken(TokenType.MULTI_USE, 2L, 20L)).thenReturn(expected);
+
+            ResponseEntity<InviteTokenResponse> response =
+                    controller.createToken(TokenType.MULTI_USE, 2L, 20L, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+            verify(inviteTokenService).createToken(TokenType.MULTI_USE, 2L, 20L);
+        }
+
+        @Test
+        @DisplayName("SUPER_ADMIN: organizationIdが未指定の場合はIllegalArgumentExceptionで400を返す")
+        void createToken_superAdmin_throwsWhenOrganizationIdMissing() {
+            when(request.getAttribute("currentUserRole")).thenReturn(Role.SUPER_ADMIN.name());
+
+            assertThatThrownBy(() ->
+                    controller.createToken(TokenType.SINGLE_USE, 2L, null, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("organizationId");
+
+            verify(inviteTokenService, never()).createToken(any(TokenType.class), anyLong(), anyLong());
+        }
+    }
+}

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/InviteTokenServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/InviteTokenServiceTest.java
@@ -1,0 +1,79 @@
+package com.karuta.matchtracker.service;
+
+import com.karuta.matchtracker.dto.InviteTokenResponse;
+import com.karuta.matchtracker.entity.InviteToken;
+import com.karuta.matchtracker.entity.InviteToken.TokenType;
+import com.karuta.matchtracker.exception.ResourceNotFoundException;
+import com.karuta.matchtracker.repository.InviteTokenRepository;
+import com.karuta.matchtracker.repository.OrganizationRepository;
+import com.karuta.matchtracker.repository.PlayerOrganizationRepository;
+import com.karuta.matchtracker.repository.PlayerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InviteTokenService 単体テスト")
+class InviteTokenServiceTest {
+
+    @Mock
+    private InviteTokenRepository inviteTokenRepository;
+    @Mock
+    private PlayerRepository playerRepository;
+    @Mock
+    private PlayerOrganizationRepository playerOrganizationRepository;
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @InjectMocks
+    private InviteTokenService inviteTokenService;
+
+    @Test
+    @DisplayName("createToken: organizationIdがnullの場合はResourceNotFoundExceptionをスローし、保存しない")
+    void createToken_throwsWhenOrganizationIdNull() {
+        assertThatThrownBy(() ->
+                inviteTokenService.createToken(TokenType.MULTI_USE, 1L, null))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(inviteTokenRepository, never()).save(any(InviteToken.class));
+    }
+
+    @Test
+    @DisplayName("createToken: 存在しないorganizationIdの場合はResourceNotFoundExceptionをスローし、保存しない")
+    void createToken_throwsWhenOrganizationDoesNotExist() {
+        when(organizationRepository.existsById(999L)).thenReturn(false);
+
+        assertThatThrownBy(() ->
+                inviteTokenService.createToken(TokenType.SINGLE_USE, 2L, 999L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Organization");
+
+        verify(inviteTokenRepository, never()).save(any(InviteToken.class));
+    }
+
+    @Test
+    @DisplayName("createToken: 存在する団体IDが指定されればトークンを発行できる")
+    void createToken_succeedsWhenOrganizationExists() {
+        when(organizationRepository.existsById(10L)).thenReturn(true);
+        when(inviteTokenRepository.save(any(InviteToken.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        InviteTokenResponse response =
+                inviteTokenService.createToken(TokenType.MULTI_USE, 1L, 10L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getOrganizationId()).isEqualTo(10L);
+        assertThat(response.getType()).isEqualTo(TokenType.MULTI_USE.name());
+        verify(inviteTokenRepository).save(any(InviteToken.class));
+    }
+}


### PR DESCRIPTION
## Summary

- 選手管理画面の招待リンク発行時に `organization_id` が未送信となり、`invite_tokens.organization_id` NOT NULL 違反で500応答になっていた問題を修正
- `inviteAPI.createToken` に `organizationId` 引数を追加（API 仕様: SUPER_ADMIN は必須、ADMIN は `adminOrganizationId` に固定されサーバー側で無視される）
- PlayerList に招待先団体セレクタを追加（`/players` は SUPER_ADMIN-only のため SUPER_ADMIN 用 UI として整理）
- 招待先団体未選択時は発行ボタンを disabled 化、未選択クリック時にメッセージ表示
- InviteTokenService で `organizationId` の NULL/存在検証を追加（NULL → 400、存在しない団体 ID → 404）

## Bug

Fixes #628

## Test plan

- [ ] SUPER_ADMIN でログインし、選手管理画面で招待先団体を選択 → グループ用 / 個人用ボタンで招待URLが生成・コピーできる
- [ ] サーバーログに `organization_id ... null value` の例外が出ない
- [ ] 招待先団体未選択時、グループ用 / 個人用ボタンが disabled になる
- [ ] バックエンド単体テスト: InviteTokenControllerTest / InviteTokenServiceTest 緑 (NULL / 存在しない orgId / 正常系を網羅)

## API 仕様メモ（参考）

- `POST /api/invite-tokens` の `organizationId` クエリ: SUPER_ADMIN ロールでは必須、ADMIN ロールでは `adminOrganizationId` で上書きされるため値は無視される（サーバー側の責務分離）

🤖 Generated with [Claude Code](https://claude.com/claude-code)