### PR TITLE
fix(densuke): 不可視BIDI制御文字によるプレイヤー重複登録を防止

### DIFF
--- a/database/cleanup_player_hidden_chars.sql
+++ b/database/cleanup_player_hidden_chars.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- Issue #671: 不可視BIDI制御文字を含むプレイヤー名の重複レコード論理削除
+-- ============================================================
+--
+-- 本番DBに混入した不可視Unicode文字 (U+202A LEFT-TO-RIGHT EMBEDDING 等)
+-- 付きの重複プレイヤーを論理削除する。
+--
+-- 経緯:
+-- 伝助メンバー名フィールドに不可視BIDI制御文字が混入したまま登録され、
+-- DensukeImportService が同名プレイヤーとマッチできず「未登録者」として
+-- 検出 → 管理者の一括登録により別IDで重複作成されていた。
+--
+-- 対象 (2026-05-20 時点で本番DB確認済み):
+--   id=39  "森保滉大"        ← 正規 (残す)
+--   id=140 "(U+202A)⭐森保滉大"  ← 重複 (論理削除)
+--   id=141 "(U+202A)森保滉大"    ← 重複 (論理削除)
+--
+-- id=140 / id=141 に紐づくレコード件数 (2026-05-20 確認):
+--   practice_participants: 0, matches: 0, match_pairings: 0,
+--   match_personal_notes: 0, notifications: 0,
+--   densuke_member_mappings: 0, player_profiles: 0,
+--   push_subscriptions: 0, line_*: 0, bye_activities: 0
+--   → 業務データに影響なし
+--   player_organizations / push_notification_preferences /
+--     line_notification_preferences は各1件のみ。残置しても
+--     deleted_at フィルタで参照されないため副作用なし。
+--
+-- コード側修正は DensukeScraper.stripLeadingEmoji の Cf (FORMAT) カテゴリ
+-- 全般除去で対応済み。本SQL適用後、伝助同期は正規 id=39 にマッチする。
+-- ============================================================
+
+UPDATE players
+SET deleted_at = NOW()
+WHERE id IN (140, 141)
+  AND deleted_at IS NULL;
+
+-- 検証クエリ: 実行後に id=39 のみがアクティブで残ることを確認
+SELECT id, name, length(name) AS chars, deleted_at
+FROM players
+WHERE name LIKE '%森保%' OR name LIKE '%滉大%'
+ORDER BY id;

--- a/database/cleanup_player_hidden_chars.sql
+++ b/database/cleanup_player_hidden_chars.sql
@@ -29,10 +29,17 @@
 -- 全般除去で対応済み。本SQL適用後、伝助同期は正規 id=39 にマッチする。
 -- ============================================================
 
+-- 安全柵: id 単独ではなく「期待する不可視文字付き名前」と AND 結合する。
+-- 別環境・リストア後DBで万一 id=140/141 が別人に再採番されていた場合に
+-- 誤って論理削除しないようにする。U& リテラルで U+202A LRE と U+2B50 ⭐ を
+-- 明示的にエスケープし、それ以外の漢字はソース上でも視認できる literal を使う。
 UPDATE players
 SET deleted_at = NOW()
-WHERE id IN (140, 141)
-  AND deleted_at IS NULL;
+WHERE deleted_at IS NULL
+  AND (
+        (id = 140 AND name = U&'\202A\2B50' || '森保滉大')
+    OR  (id = 141 AND name = U&'\202A'      || '森保滉大')
+  );
 
 -- 検証クエリ: 実行後に id=39 のみがアクティブで残ることを確認
 SELECT id, name, length(name) AS chars, deleted_at

