### PR TITLE
fix(ops): 新DB作成時に ipAllowList を全許可で明示指定

### DIFF
--- a/scripts/render-db-migration/migrate.sh
+++ b/scripts/render-db-migration/migrate.sh
@@ -174,7 +174,16 @@ CREATE_PAYLOAD=$(jq -n \
   --arg region "$NEW_DB_REGION" \
   --arg version "$NEW_DB_VERSION" \
   --arg plan "$NEW_DB_PLAN" \
-  '{name:$name, ownerId:$ownerId, databaseName:$databaseName, databaseUser:$databaseUser, region:$region, version:$version, plan:$plan}')
+  '{
+    name: $name,
+    ownerId: $ownerId,
+    databaseName: $databaseName,
+    databaseUser: $databaseUser,
+    region: $region,
+    version: $version,
+    plan: $plan,
+    ipAllowList: [{ cidrBlock: "0.0.0.0/0", description: "everywhere" }]
+  }')
 
 NEW_PG_JSON=$(render_api POST "/postgres" "$CREATE_PAYLOAD")
 NEW_PG_ID=$(echo "$NEW_PG_JSON" | jq -r '.id // .postgres.id // empty')


### PR DESCRIPTION
## 根本原因
Render API で PostgreSQL を作成する際、\`ipAllowList\` 未指定だと API はデフォルトで「空配列 = 全 IP 拒否」を割り当てる。

旧DB（Dashboard 経由で作成）と新DB（API 経由で作成）の \`ipAllowList\` 比較：

| | ipAllowList |
|---|---|
| 旧DB | \`[{cidrBlock: "0.0.0.0/0", description: "everywhere"}]\` ✅ |
| 新DB | \`[]\` ❌（API が黙ってこうしていた）|

このため、新DBはサーバが TCP accept した直後、認証前の段階で接続を RST/FIN していた。過去メモリ#110 で「正しい/誤ったパスワードが同じ応答時間で同じエラー」と判明していた症状と完全一致。

## 修正
CREATE_PAYLOAD に明示的に追加：
\`\`\`json
"ipAllowList": [{ "cidrBlock": "0.0.0.0/0", "description": "everywhere" }]
\`\`\`

## これまでの3つの修正の意義
PR #635 (suspend), #636 (host parse + EXIT trap), #637 (PGSSLMODE) はいずれも必要な修正で、特に **EXIT trap は今回もすごく役立った**：ipAllowList 問題で5回 SSL 失敗してもサービスは自動復旧された。

## Test plan
- [ ] PR merge 後、\`force=true\` で再実行
- [ ] 新DBへの接続テストが1回目から成功
- [ ] リストア成功 → env vars 更新 → デプロイ → live を確認
- [ ] LINE 通知到達

🤖 Generated with [Claude Code](https://claude.com/claude-code)