### PR TITLE
feat(org-settings): hide 北大かるた会 from participation toggle list

### DIFF
--- a/karuta-tracker-ui/src/pages/settings/OrganizationSettings.jsx
+++ b/karuta-tracker-ui/src/pages/settings/OrganizationSettings.jsx
@@ -25,7 +25,7 @@ const OrganizationSettings = () => {
         organizationAPI.getAll(),
         organizationAPI.getPlayerOrganizations(currentPlayer.id),
       ]);
-      setOrganizations(orgsRes.data);
+      setOrganizations(orgsRes.data.filter(o => o.code !== 'hokudai'));
       setSelectedOrgIds(playerOrgsRes.data.map(o => o.id));
     } catch (e) {
       setError('データの取得に失敗しました');


### PR DESCRIPTION
## Summary
- 「参加練習会の設定」画面（OrganizationSettings）から北海道大学かるた会（`code === 'hokudai'`）の選択肢をフロント側でフィルタして非表示にする

## Test plan
- [ ] `/settings/organization` を開いて、北海道大学かるた会が選択肢に出ないことを確認
- [ ] わすらもち会など他団体は従来どおり表示され、トグル・保存が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)