--- a/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeScraper.java
+++ b/karuta-tracker/src/main/java/com/karuta/matchtracker/service/DensukeScraper.java
@@ -221,25 +221,28 @@ public class DensukeScraper {
 
     /**
      * 名前の先頭に付いている絵文字（Symbol カテゴリの文字）を除去し、
-     * 不可視のUnicode制御文字（Variation Selector等）を全体から除去する。
-     * 例: "🔰田中" → "田中", "🌟鈴木" → "鈴木", "︎井桁" → "井桁"
+     * 不可視のUnicode制御文字（FORMAT カテゴリ全般 + Variation Selector）を全体から除去する。
+     * 末尾の Unicode 空白（NBSP/全角空白を含む）も除去する。
+     * 例: "🔰田中" → "田中", "🌟鈴木" → "鈴木", "︎井桁" → "井桁", "‪⭐森保滉大" → "森保滉大"
      */
     static String stripLeadingEmoji(String name) {
         if (name == null || name.isEmpty()) return name;
 
-        // 全体からVariation Selector (U+FE00–U+FE0F, U+E0100–U+E01EF) および
-        // その他の不可視FORMAT文字（ゼロ幅スペース等）を除去
+        // Step 1: 全体から不可視文字を除去
+        // - Cf (FORMAT) カテゴリ全般: BIDIコントロール(LRM/RLM/LRE/RLE/PDF/LRO/RLO/LRI/RLI/FSI/PDI)、
+        //   ゼロ幅スペース・接合子(ZWSP/ZWNJ/ZWJ)、BOM、Word Joiner、Soft Hyphen 等を一括除去。
+        //   伝助からペーストされた名前に U+202A 等が混入していた既往不具合 (#671) を救済する。
+        // - Variation Selectors (U+FE00-U+FE0F, U+E0100-U+E01EF) は Mn カテゴリのため別途明示除去。
         StringBuilder sb = new StringBuilder(name.length());
         name.codePoints().forEach(cp -> {
-            if (cp >= 0xFE00 && cp <= 0xFE0F) return;          // Variation Selectors
-            if (cp >= 0xE0100 && cp <= 0xE01EF) return;        // Variation Selectors Supplement
-            if (cp == 0x200B || cp == 0x200C || cp == 0x200D    // Zero-width chars
-                    || cp == 0xFEFF || cp == 0x2060) return;    // BOM, Word Joiner
+            if (Character.getType(cp) == Character.FORMAT) return;
+            if (cp >= 0xFE00 && cp <= 0xFE0F) return;
+            if (cp >= 0xE0100 && cp <= 0xE01EF) return;
             sb.appendCodePoint(cp);
         });
         String cleaned = sb.toString();
 
-        // 先頭の絵文字（Symbolカテゴリ）を除去
+        // Step 2: 先頭の絵文字（Symbolカテゴリ）を除去
         int i = 0;
         while (i < cleaned.length()) {
             int codePoint = cleaned.codePointAt(i);
@@ -252,6 +255,36 @@ public class DensukeScraper {
                 break;
             }
         }
-        return cleaned.substring(i).trim();
+
+        // Step 3: 末尾の Unicode 空白（U+00A0 NBSP / U+3000 全角空白 等）を含めて両端トリム。
+        // Java の String.trim() は U+0020 以下のみのため、isWhitespace + isSpaceChar の和集合で剥がす。
+        return stripUnicodeWhitespace(cleaned.substring(i));
+    }
+
+    /**
+     * 両端から Unicode の空白文字を除去する。
+     * String.strip() は Character.isWhitespace のみで NBSP (U+00A0) を残すため、
+     * Character.isSpaceChar(U+00A0/U+3000 等) との和集合で除去する。
+     */
+    private static String stripUnicodeWhitespace(String s) {
+        int start = 0;
+        int end = s.length();
+        while (start < end) {
+            int cp = s.codePointAt(start);
+            if (Character.isWhitespace(cp) || Character.isSpaceChar(cp)) {
+                start += Character.charCount(cp);
+            } else {
+                break;
+            }
+        }
+        while (end > start) {
+            int cp = s.codePointBefore(end);
+            if (Character.isWhitespace(cp) || Character.isSpaceChar(cp)) {
+                end -= Character.charCount(cp);
+            } else {
+                break;
+            }
+        }
+        return s.substring(start, end);
     }
 }

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeScraperTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeScraperTest.java
@@ -107,6 +107,42 @@ class DensukeScraperTest {
     }
 
     @Test
