### PR TITLE
fix(ops): gh secret set の --body-file フラグ削除（次回マイグレーション用）

### DIFF
--- a/scripts/render-db-migration/migrate.sh
+++ b/scripts/render-db-migration/migrate.sh
@@ -449,7 +449,8 @@ trap - ERR
 log "GitHub Secrets を新DB情報で更新します"
 set_secret() {
   local name="$1"; local value="$2"
-  printf '%s' "$value" | GH_TOKEN="$RENDER_GH_PAT" gh secret set "$name" --repo "$GITHUB_REPOSITORY" --body-file -
+  # gh CLI のバージョンによって `--body-file -` が無いので、引数なしで stdin から読む。
+  printf '%s' "$value" | GH_TOKEN="$RENDER_GH_PAT" gh secret set "$name" --repo "$GITHUB_REPOSITORY"
   log "  $name updated"
 }
 


### PR DESCRIPTION
## Summary
前回（2026-05-12 16:30 UTC）の本番マイグレーションは**本体全成功**：
- 旧DB suspend → 新DB作成 → リストア → env vars 切替 → デプロイ live → /ping 200 OK ✅

しかし**最後の Secrets 自動更新でだけ失敗**：
\`\`\`
unknown flag: --body-file
\`\`\`

GitHub Actions runner の gh CLI には \`--body-file\` フラグが無かった。

## 修正
\`gh secret set --body-file -\` から \`--body-file -\` を削除して、stdin パイプだけで値を渡す。gh CLI は引数なしで stdin から読む仕様。

## 今回の手動補完
本リリースの分は私（人間）が PowerShell で \`gh secret set --body\` で手動更新済み。
次回（5/13以降の25日後の自動実行時）は本修正で自動完遂する想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)