### PR TITLE
fix: 練習参加/キャンセル登録のチェックボックス連続タップで隣セル誤押下を防止

### DIFF
--- a/karuta-tracker-ui/src/pages/practice/PracticeCancelPage.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeCancelPage.jsx
@@ -445,7 +445,7 @@ const PracticeCancelPage = () => {
                     return (
                       <label
                         key={match.matchNumber}
-                        className={`flex items-center gap-3 p-3 rounded-lg border-2 cursor-pointer transition-colors ${
+                        className={`flex items-center gap-3 p-3 rounded-lg border-2 cursor-pointer transition-colors touch-manipulation select-none ${
                           isSelected
                             ? 'border-red-400 bg-red-50'
                             : 'border-gray-200 hover:border-gray-300 bg-white'
@@ -455,7 +455,7 @@ const PracticeCancelPage = () => {
                           type="checkbox"
                           checked={isSelected}
                           onChange={() => toggleMatchSelection(match.matchNumber)}
-                          className="w-5 h-5 rounded border-gray-300"
+                          className="w-5 h-5 rounded border-gray-300 touch-manipulation"
                           style={{ accentColor: '#8b4513' }}
                         />
                         <span className="text-sm font-medium text-gray-800">

--- a/karuta-tracker-ui/src/pages/practice/PracticeParticipation.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeParticipation.jsx
@@ -401,7 +401,7 @@ const PracticeParticipation = () => {
                                   ) : (
                                     // 抽選前: チェックボックス
                                     <label
-                                      className={`mx-auto flex min-h-11 w-10 flex-col items-center justify-center gap-0.5 rounded-md py-1 transition-colors ${
+                                      className={`mx-auto flex min-h-11 w-10 flex-col items-center justify-center gap-0.5 rounded-md py-1 transition-colors touch-manipulation select-none ${
                                         isLockedRegistration(session.id, matchNumber)
                                           ? 'cursor-not-allowed opacity-70'
                                           : 'cursor-pointer hover:bg-[#e2d9d0]'
@@ -412,7 +412,7 @@ const PracticeParticipation = () => {
                                         checked={isChecked}
                                         onChange={() => toggleMatch(session.id, matchNumber)}
                                         disabled={isLockedRegistration(session.id, matchNumber)}
-                                        className={`w-5 h-5 border-gray-300 rounded focus:ring-[#4a6b5a] ${isLockedRegistration(session.id, matchNumber) ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+                                        className={`w-5 h-5 border-gray-300 rounded focus:ring-[#4a6b5a] touch-manipulation ${isLockedRegistration(session.id, matchNumber) ? 'cursor-not-allowed' : 'cursor-pointer'}`}
                                         style={{ accentColor: '#4a6b5a' }}
                                       />
                                       <span


### PR DESCRIPTION
## Summary
- 練習参加登録 (PracticeParticipation) とキャンセル登録 (PracticeCancelPage) のチェックボックスを連続タップした際、iOS Safari のダブルタップズーム遅延により隣のセルが押下される問題を修正
- `<label>` と `<input type="checkbox">` に Tailwind の `touch-manipulation` クラス（`touch-action: manipulation`）と、テキスト選択モード防止のため `select-none` を付与

## Bug
Fixes #648

## Test plan
- [ ] iOS Safari の実機 (or Chrome DevTools のモバイルエミュレーション) で `/practice/participation` を開く
- [ ] 同じ行内の試合チェックボックスを間を置かずに連続タップしても、タップ位置のチェックボックスだけが ON/OFF されること
- [ ] 別の行・別の試合チェックボックスを連続タップしても、隣セルが誤って押下されないこと
- [ ] `/practice/cancel` の試合選択チェックボックスでも同様に意図したセルのみがトグルされること
- [ ] 既存のクリック操作（PC マウス/キーボード）でリグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)