+    @DisplayName("stripLeadingEmoji: 双方向制御文字 (Cf カテゴリ) が除去される (#671)")
+    void testStripBidiControlChars() {
+        // U+202A LEFT-TO-RIGHT EMBEDDING が先頭に付いた本番事例 (#671: 森保滉大の重複登録)
+        assertThat(DensukeScraper.stripLeadingEmoji("‪森保滉大")).isEqualTo("森保滉大");
+        // U+202A LRE + ⭐絵文字 の組み合わせ (id=140 のケース)
+        // 先頭BIDIで絵文字剥がしループが止まる旧バグの回帰防止
+        assertThat(DensukeScraper.stripLeadingEmoji("‪⭐森保滉大")).isEqualTo("森保滉大");
+        // U+200E LEFT-TO-RIGHT MARK
+        assertThat(DensukeScraper.stripLeadingEmoji("‎田中")).isEqualTo("田中");
+        // U+200F RIGHT-TO-LEFT MARK
+        assertThat(DensukeScraper.stripLeadingEmoji("‏田中")).isEqualTo("田中");
+        // U+202C POP DIRECTIONAL FORMATTING (末尾)
+        assertThat(DensukeScraper.stripLeadingEmoji("田中‬")).isEqualTo("田中");
+        // U+2068 FIRST STRONG ISOLATE + U+2069 POP DIRECTIONAL ISOLATE
+        assertThat(DensukeScraper.stripLeadingEmoji("⁨田中⁩")).isEqualTo("田中");
+        // U+00AD SOFT HYPHEN (中間に混入)
+        assertThat(DensukeScraper.stripLeadingEmoji("田­中")).isEqualTo("田中");
+    }
+
+    @Test
+    @DisplayName("stripLeadingEmoji: 非ASCII空白 (NBSP/全角空白) も両端トリムされる")
+    void testStripUnicodeWhitespace() {
+        // U+3000 IDEOGRAPHIC SPACE (全角空白)
+        assertThat(DensukeScraper.stripLeadingEmoji("　田中")).isEqualTo("田中");
+        assertThat(DensukeScraper.stripLeadingEmoji("田中　")).isEqualTo("田中");
+        assertThat(DensukeScraper.stripLeadingEmoji("　田中　")).isEqualTo("田中");
+        // U+00A0 NBSP
+        assertThat(DensukeScraper.stripLeadingEmoji(" 田中")).isEqualTo("田中");
+        assertThat(DensukeScraper.stripLeadingEmoji("田中 ")).isEqualTo("田中");
+        // ASCII space は従来通り
+        assertThat(DensukeScraper.stripLeadingEmoji("  田中  ")).isEqualTo("田中");
+        // 絵文字 + 全角空白 の組み合わせ
+        assertThat(DensukeScraper.stripLeadingEmoji("🔰田中　")).isEqualTo("田中");
+    }
+
+    @Test
     @DisplayName("parse: 3択 (○/△/×) ページで全メンバー・出欠が正しく取得される")
     void testParseThreeChoicePage() throws IOException {
         String html = buildDensukeHtml(


### PR DESCRIPTION
## Summary

- `DensukeScraper.stripLeadingEmoji` を強化し、`Character.FORMAT` (Cf) カテゴリ全般（BIDIコントロール／ゼロ幅／BOM／Soft Hyphen 等）と非ASCII空白（U+00A0 NBSP / U+3000 全角空白）の両端を除去するよう修正
- BIDI制御文字 / 全角空白 / 絵文字との組み合わせを網羅する JUnit テストケースを追加
- 本番DBに既に作成された重複プレイヤー（id=140「‪⭐森保滉大」、id=141「‪森保滉大」）を論理削除する `database/cleanup_player_hidden_chars.sql` を追加

## Bug

Fixes #671

伝助メンバー名フィールドに U+202A (LEFT-TO-RIGHT EMBEDDING) 等の不可視文字が混入していた場合、`stripLeadingEmoji` が Cf カテゴリ未対応のため照合に失敗し、既存プレイヤー（id=39「森保滉大」）が「未登録扱い」となり、管理者の一括登録で別IDの重複が作成されていた。

## 本番DB適用済み

`database/cleanup_player_hidden_chars.sql` は本PRマージ前に本番に適用済み:
- id=140, 141 を `UPDATE players SET deleted_at = NOW()` で論理削除
- id=140/141 に紐づく業務データ（practice_participants / matches / match_pairings / notifications 等）は 0件確認
- player_organizations / push_notification_preferences / line_notification_preferences が各1件のみ存在するが、`deleted_at` フィルタにより参照されない

## Test plan

- [x] `./gradlew test --tests "com.karuta.matchtracker.service.DensukeScraperTest"` パス
- [x] `./gradlew test --tests "com.karuta.matchtracker.service.DensukeImportService*"` パス
- [x] 本番DB: id=140/141 が論理削除されたことを SELECT で確認
- [ ] 次回の伝助同期で id=39「森保滉大」のみがアクティブ照合対象となる
- [ ] 万一伝助に再度不可視文字が混入しても、コード側で正規化されて id=39 にマッチする

🤖 Generated with [Claude Code](https://claude.com/claude-code)