### PR TITLE
fix(practice): SAME_DAY参加登録時の既存WONへの「今日参加します」通知誤発火を修正

### DIFF
--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeParticipantService.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/PracticeParticipantService.java
@@ -224,7 +224,14 @@ public class PracticeParticipantService {
                 .findByYearAndMonthAndOrganizationId(request.getYear(), request.getMonth(), organizationId).stream()
                 .map(PracticeSession::getId).collect(Collectors.toList());
 
+        // softDelete前に既存WONの (sessionId, matchNumber) を控えておく。
+        // 「以前からWONのまま変わらない」再登録では「今日参加します」通知を発火させないため。
+        Set<String> previouslyWonKeys = new HashSet<>();
         if (!allMonthSessionIds.isEmpty()) {
+            practiceParticipantRepository.findByPlayerIdAndSessionIds(playerId, allMonthSessionIds).stream()
+                    .filter(p -> p.getStatus() == ParticipantStatus.WON && p.getMatchNumber() != null)
+                    .forEach(p -> previouslyWonKeys.add(participationKey(p.getSessionId(), p.getMatchNumber())));
+
             practiceParticipantRepository.softDeleteByPlayerIdAndSessionIds(
                     playerId, allMonthSessionIds, JstDateTimeUtil.now());
             practiceParticipantRepository.flush();
@@ -247,7 +254,9 @@ public class PracticeParticipantService {
 
             if (isFreeRegistrationOpen(sessionsMap.get(sessionId), matchNumber)) {
                 saveOrReuseParticipant(sessionId, playerId, matchNumber, ParticipantStatus.WON, null);
-                notifySameDayJoinIfApplicable(sessionsMap.get(sessionId), matchNumber, playerId);
+                if (!previouslyWonKeys.contains(participationKey(sessionId, matchNumber))) {
+                    notifySameDayJoinIfApplicable(sessionsMap.get(sessionId), matchNumber, playerId);
+                }
                 registered++;
             } else {
                 int maxNumber = practiceParticipantRepository

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeParticipantServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/PracticeParticipantServiceTest.java
@@ -608,4 +608,85 @@ class PracticeParticipantServiceTest {
         p.setStatus(status);
         return p;
     }
+
+    @Test
+    @DisplayName("SAME_DAY: 当日12:00以降に同月内の別日を新たに登録しても、既存WONには「今日参加します」通知が発火しない")
+    void sameDay_existingWonNotReNotified_whenSavingAnotherDayInSameMonth() {
+        // 5/17（当日）= 既存WON、5/19 = 新規参加。両方ともリクエストに含まれる。
+        LocalDate today = LocalDate.of(2026, 5, 17);
+        LocalDate later = LocalDate.of(2026, 5, 19);
+
+        PracticeSession todaySession = createSession(100L, null);
+        todaySession.setSessionDate(today);
+        PracticeSession laterSession = createSession(200L, null);
+        laterSession.setSessionDate(later);
+
+        when(playerRepository.existsById(10L)).thenReturn(true);
+        when(practiceSessionRepository.findAllById(any())).thenReturn(List.of(todaySession, laterSession));
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(2026, 5, ORG_ID))
+                .thenReturn(List.of(todaySession, laterSession));
+        when(lotteryDeadlineHelper.getDeadlineType(ORG_ID)).thenReturn(DeadlineType.SAME_DAY);
+        // softDelete前のスナップショット取得: 5/17 はWON、5/19 は未登録
+        when(practiceParticipantRepository.findByPlayerIdAndSessionIds(eq(10L), eq(List.of(100L, 200L))))
+                .thenReturn(List.of(buildParticipant(100L, 10L, 1, ParticipantStatus.WON)));
+        when(practiceParticipantRepository.findBySessionIdAndPlayerIdAndMatchNumber(anyLong(), eq(10L), anyInt()))
+                .thenReturn(List.of());
+        // 5/17 はpreviouslyWonKeysに含まれるため notifySameDayJoinIfApplicable は呼ばれない。
+        // 5/19 は呼ばれるが、当日でないので isAfterSameDayNoon=false で早期return。
+        when(lotteryDeadlineHelper.isAfterSameDayNoon(later)).thenReturn(false);
+
+        PracticeParticipationRequest request = new PracticeParticipationRequest();
+        request.setPlayerId(10L);
+        request.setYear(2026);
+        request.setMonth(5);
+        request.setParticipations(List.of(
+                createParticipation(100L, 1), // 既存WONの再保存
+                createParticipation(200L, 1)  // 新規（5/19）
+        ));
+
+        service.registerParticipations(request);
+
+        // 「今日参加します」通知は発火しないこと（既存WONの再保存も、当日でない別日も対象外）
+        verify(lineNotificationService, never())
+                .sendSameDayJoinNotification(any(PracticeSession.class), anyInt(), anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("SAME_DAY: 当日12:00以降にキャンセル済みから新規WONになる場合は「今日参加します」通知が発火する")
+    void sameDay_reactivateFromCancelled_firesJoinNotificationAfterNoon() {
+        LocalDate today = LocalDate.of(2026, 5, 17);
+        PracticeSession session = createSession(100L, null);
+        session.setSessionDate(today);
+
+        when(playerRepository.existsById(10L)).thenReturn(true);
+        when(practiceSessionRepository.findAllById(any())).thenReturn(List.of(session));
+        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(2026, 5, ORG_ID))
+                .thenReturn(List.of(session));
+        when(lotteryDeadlineHelper.getDeadlineType(ORG_ID)).thenReturn(DeadlineType.SAME_DAY);
+        // 既存はCANCELLEDなのでスナップショットのWONには含まれない
+        when(practiceParticipantRepository.findByPlayerIdAndSessionIds(eq(10L), eq(List.of(100L))))
+                .thenReturn(List.of(buildParticipant(100L, 10L, 1, ParticipantStatus.CANCELLED)));
+        PracticeParticipant cancelled = PracticeParticipant.builder()
+                .id(555L).sessionId(100L).playerId(10L).matchNumber(1)
+                .status(ParticipantStatus.CANCELLED).dirty(false).build();
+        when(practiceParticipantRepository.findBySessionIdAndPlayerIdAndMatchNumber(100L, 10L, 1))
+                .thenReturn(List.of(cancelled));
+        when(lotteryDeadlineHelper.isAfterSameDayNoon(today)).thenReturn(true);
+        com.karuta.matchtracker.entity.Player player = new com.karuta.matchtracker.entity.Player();
+        player.setId(10L);
+        player.setName("テスト太郎");
+        when(playerRepository.findById(10L)).thenReturn(Optional.of(player));
+
+        PracticeParticipationRequest request = new PracticeParticipationRequest();
+        request.setPlayerId(10L);
+        request.setYear(2026);
+        request.setMonth(5);
+        request.setParticipations(List.of(createParticipation(100L, 1)));
+
+        service.registerParticipations(request);
+
+        // 通知発火を検証
+        verify(lineNotificationService)
+                .sendSameDayJoinNotification(eq(session), eq(1), eq("テスト太郎"), eq(10L));
+    }
 }


### PR DESCRIPTION
## Summary
- SAME_DAY参加登録時、当日12:00以降に同月内の別日を新たに登録すると、変更のない既存WONにも「今日参加します」通知が誤発火していた問題を修正
- `registerSameDay()` の softDelete 前に既存WONレコードのキー集合を控え、以前からWONだった (sessionId, matchNumber) は通知をスキップ
- ユニットテストを2件追加（変更なしWONで通知発火しないこと／CANCELLED→WONの復活では通知発火すること）

## Bug
Fixes #643

## Test plan
- [x] `PracticeParticipantServiceTest` 全件通過
- [ ] 本番動作確認: 当日12:00以降にSAME_DAY団体で別日の参加チェックを変更して保存し、既存参加日に通知が来ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)