### PR TITLE
fix(ops): SSL接続エラー対応（PGSSLMODE=require + 接続テストリトライ）

### DIFF
--- a/scripts/render-db-migration/migrate.sh
+++ b/scripts/render-db-migration/migrate.sh
@@ -15,6 +15,10 @@
 #
 set -euo pipefail
 
+# Render PostgreSQL は SSL 必須。libpq のデフォルト sslmode=prefer だとフォールバックして
+# 接続が切られる場合があるので、全 psql/pg_dump に明示的に require を強制。
+export PGSSLMODE=require
+
 DRY_RUN="${DRY_RUN:-false}"
 FORCE="${FORCE:-false}"
 MIN_AGE_DAYS="${MIN_AGE_DAYS:-25}"
@@ -204,8 +208,8 @@ while :; do
   STATUS=$(echo "$STATUS_JSON" | jq -r '.status // .postgres.status // empty')
   log "  status=$STATUS"
   if [[ "$STATUS" == "available" ]]; then
-    log "新DBが available。接続安定化のため 30 秒待機"
-    sleep 30
+    log "新DBが available。接続安定化のため 60 秒待機"
+    sleep 60
     break
   fi
   if [[ "$STATUS" == "suspended" || "$STATUS" == "deleting" || "$STATUS" == "unknown" ]]; then
@@ -252,6 +256,28 @@ NEW_PG_INT_HOST=$(echo "$NEW_PG_INT_URL" | sed -E 's|^postgresql://[^@]+@([^:/]+
 log "新DB: host=$NEW_PG_HOST  internalHost=$NEW_PG_INT_HOST  db=$NEW_PG_DATABASE"
 
 #=== 6. リストア =============================================================
+# Available になった直後でも SSL ハンドシェイクが安定しないことがあるので、
+# リストア前に簡単な接続テストでリトライ。
+log "新DBへの SSL 接続テスト（最大 5 回 × 30 秒）"
+CONN_OK=false
+for i in 1 2 3 4 5; do
+  if PGPASSWORD="$NEW_PG_PASSWORD" psql \
+    -h "$NEW_PG_HOST" -U "$NEW_DB_USER" -d "$NEW_PG_DATABASE" \
+    -c "SELECT 1;" > /tmp/conn-test.log 2>&1; then
+    log "  接続テスト成功 (attempt $i)"
+    CONN_OK=true
+    break
+  fi
+  log "  接続テスト失敗 (attempt $i): $(tail -1 /tmp/conn-test.log)"
+  sleep 30
+done
+
+if [[ "$CONN_OK" != "true" ]]; then
+  err "新DBへの接続テストが5回失敗"
+  notify failure "Render DB 自動マイグレーション失敗" "新DBへの接続が安定しません（SSL ハンドシェイク不安定）。"
+  exit 1
+fi
+
 log "新DBへリストア実行"
 PGPASSWORD="$NEW_PG_PASSWORD" psql \
   -h "$NEW_PG_HOST" -U "$NEW_DB_USER" -d "$NEW_PG_DATABASE" \


### PR DESCRIPTION
## 前回失敗の原因
PR #636 マージ後の本番マイグレーションで host パースは直ったが、リストアの psql が SSL エラーで失敗：
\`\`\`
psql: error: connection to server at "dpg-...render.com" (35.227.164.209), port 5432 failed:
SSL connection has been closed unexpectedly
\`\`\`

## 仮説と修正
### 仮説
- libpq のデフォルト \`sslmode=prefer\` は SSL→non-SSL フォールバックを試みる
- Render は non-SSL を拒否する → 中途半端な状態でハンドシェイクが切られる
- さらに新DB は available になっても SSL 受付の準備未完了の可能性あり

### 修正
1. \`export PGSSLMODE=require\` をスクリプト先頭で強制
2. リストア前に **SSL 接続テスト**を追加（5回 × 30秒）
3. Available 後の固定 sleep を 30 → 60 秒に

## 良い知らせ
前回の \`trap on_exit EXIT\` の修正が効いて、cleanup が正しく動作：
- 失敗を検知 → 新DB削除 → 旧DB resume の流れがログに記録された
- 本番サービスは自動で復旧（手動介入不要）

## Test plan
- [ ] PR merge 後、\`force=true\` で再実行
- [ ] \`接続テスト成功\` ログが出ること
- [ ] リストア成功 → env vars 更新 → デプロイ → live を確認
- [ ] LINE 通知到達

🤖 Generated with [Claude Code](https://claude.com/claude-code)