### PR TITLE
feat(ops): Render DB の月次自動マイグレーションを追加

### DIFF
--- a/.github/workflows/cleanup-old-render-db.yml
+++ b/.github/workflows/cleanup-old-render-db.yml
@@ -1,0 +1,40 @@
+name: Cleanup Old Render PostgreSQL
+
+on:
+  schedule:
+    # 毎日 UTC 15:30 = JST 0:30。
+    # OLD_RENDER_PG_DELETE_AFTER の日時に達していたら旧DBを削除。
+    - cron: '30 15 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'DELETE_AFTER を無視して即削除'
+        type: boolean
+        default: false
+
+concurrency:
+  group: render-db-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run cleanup script
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_GH_PAT: ${{ secrets.RENDER_GH_PAT }}
+          OLD_RENDER_PG_ID: ${{ secrets.OLD_RENDER_PG_ID }}
+          OLD_RENDER_PG_DELETE_AFTER: ${{ secrets.OLD_RENDER_PG_DELETE_AFTER }}
+          LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
+          LINE_NOTIFY_USER_IDS: ${{ secrets.LINE_NOTIFY_USER_IDS }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          chmod +x scripts/render-db-migration/cleanup.sh scripts/render-db-migration/notify-line.sh
+          bash scripts/render-db-migration/cleanup.sh

--- a/.github/workflows/migrate-render-db.yml
+++ b/.github/workflows/migrate-render-db.yml
@@ -1,0 +1,67 @@
+name: Migrate Render PostgreSQL (monthly auto)
+
+on:
+  schedule:
+    # 毎日 UTC 15:00 = JST 0:00 に起動。
+    # スクリプト内で「現DB作成から25日未満ならスキップ」のガードあり。
+    - cron: '0 15 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'ガード判定だけ確認し、実マイグレーションは実行しない'
+        type: boolean
+        default: false
+      force:
+        description: '25日ガードを無視して強制実行'
+        type: boolean
+        default: false
+
+concurrency:
+  group: render-db-migration
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL 18 client
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql-client-18
+          echo "/usr/lib/postgresql/18/bin" >> $GITHUB_PATH
+
+      - name: Run migration script
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_OWNER_ID: ${{ secrets.RENDER_OWNER_ID }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+          RENDER_PG_ID: ${{ secrets.RENDER_PG_ID }}
+          RENDER_GH_PAT: ${{ secrets.RENDER_GH_PAT }}
+          PG_HOST: ${{ secrets.PG_HOST }}
+          PG_USER: ${{ secrets.PG_USER }}
+          PG_PASSWORD: ${{ secrets.PG_PASSWORD }}
+          PG_DATABASE: ${{ secrets.PG_DATABASE }}
+          LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
+          LINE_NOTIFY_USER_IDS: ${{ secrets.LINE_NOTIFY_USER_IDS }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          chmod +x scripts/render-db-migration/migrate.sh scripts/render-db-migration/notify-line.sh
+          bash scripts/render-db-migration/migrate.sh
+
+      - name: Upload dump artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-dump-${{ github.run_id }}
+          path: ${{ runner.temp }}/db-dump-*.sql
+          retention-days: 30
+          if-no-files-found: ignore

--- a/docs/operations/render-database-migration.md
+++ b/docs/operations/render-database-migration.md
@@ -1,14 +1,34 @@
 # Render PostgreSQL データベース移行手順書
 
-Renderの無料プランPostgreSQLデータベースは90日間の制限があります。この手順書では、既存のデータを新しいデータベースに移行する方法を説明します。
+Renderの無料プラン PostgreSQL は約30日で削除されるため、定期的に新しいDBを作成してデータを移行する必要がある。
 
-## 前提条件
+> **2026-05 以降は GitHub Actions による自動マイグレーションが動作している。**
+> 通常運用では本書の手動手順は不要。自動化の初期セットアップ手順は
+> [`render-db-migration-setup.md`](render-db-migration-setup.md) を参照。
+>
+> 本書は以下のケースで使用する：
+> - 自動ワークフローが失敗し、フォールバックで手動移行が必要なとき
+> - 自動ワークフローを止めて緊急で手動運用に戻すとき
+> - 動作原理を理解するための参照資料として
+
+## 自動運用の挙動（参考）
+
+- `.github/workflows/migrate-render-db.yml` が毎日 0:00 JST に起動
+- スクリプト内で「現DBが作成から25日未満ならスキップ」のガードあり
+- 25日以上経過したら自動で：dump → 新DB作成 → restore → env vars 差し替え → 再デプロイ → ヘルスチェック → Secrets 書き戻し
+- 失敗時は env vars を旧DBにロールバック
+- 旧DB は 14日後に `.github/workflows/cleanup-old-render-db.yml` が自動削除
+- 実行結果は LINE Messaging API で通知される
+
+---
+
+## 手動移行手順（自動ワークフロー停止時のフォールバック）
+
+**前提条件:**
 
 - PostgreSQL 18のクライアントツールがインストールされていること
 - 既存のデータベースへのアクセス権限があること
 - 新しいデータベースを作成済みであること
-
-## 手順
 
 ### 1. PostgreSQL 18クライアントツールのインストール
 
@@ -281,8 +301,9 @@ ERROR: permission denied to change default privileges
 
 ## まとめ
 
-- Renderの無料DBは90日制限があるため、定期的な移行が必要
-- pg_dumpとpsqlを使ってデータを完全に移行可能
+- Renderの無料DBは約30日制限があるため、定期的な移行が必要
+- 通常は GitHub Actions による自動マイグレーションが処理する（`migrate-render-db.yml`）
+- 手動フォールバック時は pg_dumpとpsqlを使ってデータを完全に移行可能
 - External URLとInternal URLの使い分けが重要
 - JDBC URLにはクエリパラメータを付けない
 - **Internal接続では必ずポート番号 `:5432` を明示する**
@@ -317,4 +338,4 @@ The connection attempt failed.
 
 ---
 
-**最終更新:** 2026-03-18
+**最終更新:** 2026-05-12（自動マイグレーション導入に伴い手動手順をフォールバック扱いに変更）

--- a/docs/operations/render-db-migration-setup.md
+++ b/docs/operations/render-db-migration-setup.md
@@ -1,0 +1,270 @@
+# Render DB 自動マイグレーション 初期セットアップ手順
+
+Render 無料 PostgreSQL の30日制限を回避するため、月次で「新DB作成 → データ移行 → 環境変数差し替え → 旧DB削除」を GitHub Actions で自動実行する。本書はその初回セットアップ手順をまとめる。
+
+通常運用（自動マイグレーションが動き始めた後の挙動・障害対応）は `docs/operations/render-database-migration.md` を参照。
+
+---
+
+## 全体像
+
+```
+[毎日 0:00 JST]
+  └─ .github/workflows/migrate-render-db.yml が起動
+       └─ 現DB が作成から 25 日未満なら exit 0 (skip)
+       └─ 25 日以上なら：
+            1. pg_dump で現DBをバックアップ
+            2. Render API で新 PostgreSQL (free, v18) を作成
+            3. 新DBが Available になるまでポーリング
+            4. psql で新DBにリストア
+            5. リストア検証（テーブルごとの件数一致）
+            6. Render API で web service の DB_URL/USERNAME/PASSWORD を新DBへ差し替え
+            7. デプロイトリガー → /ping ヘルスチェック
+            8. 失敗時は env vars をロールバック
+            9. 成功時は新DB情報を GitHub Secrets に書き戻す
+           10. 旧DB情報を `OLD_*` Secrets に退避（14日後の削除予約）
+           11. LINE Messaging API で実行結果を通知
+
+[毎日 0:30 JST]
+  └─ .github/workflows/cleanup-old-render-db.yml が起動
+       └─ OLD_RENDER_PG_DELETE_AFTER が現在時刻以前なら旧DB削除
+```
+
+---
+
+## 必要なシークレット一覧
+
+すべて GitHub Secrets に登録する（リポジトリ Settings → Secrets and variables → Actions）。
+
+### 手動で発行・登録するもの（初回のみ）
+
+| Secret名 | 用途 | 取得元 |
+|---|---|---|
+| `RENDER_API_KEY` | Render API 全般 | Render Dashboard → Account Settings → API Keys |
+| `RENDER_OWNER_ID` | 新DB作成時の所有者指定 | Render API（後述コマンド） |
+| `RENDER_SERVICE_ID` | karuta-tracker-api の Service ID | Render API（後述コマンド） |
+| `RENDER_GH_PAT` | Actions から Secrets を更新するための PAT | GitHub Settings → Developer settings → Personal access tokens |
+| `LINE_CHANNEL_ACCESS_TOKEN` | LINE Messaging API でプッシュ送信 | LINE Developers Console |
+| `LINE_NOTIFY_USER_IDS` | 通知先 LINE userId（カンマ区切り） | DB の `players` テーブル or LINE 友だち追加時のログ |
+
+### 自動で更新されるもの（初回登録後、ワークフローが書き換える）
+
+| Secret名 | 用途 |
+|---|---|
+| `RENDER_PG_ID` | 現DB の Postgres リソース ID（25日経過判定に使用） |
+| `PG_HOST` / `PG_USER` / `PG_PASSWORD` / `PG_DATABASE` | 現DB の接続情報 |
+| `OLD_RENDER_PG_ID` | 削除予約中の旧DB ID |
+| `OLD_RENDER_PG_DELETE_AFTER` | 旧DB削除予定日時（ISO 8601） |
+
+初回は `CLAUDE.local.md` の値を元に手動登録する。
+
+---
+
+## 1. Render API Key の取得
+
+1. https://dashboard.render.com/u/settings#api-keys を開く
+2. **Create API Key** をクリック
+3. 名前を `github-actions-db-migration` などにして発行
+4. 表示された API Key をコピー（再表示不可なので必ず控える）
+
+---
+
+## 2. Render の OwnerId と ServiceId の取得
+
+Render API を直接叩いて取得する。API Key を環境変数に入れて以下を実行：
+
+```bash
+export RENDER_API_KEY='<手順1で発行したキー>'
+
+# OwnerId 一覧
+curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
+  https://api.render.com/v1/owners | jq '.[].owner | {id, name, type}'
+
+# Service ID 一覧
+curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
+  "https://api.render.com/v1/services?type=web_service&name=karuta-tracker-api" \
+  | jq '.[].service | {id, name}'
+
+# 現在の PostgreSQL リソース ID
+curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
+  https://api.render.com/v1/postgres | jq '.[].postgres | {id, name, status, createdAt}'
+```
+
+それぞれ次の Secret に登録する：
+- `RENDER_OWNER_ID` ← owner ID
+- `RENDER_SERVICE_ID` ← `karuta-tracker-api` の service ID
+- `RENDER_PG_ID` ← 現在の Postgres ID
+
+---
+
+## 3. GitHub PAT の取得
+
+Actions から Secrets を書き換えるために必要。
+
+1. https://github.com/settings/tokens?type=beta を開く
+2. **Generate new token (fine-grained)** をクリック
+3. 設定：
+   - **Token name**: `match-tracker-db-migration`
+   - **Expiration**: 1 year（有効期限が切れたら再発行が必要）
+   - **Repository access**: Only select repositories → `poponta2020/match-tracker`
+   - **Repository permissions**:
+     - `Secrets`: **Read and write**
+     - `Actions`: Read（任意）
+     - `Metadata`: Read（必須・自動付与）
+4. **Generate token** → 表示されたトークンをコピー
+
+`RENDER_GH_PAT` Secret に登録する。
+
+---
+
+## 4. LINE Messaging API トークンの取得
+
+既に `LineMessagingService` が動いているなら、同じチャネルのアクセストークンを使う。
+
+### 既存 channel を使う場合
+
+`karuta-tracker` の Render 環境変数または `application*.yml` で設定済みの LINE channel access token を `LINE_CHANNEL_ACCESS_TOKEN` Secret にコピーする。
+
+### 新規 channel の場合
+
+1. https://developers.line.biz/console/ にログイン
+2. 該当 Provider → Messaging API channel を選択
+3. **Messaging API settings** タブ → **Channel access token (long-lived)** を Issue
+4. 表示されたトークンを `LINE_CHANNEL_ACCESS_TOKEN` に登録
+
+---
+
+## 5. LINE 通知先 userId の取得
+
+DB 移行通知の宛先となる管理者の LINE userId を控える。複数人ならカンマ区切り。
+
+既存運用に紐付けて取得する：
+
+```bash
+PGPASSWORD='<DBパスワード>' psql \
+  -h dpg-d7fpnf8sfn5c73d7hkgg-a.oregon-postgres.render.com \
+  -U karuta -d karuta_tracker_o7gz \
+  -c "SELECT p.name, p.line_user_id
+      FROM players p
+      WHERE p.role IN ('SUPER_ADMIN', 'ADMIN')
+        AND p.line_user_id IS NOT NULL;"
+```
+
+得られた `line_user_id` をカンマ区切りで `LINE_NOTIFY_USER_IDS` Secret に登録する。
+
+例: `LINE_NOTIFY_USER_IDS=U1234abcd...,U5678efgh...`
+
+---
+
+## 6. 現DB の接続情報を Secrets に登録
+
+`CLAUDE.local.md` の値を元に登録する：
+
+| Secret | 値 |
+|---|---|
+| `PG_HOST` | `dpg-d7fpnf8sfn5c73d7hkgg-a.oregon-postgres.render.com` |
+| `PG_USER` | `karuta` |
+| `PG_PASSWORD` | （`CLAUDE.local.md` の `DB_PASSWORD`） |
+| `PG_DATABASE` | `karuta_tracker_o7gz` |
+
+---
+
+## 7. GitHub Secrets への一括登録（コマンド例）
+
+`gh` CLI が手元にあるなら一括で登録できる：
+
+```bash
+# 必要に応じて gh auth login で先にログイン
+
+REPO=poponta2020/match-tracker
+
+# 値はそれぞれ実際のものに置き換える
+gh secret set RENDER_API_KEY            --repo $REPO --body '<step1の値>'
+gh secret set RENDER_OWNER_ID           --repo $REPO --body '<step2のowner ID>'
+gh secret set RENDER_SERVICE_ID         --repo $REPO --body '<step2のservice ID>'
+gh secret set RENDER_PG_ID              --repo $REPO --body '<step2のpostgres ID>'
+gh secret set RENDER_GH_PAT             --repo $REPO --body '<step3のPAT>'
+gh secret set LINE_CHANNEL_ACCESS_TOKEN --repo $REPO --body '<step4のtoken>'
+gh secret set LINE_NOTIFY_USER_IDS      --repo $REPO --body '<step5のIDカンマ区切り>'
+gh secret set PG_HOST                   --repo $REPO --body '<step6の値>'
+gh secret set PG_USER                   --repo $REPO --body '<step6の値>'
+gh secret set PG_PASSWORD               --repo $REPO --body '<step6の値>'
+gh secret set PG_DATABASE               --repo $REPO --body '<step6の値>'
+```
+
+登録確認：
+
+```bash
+gh secret list --repo $REPO
+```
+
+---
+
+## 8. 初回動作確認
+
+### Dry-run（実際にはマイグレーションしない動作テスト）
+
+```bash
+gh workflow run migrate-render-db.yml --repo $REPO -f dry_run=true
+```
+
+ジョブログで以下が確認できれば OK：
+- 現DB の createdAt 取得に成功
+- 25日ガードの判定が正しく出力される
+- dry_run なので実際の pg_dump 以降は実行されない（早期 exit）
+
+### 強制実行（25日ガードを無視して本番フローを通す）
+
+```bash
+gh workflow run migrate-render-db.yml --repo $REPO -f force=true
+```
+
+**注意:** これは本番DBを実際に置き換える。動作確認は十分に検証してから。
+
+---
+
+## 9. 通常運用の挙動
+
+セットアップ完了後は完全に放置で動作する：
+
+- **毎日 0:00 JST**: ガード判定のみ。25日未満なら何もせず exit
+- **25日経過後の起動**: 実際のマイグレーション実行 → LINE 通知
+- **マイグレーション翌日以降の毎日 0:30 JST**: 旧DB の削除予定日時に達していれば削除 → LINE 通知
+
+ユーザーがやること：
+1. LINE 通知が来たら成功/失敗を確認
+2. 失敗していた場合は Actions ログを確認
+3. 成功したら `CLAUDE.local.md` の DB 接続情報を新DBの値に書き換え（ローカル開発用）
+   - LINE 通知に新DB の `DB_URL`/`DB_USERNAME`/`DB_PASSWORD` が含まれる
+
+---
+
+## トラブルシューティング
+
+### Actions が起動しない
+
+- `.github/workflows/migrate-render-db.yml` がデフォルトブランチ（main）にマージされているか確認
+- Actions が無効化されていないか（Settings → Actions → General）
+
+### Render API 401 エラー
+
+- `RENDER_API_KEY` の有効期限切れ。再発行して Secret を更新
+
+### LINE 通知が届かない
+
+- `LINE_CHANNEL_ACCESS_TOKEN` が long-lived トークンか確認
+- `LINE_NOTIFY_USER_IDS` の userId が当該 LINE Bot を友だち追加済みか確認
+- ジョブログで `line-api-error` 行を確認
+
+### マイグレーションが失敗してロールバックされた
+
+- 旧DB はまだ生きているので、サービスは継続稼働
+- ジョブログで失敗ステップを特定
+- 必要なら Actions の `force=true` で再実行
+- 旧DB の期限切れが迫っているなら、`docs/operations/render-database-migration.md` の手動手順でフォールバック
+
+### PAT の有効期限切れ
+
+- 1年に1回再発行が必要
+- 期限が近づくと GitHub からメール通知が来る
+- 期限切れになると Secrets 自動更新が失敗 → 次回マイグレーションで失敗

--- a/scripts/render-db-migration/cleanup.sh
+++ b/scripts/render-db-migration/cleanup.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# 旧 Render PostgreSQL 削除スクリプト
+#
+# 必要な環境変数:
+#   RENDER_API_KEY
+#   RENDER_GH_PAT
+#   OLD_RENDER_PG_ID            ... 削除対象 ID（空ならスキップ）
+#   OLD_RENDER_PG_DELETE_AFTER  ... ISO 8601、これより未来なら何もしない
+#   LINE_CHANNEL_ACCESS_TOKEN, LINE_NOTIFY_USER_IDS
+#   GITHUB_REPOSITORY
+# 任意:
+#   FORCE=true  ... DELETE_AFTER を無視して即削除
+#
+set -euo pipefail
+
+FORCE="${FORCE:-false}"
+RENDER_API="https://api.render.com/v1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log()  { echo "[$(date -u +%H:%M:%S)] $*"; }
+warn() { echo "[$(date -u +%H:%M:%S)] WARN: $*" >&2; }
+err()  { echo "[$(date -u +%H:%M:%S)] ERROR: $*" >&2; }
+
+notify() {
+  "$SCRIPT_DIR/notify-line.sh" "$1" "$2" "$3" || warn "LINE通知失敗"
+}
+
+render_api() {
+  local method="$1"; local path="$2"
+  curl -sS -X "$method" -H "Authorization: Bearer $RENDER_API_KEY" \
+    -H "Accept: application/json" "$RENDER_API$path"
+}
+
+OLD_ID="${OLD_RENDER_PG_ID:-}"
+OLD_AT="${OLD_RENDER_PG_DELETE_AFTER:-}"
+
+if [[ -z "$OLD_ID" ]]; then
+  log "OLD_RENDER_PG_ID が未設定。削除対象なし。"
+  exit 0
+fi
+
+if [[ "$FORCE" != "true" ]]; then
+  if [[ -z "$OLD_AT" ]]; then
+    log "OLD_RENDER_PG_DELETE_AFTER が未設定。スキップ。"
+    exit 0
+  fi
+  NOW=$(date -u +%s)
+  TARGET=$(date -u -d "$OLD_AT" +%s)
+  if [[ "$NOW" -lt "$TARGET" ]]; then
+    log "削除予定時刻 $OLD_AT までまだ時間があります（残り $(( (TARGET-NOW)/3600 )) 時間）"
+    exit 0
+  fi
+fi
+
+# 削除実行
+log "旧DBを削除: $OLD_ID"
+RESP_CODE=$(curl -sS -o /tmp/del-resp.json -w "%{http_code}" \
+  -X DELETE -H "Authorization: Bearer $RENDER_API_KEY" \
+  "$RENDER_API/postgres/$OLD_ID" || echo "000")
+
+case "$RESP_CODE" in
+  204|404)
+    log "削除成功 (HTTP $RESP_CODE)"
+    ;;
+  *)
+    err "削除失敗 (HTTP $RESP_CODE): $(cat /tmp/del-resp.json 2>/dev/null || true)"
+    notify failure "旧Render DB削除失敗" "旧DB($OLD_ID) の削除APIが HTTP $RESP_CODE を返しました。手動確認してください。"
+    exit 1
+    ;;
+esac
+
+# Secret を空にしてループ脱出
+clear_secret() {
+  local name="$1"
+  GH_TOKEN="$RENDER_GH_PAT" gh secret delete "$name" --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+  log "  $name cleared"
+}
+clear_secret "OLD_RENDER_PG_ID"
+clear_secret "OLD_RENDER_PG_DELETE_AFTER"
+
+notify success "旧Render DB削除完了" "旧DB($OLD_ID) を削除しました。"
+log "完了"

--- a/scripts/render-db-migration/migrate.sh
+++ b/scripts/render-db-migration/migrate.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+#
+# Render PostgreSQL 自動マイグレーションスクリプト
+#
+# 必要な環境変数:
+#   RENDER_API_KEY, RENDER_OWNER_ID, RENDER_SERVICE_ID, RENDER_PG_ID
+#   RENDER_GH_PAT
+#   PG_HOST, PG_USER, PG_PASSWORD, PG_DATABASE
+#   LINE_CHANNEL_ACCESS_TOKEN, LINE_NOTIFY_USER_IDS
+#   GITHUB_REPOSITORY
+# 任意:
+#   DRY_RUN=true   ... pg_dump 以降を実行せず判定のみ
+#   FORCE=true     ... 25日ガードを無視して強制実行
+#   MIN_AGE_DAYS=25 ... ガードの閾値 (デフォルト 25)
+#
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-false}"
+FORCE="${FORCE:-false}"
+MIN_AGE_DAYS="${MIN_AGE_DAYS:-25}"
+DELETE_AFTER_DAYS="${DELETE_AFTER_DAYS:-14}"
+
+RENDER_API="https://api.render.com/v1"
+NEW_DB_NAME="karuta-tracker-db-$(date -u +%Y%m%d)"
+NEW_DB_DATABASE="karuta_tracker"
+NEW_DB_USER="karuta"
+NEW_DB_REGION="oregon"
+NEW_DB_VERSION="18"
+NEW_DB_PLAN="free"
+
+DUMP_FILE="${RUNNER_TEMP:-/tmp}/db-dump-$(date -u +%Y%m%d-%H%M%S).sql"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log()  { echo "[$(date -u +%H:%M:%S)] $*"; }
+warn() { echo "[$(date -u +%H:%M:%S)] WARN: $*" >&2; }
+err()  { echo "[$(date -u +%H:%M:%S)] ERROR: $*" >&2; }
+
+notify() {
+  local status="$1"; local title="$2"; local body="$3"
+  "$SCRIPT_DIR/notify-line.sh" "$status" "$title" "$body" || warn "LINE通知失敗（処理は継続）"
+}
+
+render_api() {
+  local method="$1"; local path="$2"; local payload="${3:-}"
+  local args=(-sS -X "$method" -H "Authorization: Bearer $RENDER_API_KEY" -H "Accept: application/json")
+  if [[ -n "$payload" ]]; then
+    args+=(-H "Content-Type: application/json" --data "$payload")
+  fi
+  curl "${args[@]}" "$RENDER_API$path"
+}
+
+require_env() {
+  local missing=()
+  for v in RENDER_API_KEY RENDER_OWNER_ID RENDER_SERVICE_ID RENDER_PG_ID RENDER_GH_PAT \
+           PG_HOST PG_USER PG_PASSWORD PG_DATABASE \
+           LINE_CHANNEL_ACCESS_TOKEN LINE_NOTIFY_USER_IDS GITHUB_REPOSITORY; do
+    if [[ -z "${!v:-}" ]]; then missing+=("$v"); fi
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    err "必須環境変数が未設定: ${missing[*]}"
+    exit 2
+  fi
+}
+
+#=== 1. 事前チェック =========================================================
+require_env
+
+log "現DB情報を取得: pgId=$RENDER_PG_ID"
+CURRENT_PG_JSON=$(render_api GET "/postgres/$RENDER_PG_ID")
+# レスポンス形式が `{...}` と `{"postgres": {...}}` の両方ある可能性に備えて両対応
+CURRENT_CREATED_AT=$(echo "$CURRENT_PG_JSON" | jq -r '.createdAt // .postgres.createdAt // empty')
+
+if [[ -z "$CURRENT_CREATED_AT" ]]; then
+  err "現DBの createdAt 取得失敗。Render API レスポンス: $CURRENT_PG_JSON"
+  notify failure "Render DB 自動マイグレーション失敗" "現DBの情報取得に失敗しました。RENDER_PG_ID が正しいか確認してください。"
+  exit 1
+fi
+
+# 経過日数の判定
+CREATED_EPOCH=$(date -u -d "$CURRENT_CREATED_AT" +%s)
+NOW_EPOCH=$(date -u +%s)
+AGE_DAYS=$(( (NOW_EPOCH - CREATED_EPOCH) / 86400 ))
+
+log "現DB作成日: $CURRENT_CREATED_AT (経過 $AGE_DAYS 日)"
+
+if [[ "$FORCE" != "true" && "$AGE_DAYS" -lt "$MIN_AGE_DAYS" ]]; then
+  log "経過日数 $AGE_DAYS < $MIN_AGE_DAYS 日のため、マイグレーションをスキップします"
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  log "DRY_RUN=true のため、ここで終了します（実マイグレーションは実行しません）"
+  exit 0
+fi
+
+#=== 2. pg_dump =============================================================
+log "現DBから pg_dump を取得します"
+PGPASSWORD="$PG_PASSWORD" pg_dump \
+  -h "$PG_HOST" -U "$PG_USER" -d "$PG_DATABASE" \
+  --no-owner --no-privileges --format=plain \
+  > "$DUMP_FILE"
+
+DUMP_SIZE=$(stat -c%s "$DUMP_FILE")
+log "ダンプ取得完了: $DUMP_FILE ($DUMP_SIZE bytes)"
+
+if [[ "$DUMP_SIZE" -lt 1024 ]]; then
+  err "ダンプサイズが異常に小さい ($DUMP_SIZE bytes)"
+  notify failure "Render DB 自動マイグレーション失敗" "pg_dump の出力が小さすぎます (${DUMP_SIZE} bytes)。"
+  exit 1
+fi
+
+# 件数比較用に source DB の行数を取得（psql で直接 count → ダンプ依存なし）
+declare -A SRC_COUNTS
+for table in players matches practice_sessions practice_participants match_pairings venues; do
+  SRC_COUNTS[$table]=$(PGPASSWORD="$PG_PASSWORD" psql \
+    -h "$PG_HOST" -U "$PG_USER" -d "$PG_DATABASE" \
+    -tAc "SELECT COUNT(*) FROM $table;")
+  log "  source.$table = ${SRC_COUNTS[$table]} 行"
+done
+
+#=== 3. 新DB作成 ============================================================
+log "新DBを作成します: name=$NEW_DB_NAME"
+
+CREATE_PAYLOAD=$(jq -n \
+  --arg name "$NEW_DB_NAME" \
+  --arg ownerId "$RENDER_OWNER_ID" \
+  --arg databaseName "$NEW_DB_DATABASE" \
+  --arg databaseUser "$NEW_DB_USER" \
+  --arg region "$NEW_DB_REGION" \
+  --arg version "$NEW_DB_VERSION" \
+  --arg plan "$NEW_DB_PLAN" \
+  '{name:$name, ownerId:$ownerId, databaseName:$databaseName, databaseUser:$databaseUser, region:$region, version:$version, plan:$plan}')
+
+NEW_PG_JSON=$(render_api POST "/postgres" "$CREATE_PAYLOAD")
+NEW_PG_ID=$(echo "$NEW_PG_JSON" | jq -r '.id // .postgres.id // empty')
+
+if [[ -z "$NEW_PG_ID" ]]; then
+  err "新DB作成失敗。レスポンス: $NEW_PG_JSON"
+  notify failure "Render DB 自動マイグレーション失敗" "新DB作成APIが ID を返しませんでした。Render側のクォータ等を確認してください。"
+  exit 1
+fi
+log "新DB作成リクエスト受理: id=$NEW_PG_ID"
+
+# rollback 用に「失敗したら作成済みの新DBは削除」をセット
+ROLLBACK_NEW_PG=true
+cleanup() {
+  if [[ "${ROLLBACK_NEW_PG:-false}" == "true" && -n "${NEW_PG_ID:-}" ]]; then
+    warn "失敗のため作成済み新DBを削除: $NEW_PG_ID"
+    render_api DELETE "/postgres/$NEW_PG_ID" >/dev/null || true
+  fi
+}
+trap cleanup ERR
+
+#=== 4. 新DB が available になるまでポーリング ===============================
+log "新DBが available になるまで待機します（最大 20 分）"
+DEADLINE=$(( $(date -u +%s) + 1200 ))
+while :; do
+  STATUS_JSON=$(render_api GET "/postgres/$NEW_PG_ID")
+  STATUS=$(echo "$STATUS_JSON" | jq -r '.status // .postgres.status // empty')
+  log "  status=$STATUS"
+  if [[ "$STATUS" == "available" ]]; then
+    log "新DBが available。接続安定化のため 30 秒待機"
+    sleep 30
+    break
+  fi
+  if [[ "$STATUS" == "suspended" || "$STATUS" == "deleting" || "$STATUS" == "unknown" ]]; then
+    err "新DBが予期しない status になりました: $STATUS"
+    notify failure "Render DB 自動マイグレーション失敗" "新DBの status が $STATUS になりました。"
+    exit 1
+  fi
+  if [[ $(date -u +%s) -gt $DEADLINE ]]; then
+    err "新DBが20分以内に available になりませんでした"
+    notify failure "Render DB 自動マイグレーション失敗" "新DB($NEW_PG_ID) が available にならないままタイムアウト。"
+    exit 1
+  fi
+  sleep 20
+done
+
+#=== 5. 新DB接続情報取得 =====================================================
+log "新DB接続情報を取得します"
+CONN_JSON=$(render_api GET "/postgres/$NEW_PG_ID/connection-info")
+NEW_PG_PASSWORD=$(echo "$CONN_JSON" | jq -r '.password // empty')
+NEW_PG_EXT_URL=$(echo "$CONN_JSON" | jq -r '.externalConnectionString // empty')
+NEW_PG_INT_URL=$(echo "$CONN_JSON" | jq -r '.internalConnectionString // empty')
+
+if [[ -z "$NEW_PG_PASSWORD" || -z "$NEW_PG_EXT_URL" ]]; then
+  err "新DB接続情報取得失敗。レスポンス: $CONN_JSON"
+  notify failure "Render DB 自動マイグレーション失敗" "新DB接続情報の取得に失敗しました。"
+  exit 1
+fi
+
+# external URL から host と database 名を抽出
+# 形式: postgresql://user:pass@host/database
+NEW_PG_HOST=$(echo "$NEW_PG_EXT_URL" | sed -E 's|^postgresql://[^@]+@([^/]+)/.*$|\1|')
+NEW_PG_DATABASE=$(echo "$NEW_PG_EXT_URL" | sed -E 's|^postgresql://[^@]+@[^/]+/([^?]+).*$|\1|')
+
+if [[ -z "$NEW_PG_HOST" || -z "$NEW_PG_DATABASE" ]]; then
+  err "新DB external URL のパース失敗: $NEW_PG_EXT_URL"
+  notify failure "Render DB 自動マイグレーション失敗" "新DBの接続URLパースに失敗しました。"
+  exit 1
+fi
+
+# internal URL のホスト部（Renderサービス間アクセス用、ドメインなし）
+NEW_PG_INT_HOST=$(echo "$NEW_PG_INT_URL" | sed -E 's|^postgresql://[^@]+@([^/]+)/.*$|\1|')
+
+log "新DB: host=$NEW_PG_HOST  internalHost=$NEW_PG_INT_HOST  db=$NEW_PG_DATABASE"
+
+#=== 6. リストア =============================================================
+log "新DBへリストア実行"
+PGPASSWORD="$NEW_PG_PASSWORD" psql \
+  -h "$NEW_PG_HOST" -U "$NEW_DB_USER" -d "$NEW_PG_DATABASE" \
+  -v ON_ERROR_STOP=1 \
+  -f "$DUMP_FILE" \
+  > /tmp/restore.log 2>&1 || {
+    err "リストア失敗。tail of restore log:"
+    tail -50 /tmp/restore.log >&2
+    notify failure "Render DB 自動マイグレーション失敗" "新DBへのリストアに失敗しました。"
+    exit 1
+  }
+log "リストア完了"
+
+#=== 7. リストア検証 =========================================================
+log "リストア結果を検証します"
+verify_count() {
+  local table="$1"; local expected="$2"
+  local actual
+  actual=$(PGPASSWORD="$NEW_PG_PASSWORD" psql \
+    -h "$NEW_PG_HOST" -U "$NEW_DB_USER" -d "$NEW_PG_DATABASE" \
+    -tAc "SELECT COUNT(*) FROM $table;")
+  if [[ "$actual" != "$expected" ]]; then
+    err "  $table: 期待値 $expected ≠ 実際 $actual"
+    return 1
+  fi
+  log "  $table: $actual 行 (一致)"
+}
+
+VERIFY_FAILED=false
+for table in "${!SRC_COUNTS[@]}"; do
+  verify_count "$table" "${SRC_COUNTS[$table]}" || VERIFY_FAILED=true
+done
+
+if [[ "$VERIFY_FAILED" == "true" ]]; then
+  notify failure "Render DB 自動マイグレーション失敗" "リストア後のレコード件数が一致しません。"
+  exit 1
+fi
+
+#=== 8. ロールバック用に現 env vars を保存 ===================================
+log "現在の env vars をロールバック用に取得"
+OLD_ENV_RAW=$(render_api GET "/services/$RENDER_SERVICE_ID/env-vars")
+# レスポンスが [{"envVar": {...}}, ...] と [{"key":..,"value":..}, ...] のどちらでも処理できるよう正規化
+OLD_ENV_NORM=$(echo "$OLD_ENV_RAW" | jq '[.[] | if .envVar then .envVar else . end | {key, value}]')
+OLD_ENV_COUNT=$(echo "$OLD_ENV_NORM" | jq 'length')
+log "現env vars 件数: $OLD_ENV_COUNT"
+
+if [[ "$OLD_ENV_COUNT" == "0" || "$OLD_ENV_COUNT" == "null" ]]; then
+  err "env vars 取得失敗。raw: $OLD_ENV_RAW"
+  notify failure "Render DB 自動マイグレーション失敗" "web service の env vars 取得に失敗しました。"
+  exit 1
+fi
+
+#=== 9. env vars 更新 ========================================================
+NEW_DB_URL_JDBC="jdbc:postgresql://$NEW_PG_INT_HOST:5432/$NEW_PG_DATABASE"
+
+log "web service の env vars を新DB情報で置き換えます"
+
+NEW_ENV_PAYLOAD=$(echo "$OLD_ENV_NORM" | jq \
+  --arg url "$NEW_DB_URL_JDBC" \
+  --arg user "$NEW_DB_USER" \
+  --arg pass "$NEW_PG_PASSWORD" \
+  '[.[] | if .key == "DB_URL" then .value = $url
+          elif .key == "DB_USERNAME" then .value = $user
+          elif .key == "DB_PASSWORD" then .value = $pass
+          else . end]')
+
+UPDATE_RESP=$(render_api PUT "/services/$RENDER_SERVICE_ID/env-vars" "$NEW_ENV_PAYLOAD")
+log "env vars 更新レスポンス受信"
+
+# 失敗したら env vars を元に戻す
+ROLLBACK_ENV=true
+rollback_env() {
+  if [[ "${ROLLBACK_ENV:-false}" != "true" ]]; then return 0; fi
+  warn "env vars をロールバックします"
+  render_api PUT "/services/$RENDER_SERVICE_ID/env-vars" "$OLD_ENV_NORM" >/dev/null || true
+  render_api POST "/services/$RENDER_SERVICE_ID/deploys" '{"clearCache":"do_not_clear"}' >/dev/null || true
+}
+cleanup() {
+  rollback_env
+  if [[ "${ROLLBACK_NEW_PG:-false}" == "true" && -n "${NEW_PG_ID:-}" ]]; then
+    warn "失敗のため作成済み新DBを削除: $NEW_PG_ID"
+    render_api DELETE "/postgres/$NEW_PG_ID" >/dev/null || true
+  fi
+}
+trap cleanup ERR
+
+#=== 10. デプロイトリガー ===================================================
+log "再デプロイをトリガーします"
+DEPLOY_RESP=$(render_api POST "/services/$RENDER_SERVICE_ID/deploys" '{"clearCache":"do_not_clear"}')
+DEPLOY_ID=$(echo "$DEPLOY_RESP" | jq -r '.id // .deploy.id // empty')
+
+if [[ -z "$DEPLOY_ID" ]]; then
+  err "デプロイ ID 取得失敗: $DEPLOY_RESP"
+  notify failure "Render DB 自動マイグレーション失敗" "デプロイトリガーが失敗しました。"
+  exit 1
+fi
+log "デプロイ開始: id=$DEPLOY_ID"
+
+#=== 11. デプロイ完了を待つ =================================================
+DEADLINE=$(( $(date -u +%s) + 1500 ))   # 25分
+while :; do
+  D_JSON=$(render_api GET "/services/$RENDER_SERVICE_ID/deploys/$DEPLOY_ID")
+  D_STATUS=$(echo "$D_JSON" | jq -r '.status // .deploy.status // empty')
+  log "  deploy.status=$D_STATUS"
+  case "$D_STATUS" in
+    live) break ;;
+    build_failed|deploy_failed|update_failed|pre_deploy_failed|canceled)
+      err "デプロイ失敗: $D_STATUS"
+      notify failure "Render DB 自動マイグレーション失敗" "再デプロイが失敗しました (status=$D_STATUS)。env varsをロールバックします。"
+      exit 1
+      ;;
+  esac
+  if [[ $(date -u +%s) -gt $DEADLINE ]]; then
+    err "デプロイが25分以内に完了しませんでした"
+    notify failure "Render DB 自動マイグレーション失敗" "デプロイがタイムアウトしました。"
+    exit 1
+  fi
+  sleep 20
+done
+log "デプロイ完了 (live)"
+
+#=== 12. /ping ヘルスチェック ===============================================
+SERVICE_INFO=$(render_api GET "/services/$RENDER_SERVICE_ID")
+SERVICE_URL=$(echo "$SERVICE_INFO" | jq -r '
+  .serviceDetails.url
+  // .serviceDetails.externalUrl
+  // .service.serviceDetails.url
+  // .service.serviceDetails.externalUrl
+  // empty
+')
+if [[ -n "$SERVICE_URL" ]]; then
+  log "ヘルスチェック: $SERVICE_URL/ping"
+  for i in 1 2 3 4 5; do
+    HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" "$SERVICE_URL/ping" || echo "000")
+    if [[ "$HTTP_CODE" == "200" ]]; then
+      log "  /ping = 200 OK"
+      break
+    fi
+    log "  attempt $i: /ping = $HTTP_CODE, retrying in 15s"
+    if [[ "$i" == "5" ]]; then
+      err "ヘルスチェック失敗 (最終 HTTP $HTTP_CODE)"
+      notify failure "Render DB 自動マイグレーション失敗" "/ping が 200 を返しません ($HTTP_CODE)。"
+      exit 1
+    fi
+    sleep 15
+  done
+else
+  warn "service URL が取得できないためヘルスチェックをスキップ"
+fi
+
+#=== 13. ここまで来たらロールバック不要 =====================================
+ROLLBACK_NEW_PG=false
+ROLLBACK_ENV=false
+trap - ERR
+
+#=== 14. GitHub Secrets を新DB情報で更新 ====================================
+log "GitHub Secrets を新DB情報で更新します"
+set_secret() {
+  local name="$1"; local value="$2"
+  printf '%s' "$value" | GH_TOKEN="$RENDER_GH_PAT" gh secret set "$name" --repo "$GITHUB_REPOSITORY" --body-file -
+  log "  $name updated"
+}
+
+# 旧DB情報を退避（cleanup ワークフローが14日後に削除する）
+DELETE_AFTER=$(date -u -d "+$DELETE_AFTER_DAYS days" +%Y-%m-%dT%H:%M:%SZ)
+set_secret "OLD_RENDER_PG_ID"           "$RENDER_PG_ID"
+set_secret "OLD_RENDER_PG_DELETE_AFTER" "$DELETE_AFTER"
+
+# 新DB情報を「現DB」として書き戻し
+set_secret "RENDER_PG_ID" "$NEW_PG_ID"
+set_secret "PG_HOST"      "$NEW_PG_HOST"
+set_secret "PG_USER"      "$NEW_DB_USER"
+set_secret "PG_PASSWORD"  "$NEW_PG_PASSWORD"
+set_secret "PG_DATABASE"  "$NEW_PG_DATABASE"
+
+#=== 15. 成功通知 ===========================================================
+SUMMARY=$(cat <<EOF
+Render PostgreSQL 自動マイグレーション完了
+
+新DB:
+  name: $NEW_DB_NAME
+  id:   $NEW_PG_ID
+  host: $NEW_PG_HOST
+  db:   $NEW_PG_DATABASE
+  user: $NEW_DB_USER
+
+旧DB:
+  id:   $RENDER_PG_ID
+  作成: $CURRENT_CREATED_AT (経過 $AGE_DAYS 日)
+  削除予定: $DELETE_AFTER
+
+ローカル開発の CLAUDE.local.md を更新してください:
+DB_URL=jdbc:postgresql://$NEW_PG_HOST/$NEW_PG_DATABASE
+DB_USERNAME=$NEW_DB_USER
+DB_PASSWORD=$NEW_PG_PASSWORD
+EOF
+)
+
+notify success "Render DB 自動マイグレーション成功" "$SUMMARY"
+log "全工程完了"

--- a/scripts/render-db-migration/notify-line.sh
+++ b/scripts/render-db-migration/notify-line.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# LINE Messaging API push helper.
+#
+# Usage: notify-line.sh <success|failure|info> <title> <body>
+#
+# 必要な環境変数:
+#   LINE_CHANNEL_ACCESS_TOKEN
+#   LINE_NOTIFY_USER_IDS    ... カンマ区切り
+#
+set -euo pipefail
+
+STATUS="${1:-info}"
+TITLE="${2:-}"
+BODY="${3:-}"
+
+if [[ -z "${LINE_CHANNEL_ACCESS_TOKEN:-}" || -z "${LINE_NOTIFY_USER_IDS:-}" ]]; then
+  echo "LINE 通知用 env が未設定のためスキップ" >&2
+  exit 0
+fi
+
+case "$STATUS" in
+  success) PREFIX="[OK]" ;;
+  failure) PREFIX="[NG]" ;;
+  *)       PREFIX="[INFO]" ;;
+esac
+
+MESSAGE="$PREFIX $TITLE"
+if [[ -n "$BODY" ]]; then
+  MESSAGE="$MESSAGE
+
+$BODY"
+fi
+
+# LINE の text メッセージ上限 5000 文字
+if [[ ${#MESSAGE} -gt 4900 ]]; then
+  MESSAGE="${MESSAGE:0:4900}
+... (truncated)"
+fi
+
+IFS=',' read -ra USER_IDS <<< "$LINE_NOTIFY_USER_IDS"
+
+EXIT_CODE=0
+for raw in "${USER_IDS[@]}"; do
+  uid="$(echo "$raw" | tr -d '[:space:]')"
+  [[ -z "$uid" ]] && continue
+
+  PAYLOAD=$(jq -n --arg to "$uid" --arg text "$MESSAGE" \
+    '{to:$to, messages:[{type:"text", text:$text}]}')
+
+  HTTP_CODE=$(curl -sS -o /tmp/line-resp.json -w "%{http_code}" \
+    -X POST https://api.line.me/v2/bot/message/push \
+    -H "Authorization: Bearer $LINE_CHANNEL_ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    --data "$PAYLOAD" || echo "000")
+
+  if [[ "$HTTP_CODE" != "200" ]]; then
+    echo "line-api-error uid=$uid http=$HTTP_CODE body=$(cat /tmp/line-resp.json 2>/dev/null || true)" >&2
+    EXIT_CODE=1
+  fi
+done
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- Render 無料 PostgreSQL の30日制限を回避する月次自動マイグレーションを追加
- 毎日 0:00 JST 起動、現DBが25日経過したら新DB作成 → リストア → env vars 差し替え → 再デプロイ → 旧DB(14日後)削除を完全自動化
- 失敗時は env vars と新DBを自動ロールバック
- 実行結果は LINE Messaging API で SUPER_ADMIN に通知

## 追加ファイル
- `.github/workflows/migrate-render-db.yml` - 月次マイグレーション本体
- `.github/workflows/cleanup-old-render-db.yml` - 旧DB削除
- `scripts/render-db-migration/migrate.sh` - メインロジック
- `scripts/render-db-migration/cleanup.sh` - 旧DB削除
- `scripts/render-db-migration/notify-line.sh` - LINE 通知ヘルパー
- `docs/operations/render-db-migration-setup.md` - 初期セットアップ手順

## 更新
- `docs/operations/render-database-migration.md` - 既存手動手順を「自動運用停止時のフォールバック」位置付けに整理

## Test plan
- [ ] \`gh workflow run migrate-render-db.yml -f dry_run=true\` でガード判定の動作確認
- [ ] \`gh workflow run migrate-render-db.yml -f force=true\` で初回本番マイグレーション
- [ ] LINE 通知到達確認
- [ ] 14日後の cleanup ワークフロー動作確認

## Secrets
GitHub Secrets に 11個（RENDER_API_KEY, RENDER_OWNER_ID, RENDER_SERVICE_ID, RENDER_PG_ID, RENDER_GH_PAT, LINE_CHANNEL_ACCESS_TOKEN, LINE_NOTIFY_USER_IDS, PG_HOST, PG_USER, PG_PASSWORD, PG_DATABASE）登録済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)