### PR TITLE
fix: 個人の対戦一覧で同日内も試合番号の降順に並べる

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/MatchRepository.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/repository/MatchRepository.java
@@ -27,12 +27,12 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
     List<Match> findByMatchDateOrderByMatchNumber(@Param("matchDate") LocalDate matchDate);
 
     /**
-     * 選手の対戦結果を取得（日付の降順）
+     * 選手の対戦結果を取得（日付・試合番号の降順）
      *
      * @param playerId 選手ID
      * @return 対戦結果のリスト
      */
-    @Query("SELECT m FROM Match m WHERE m.player1Id = :playerId OR m.player2Id = :playerId ORDER BY m.matchDate DESC, m.matchNumber ASC")
+    @Query("SELECT m FROM Match m WHERE m.player1Id = :playerId OR m.player2Id = :playerId ORDER BY m.matchDate DESC, m.matchNumber DESC")
     List<Match> findByPlayerId(@Param("playerId") Long playerId);
 
     /**

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/repository/MatchRepositoryTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/repository/MatchRepositoryTest.java
@@ -118,7 +118,7 @@ class MatchRepositoryTest {
     }
 
     @Test
-    @DisplayName("選手の対戦結果を全て取得できる")
+    @DisplayName("選手の対戦結果を全て取得できる（同日内は試合番号の降順）")
     void testFindByPlayerId() {
         // When
         List<Match> matches = matchRepository.findByPlayerId(player1.getId());
@@ -128,6 +128,23 @@ class MatchRepositoryTest {
         assertThat(matches)
                 .allMatch(m -> m.getPlayer1Id().equals(player1.getId()) ||
                               m.getPlayer2Id().equals(player1.getId()));
+        // 同日内は matchNumber の降順（新しい試合番号が先頭）
+        assertThat(matches.get(0).getMatchDate()).isEqualTo(today);
+        assertThat(matches.get(0).getMatchNumber()).isEqualTo(2);
+        assertThat(matches.get(1).getMatchDate()).isEqualTo(today);
+        assertThat(matches.get(1).getMatchNumber()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("選手の対戦結果は試合日の降順で取得される")
+    void testFindByPlayerIdOrdersByMatchDateDesc() {
+        // When: player2は today（matchNumber=1）と today-7（matchNumber=1）の試合に出場
+        List<Match> matches = matchRepository.findByPlayerId(player2.getId());
+
+        // Then: 試合日の降順（新しい日が先頭）
+        assertThat(matches).hasSize(2);
+        assertThat(matches.get(0).getMatchDate()).isEqualTo(today);
+        assertThat(matches.get(1).getMatchDate()).isEqualTo(today.minusDays(7));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `MatchRepository.findByPlayerId` の ORDER BY を `matchDate DESC, matchNumber ASC` → `matchDate DESC, matchNumber DESC` に変更
- 個人の対戦一覧で、同じ日に複数試合がある場合、最新の試合（試合番号が大きい方）が上に表示されるようになる

## Test plan
- [ ] バックエンドテスト（MatchRepositoryTest / MatchServiceTest / MatchControllerTest / MatchIntegrationTest）通過
- [ ] 同日に複数試合がある選手のページで、試合番号の降順に並ぶことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)