### PR TITLE
feat(matches): relocate filter trigger to top year-month button

### DIFF
--- a/docs/features/match-list-filter-trigger-relocate/fix-implementation-plan.md
+++ b/docs/features/match-list-filter-trigger-relocate/fix-implementation-plan.md
@@ -1,0 +1,105 @@
+---
+status: completed
+---
+# 対戦結果一覧 フィルタートリガー再配置 改修実装手順書
+
+## 実装タスク
+
+### タスク1: MatchList.jsx の import 整理と適用中フィルタ件数の算出ロジック追加
+- [x] 完了
+- **概要:**
+  - `lucide-react` から `ChevronDown` を追加 import する
+  - 同 import から `Filter` を削除する（FAB削除に伴い `MatchList.jsx` 内では未使用になる）
+  - レンダリング内で `activeFilterCount` を算出する式を追加する（年月以外のフィルタが何件アクティブかを数える）
+- **変更対象ファイル:**
+  - `karuta-tracker-ui/src/pages/matches/MatchList.jsx` — import 文の修正、`activeFilterCount` 算出ロジック追加
+- **依存タスク:** なし
+- **対応Issue:** #681
+
+### タスク2: 上部ナビゲーションバーの「年月」トリガー化
+- [x] 完了
+- **概要:**
+  - `<p className="text-sm text-white/70 mt-0.5">...</p>`（[MatchList.jsx:296-302](../../../karuta-tracker-ui/src/pages/matches/MatchList.jsx#L296-L302)）を `<button>` に変更
+  - `onClick={() => setIsFilterOpen(true)}` を設定
+  - 年月テキストの右に `ChevronDown` アイコン（`w-4 h-4` 程度）を追加
+  - 下線スタイル（`underline decoration-dotted underline-offset-4` または `border-b border-white/40`）を追加
+  - 状態クラス: `hover:bg-white/10 active:scale-95 active:bg-white/10 transition-all`
+  - パディング・rounded など適切な余白とタップターゲットサイズを確保（最低 44px 相当）
+- **変更対象ファイル:**
+  - `karuta-tracker-ui/src/pages/matches/MatchList.jsx` — 上部ナビゲーションバーの構造変更
+- **依存タスク:** #681 (タスク1)
+- **対応Issue:** #682
+
+### タスク3: 適用中フィルタ件数バッジの表示
+- [x] 完了
+- **概要:**
+  - タスク1 で算出した `activeFilterCount` が 1 以上の場合、年月ボタンの右に「フィルタ N件」バッジを表示
+  - バッジスタイル: `bg-white/20 text-white text-xs px-2 py-0.5 rounded-full ml-2`
+  - 0 件の場合はバッジを表示しない（`{activeFilterCount > 0 && ...}`）
+  - レイアウトは flex で年月ボタンとバッジを横並び、画面幅が狭い場合は折り返しも確認
+- **変更対象ファイル:**
+  - `karuta-tracker-ui/src/pages/matches/MatchList.jsx` — 件数バッジ表示の JSX 追加
+- **依存タスク:** #681, #682 (タスク1, 2)
+- **対応Issue:** #683
+
+### タスク4: 右下FABのコメントアウト
+- [x] 完了
+- **概要:**
+  - [MatchList.jsx:473-480](../../../karuta-tracker-ui/src/pages/matches/MatchList.jsx#L473-L480) の FAB ブロックを JSX コメント `{/* ... */}` で囲んでコメントアウト
+  - 将来の参考用に残す（ユーザー指示）
+  - コメントの先頭に「FAB は上部年月ボタンへ移行済み（YYYY-MM-DD）」のような短いメモを 1 行入れる
+- **変更対象ファイル:**
+  - `karuta-tracker-ui/src/pages/matches/MatchList.jsx` — FAB ブロックのコメントアウト
+- **依存タスク:** なし（タスク1〜3 と並行可能）
+- **対応Issue:** #684
+
+### タスク5: 開発サーバーでの動作確認
+- [ ] 完了
+- **概要:**
+  - `cd karuta-tracker-ui && npm run dev` で開発サーバーを起動
+  - `/matches` 画面を開いて以下を確認:
+    - 上部の年月テキストが押せる見た目になっている（下線・ChevronDown）
+    - クリックすると `FilterBottomSheet` が開く
+    - ボトムシートでフィルタを設定すると、上部に件数バッジが表示される
+    - フィルタを全て解除すると件数バッジが消える
+    - 右下FABが表示されない
+    - タップ時に少し縮む/光るアニメーションが効く
+    - 他選手の対戦結果一覧（`/matches?playerId=X`）でも同様に動作する
+  - レスポンシブも確認（モバイル幅と PC 幅の両方）
+- **変更対象ファイル:** なし（動作確認のみ）
+- **依存タスク:** #681, #682, #683, #684 (タスク1〜4)
+- **対応Issue:** #685
+
+### タスク6: lint・ビルド・既存テストの実行
+- [ ] 完了
+- **概要:**
+  - `cd karuta-tracker-ui && npm run lint` で ESLint エラーがないことを確認
+  - `npm run build` でプロダクションビルドが通ることを確認
+  - 既存テスト（`MatchForm.navigation.test.jsx` 等）は `MatchList.jsx` を直接対象としていないが、関連テストが落ちないこと（必要に応じて `npm test` 相当のコマンド）
+- **変更対象ファイル:** なし
+- **依存タスク:** #681, #682, #683, #684 (タスク1〜4)
+- **対応Issue:** #686
+
+### タスク7: ドキュメントの更新
+- [ ] 完了
+- **概要:**
+  - `docs/SPECIFICATION.md`, `docs/SCREEN_LIST.md`, `docs/DESIGN.md` を確認し、対戦結果一覧画面のフィルタリングUIに関する記述があれば最新の内容（年月クリックでフィルタを開く、件数バッジ表示、FABなし）に更新
+  - 該当記述がなければ更新不要
+- **変更対象ファイル:**
+  - `docs/SPECIFICATION.md`（必要に応じて）
+  - `docs/SCREEN_LIST.md`（必要に応じて）
+  - `docs/DESIGN.md`（必要に応じて）
+- **依存タスク:** #681, #682, #683, #684 (タスク1〜4)
+- **対応Issue:** #687
+
+## 実装順序
+
+1. **タスク1**: import 整理と件数算出ロジック追加（依存なし）
+2. **タスク2**: 上部年月トリガー化（タスク1に依存）
+3. **タスク3**: 件数バッジ表示（タスク1, 2に依存）
+4. **タスク4**: FABコメントアウト（並行可能）
+5. **タスク5**: 開発サーバーでの動作確認（タスク1〜4 完了後）
+6. **タスク6**: lint・ビルド・テスト確認（タスク1〜4 完了後、タスク5と並行可能）
+7. **タスク7**: ドキュメント更新（タスク1〜4 完了後）
+
+タスク1〜4はすべて `MatchList.jsx` の変更なので、実際には1つのPRで一気に行うのが効率的。Issueとしては分けても、コミット/PRはまとめて良い。

--- a/docs/features/match-list-filter-trigger-relocate/fix-implementation-plan.md
+++ b/docs/features/match-list-filter-trigger-relocate/fix-implementation-plan.md
@@ -54,7 +54,7 @@ status: completed
 - **対応Issue:** #684
 
 ### タスク5: 開発サーバーでの動作確認
-- [ ] 完了
+- [x] 完了
 - **概要:**
   - `cd karuta-tracker-ui && npm run dev` で開発サーバーを起動
   - `/matches` 画面を開いて以下を確認:

--- a/docs/features/match-list-filter-trigger-relocate/fix-implementation-plan.md
+++ b/docs/features/match-list-filter-trigger-relocate/fix-implementation-plan.md
@@ -71,7 +71,7 @@ status: completed
 - **対応Issue:** #685
 
 ### タスク6: lint・ビルド・既存テストの実行
-- [ ] 完了
+- [x] 完了
 - **概要:**
   - `cd karuta-tracker-ui && npm run lint` で ESLint エラーがないことを確認
   - `npm run build` でプロダクションビルドが通ることを確認
@@ -81,7 +81,7 @@ status: completed
 - **対応Issue:** #686
 
 ### タスク7: ドキュメントの更新
-- [ ] 完了
+- [x] 完了
 - **概要:**
   - `docs/SPECIFICATION.md`, `docs/SCREEN_LIST.md`, `docs/DESIGN.md` を確認し、対戦結果一覧画面のフィルタリングUIに関する記述があれば最新の内容（年月クリックでフィルタを開く、件数バッジ表示、FABなし）に更新
   - 該当記述がなければ更新不要

--- a/docs/features/match-list-filter-trigger-relocate/fix-requirements.md
+++ b/docs/features/match-list-filter-trigger-relocate/fix-requirements.md
@@ -1,0 +1,182 @@
+---
+status: completed
+audit_source: ユーザー直接指示（監査レポートなし）
+selected_items:
+  - 上部「年月」テキストのフィルタートリガー化
+  - 適用中フィルタの件数バッジ表示
+  - 右下FABの削除（コメントアウト保留）
+---
+
+# 対戦結果一覧 フィルタートリガー再配置 改修要件定義書
+
+## 1. 改修概要
+
+### 対象機能
+- **画面:** `/matches`（自分または他選手の対戦結果一覧）
+- **対象ファイル:**
+  - [karuta-tracker-ui/src/pages/matches/MatchList.jsx](../../../karuta-tracker-ui/src/pages/matches/MatchList.jsx)
+  - [karuta-tracker-ui/src/components/FilterBottomSheet.jsx](../../../karuta-tracker-ui/src/components/FilterBottomSheet.jsx)
+
+### 改修の背景
+- 現状、右下のFAB（フィルターアイコン）から `FilterBottomSheet` を呼び出して絞り込みを行っているが、画面上部に表示されている「YYYY年 M月」テキストとは導線が分かれており、操作の一貫性が低い。
+- 上部の「YYYY年 M月」が単なる表示テキストになっており、押せること（変更できること）が分かりにくい。
+- FABが右下にあるため、上部の年月表示と絞り込み操作の関係が直感的でない。
+
+### 改修スコープ
+1. 上部ナビゲーションバーの「YYYY年 M月」（または「YYYY年」「全期間」）をクリック可能にして、`FilterBottomSheet` を呼び出すトリガーに変更する。
+2. クリック可能であることを示すために、`ChevronDown` アイコン・テキスト下線・タップ時の状態変化（Tailwind 状態クラス）を追加する。
+3. 年月以外のフィルタ（級・性別・利き手・対戦相手検索・結果）が適用されているとき、適用件数バッジを表示する。
+4. 右下のFAB を削除する（コメントアウトで保留）。
+
+## 2. 改修内容
+
+### 2.1 上部「年月」テキストのトリガー化
+
+**現状（[MatchList.jsx:296-302](../../../karuta-tracker-ui/src/pages/matches/MatchList.jsx#L296-L302)）:**
+
+```jsx
+<p className="text-sm text-white/70 mt-0.5">
+  {selectedYear && selectedMonth
+    ? `${selectedYear}年 ${selectedMonth}月`
+    : selectedYear
+    ? `${selectedYear}年`
+    : '全期間'}
+</p>
+```
+
+- 単なる `<p>` タグでクリック不可
+- 視覚的にも「押せる」要素には見えない
+
+**改修後:**
+
+- `<button>` 要素に変更し、`onClick={() => setIsFilterOpen(true)}` を設定
+- 年月テキストの右に `ChevronDown` アイコンを追加（`lucide-react` から import）
+- テキスト下に下線を追加（`underline decoration-dotted underline-offset-4` または `border-b border-white/40`）
+- タップ時の状態クラス: `active:scale-95 active:bg-white/10`
+- ホバー時の状態: `hover:bg-white/10`
+- パディングを微調整して、タップターゲットを十分な大きさに（最低 44x44px 相当）
+
+**期待する見た目（イメージ）:**
+
+```
+┌───────────────────────────────┐
+│ 山田太郎  A級           [🔍] │
+│ ───────────────              │
+│  2026年 5月 ▼  [フィルタ2件] │
+│ ─────────                    │
+└───────────────────────────────┘
+```
+
+### 2.2 適用中フィルタの件数バッジ
+
+**現状:**
+- 年月以外のフィルタ（級・性別・利き手・対戦相手検索・結果）が適用されていても、上部には何も表示されない
+- 利用者は実際に絞り込み画面を開くまで他のフィルタが効いているか分からない
+
+**改修後:**
+
+- 以下のフィルタが「アクティブ」かどうかを判定:
+  - `filterKyuRank`: 空文字以外でアクティブ
+  - `filterGender`: 空文字以外でアクティブ
+  - `filterDominantHand`: 空文字以外でアクティブ
+  - `searchTerm`: 空文字以外でアクティブ
+  - `filterResult`: `'全て'` 以外でアクティブ
+- アクティブな件数を集計
+- 1件以上の場合、年月ボタンの右に「フィルタ N件」のバッジを表示
+- 0件の場合はバッジ非表示
+- バッジは年月ボタン外に配置し、ボタンクリックでも独立してフィルター画面を開ける（一体感のため、バッジもボタン領域に含めることも可）
+- バッジスタイル: `bg-white/20 text-white text-xs px-2 py-0.5 rounded-full`
+
+### 2.3 右下FABの削除
+
+**現状（[MatchList.jsx:473-480](../../../karuta-tracker-ui/src/pages/matches/MatchList.jsx#L473-L480)）:**
+
+```jsx
+{/* フローティングアクションボタン (FAB) */}
+<button
+  onClick={() => setIsFilterOpen(true)}
+  className="fixed right-4 z-20 bg-[#4a6b5a] text-white p-4 rounded-full shadow-lg hover:bg-[#3d5a4c] transition-all hover:shadow-xl"
+  style={{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom, 0px))' }}
+>
+  <Filter className="w-6 h-6" />
+</button>
+```
+
+**改修後:**
+- 上記のFABブロックをコメントアウトして残す（将来の参考用、ユーザー指示による）
+- `Filter` アイコンの import は `FilterBottomSheet` 内のヘッダーで使用中のため、`MatchList.jsx` 側の import からは削除する
+
+## 3. 技術設計
+
+### 3.1 API変更
+- なし
+
+### 3.2 DB変更
+- なし
+
+### 3.3 フロントエンド変更
+
+#### `karuta-tracker-ui/src/pages/matches/MatchList.jsx`
+
+**変更内容:**
+
+1. **import の追加**
+   - `lucide-react` から `ChevronDown` を追加 import
+   - `Filter` の import を削除（FAB削除に伴い使われなくなる）
+
+2. **適用中フィルタ件数の計算**
+   ```jsx
+   const activeFilterCount = [
+     filterKyuRank,
+     filterGender,
+     filterDominantHand,
+     searchTerm,
+     filterResult !== '全て' ? filterResult : '',
+   ].filter(Boolean).length;
+   ```
+   - レンダリング時に再計算（React の通常レンダリングで十分、`useMemo` は不要）
+
+3. **上部ナビゲーションバーの構造変更（[MatchList.jsx:288-303](../../../karuta-tracker-ui/src/pages/matches/MatchList.jsx#L288-L303) 周辺）**
+   - 既存の `<h1>` （名前 + 級）はそのまま
+   - 既存の `<p>` （年月）を `<button>` に変更
+   - `ChevronDown` アイコンを追加
+   - 下線スタイルを追加
+   - 件数バッジを併記
+   - onClick: `setIsFilterOpen(true)`
+
+4. **FAB部分のコメントアウト**
+   - 既存の FAB ブロック（473-480行付近）を JSX コメント `{/* ... */}` で囲む
+
+#### `karuta-tracker-ui/src/components/FilterBottomSheet.jsx`
+- 変更なし（呼び出し側のトリガーが変わるだけで、ボトムシート自体の動作・props は変更なし）
+
+### 3.4 バックエンド変更
+- なし
+
+## 4. 影響範囲
+
+### 影響を受ける既存機能
+- **対象画面の操作フロー（`/matches`）:** フィルタを開く動作の起点が右下FAB → 上部年月テキストに変わる。機能自体は変わらない。
+- **`FilterBottomSheet` コンポーネント:** 内部の動作・props は変更なし。
+- **`FilterBottomSheet` の他画面での利用:** 全文検索で確認した結果、`FilterBottomSheet` を import しているのは `MatchList.jsx` のみ。他画面への影響なし。
+
+### 破壊的変更
+- なし（APIもDBスキーマも変更なし）
+- 既存のURL・クエリパラメータの仕様も変更なし
+
+### 既存テストへの影響
+- `karuta-tracker-ui/src/pages/matches/` 配下のテストファイル: `MatchForm.navigation.test.jsx`, `MatchCommentThread.test.jsx`, `byePlayersLogic.test.js`
+- `MatchList.jsx` 自体のテストはない（影響なし）
+
+### 既存ドキュメントへの影響
+- `docs/SPECIFICATION.md`, `docs/SCREEN_LIST.md`, `docs/DESIGN.md` に対戦結果一覧画面の絞り込みUIが記載されているかを確認し、必要に応じて更新する
+
+## 5. 設計判断の根拠
+
+- **アイコンに `ChevronDown` を選択した理由:** セレクトボックスやドロップダウンとの視覚的類似性により、「クリックして変更できる」がもっとも直感的に伝わる。`Filter` アイコンは「フィルター機能を呼び出す」というメンタルモデルを必要とするが、`ChevronDown` は「ここから選び直せる」というより直接的なメッセージを伝える。
+
+- **件数バッジを「件数表示」にした理由:** ドットだけだと「何があるか分からない」、フィルタ名列挙だと「画面幅が足りなくなる」。件数表示は中間で、必要十分な情報量。
+
+- **タップ波紋を Tailwind の状態クラスで実装する理由:** Material-UI 風の ripple エフェクトを実装するには別途ライブラリやカスタムCSSが必要。`active:scale-95` + `active:bg-white/10` の組み合わせで、押した瞬間にボタンが少し縮み、背景が一瞬光るような視覚効果が得られる。十分なフィードバック。
+
+- **FAB をコメントアウトで残す:** ユーザーの判断による。一般的なベストプラクティスとしては git 履歴に残るため完全削除が望ましいが、ユーザーが「他画面で似た実装を参照したい」等の意図を持っている可能性を尊重。

--- a/karuta-tracker-ui/src/pages/matches/MatchList.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchList.jsx
@@ -8,7 +8,7 @@ import {
   Trophy,
   Plus,
   Search,
-  Filter,
+  ChevronDown,
   X,
   StickyNote,
 } from 'lucide-react';
@@ -281,6 +281,14 @@ const MatchList = () => {
     return <LoadingScreen />;
   }
 
+  const activeFilterCount = [
+    filterKyuRank,
+    filterGender,
+    filterDominantHand,
+    searchTerm,
+    filterResult !== '全て' ? filterResult : '',
+  ].filter(Boolean).length;
+
   return (
     <div className="space-y-6 pb-20">
       {/* ナビゲーションバー */}
@@ -293,13 +301,25 @@ const MatchList = () => {
                 <span>{isOtherPlayer ? targetPlayerName : currentPlayer?.name || ''}</span>
                 <span className="text-sm font-normal text-white/70">{targetPlayerKyuRank || '初心者'}</span>
               </h1>
-              <p className="text-sm text-white/70 mt-0.5">
-                {selectedYear && selectedMonth
-                  ? `${selectedYear}年 ${selectedMonth}月`
-                  : selectedYear
-                  ? `${selectedYear}年`
-                  : '全期間'}
-              </p>
+              <button
+                type="button"
+                onClick={() => setIsFilterOpen(true)}
+                className="mt-0.5 -ml-2 inline-flex items-center gap-1.5 rounded px-2 py-2 text-sm text-white/70 transition-all hover:bg-white/10 active:scale-95 active:bg-white/10"
+              >
+                <span className="underline decoration-dotted underline-offset-4">
+                  {selectedYear && selectedMonth
+                    ? `${selectedYear}年 ${selectedMonth}月`
+                    : selectedYear
+                    ? `${selectedYear}年`
+                    : '全期間'}
+                </span>
+                <ChevronDown className="w-4 h-4" aria-hidden="true" />
+                {activeFilterCount > 0 && (
+                  <span className="ml-1 rounded-full bg-white/20 px-2 py-0.5 text-xs text-white">
+                    フィルタ {activeFilterCount}件
+                  </span>
+                )}
+              </button>
             </div>
             {/* 右: アクションボタン */}
             <div className="flex items-center gap-2 ml-3 flex-shrink-0">
@@ -368,7 +388,7 @@ const MatchList = () => {
       </div>
 
       {/* コンテンツ（上部パディング追加） */}
-      <div className={`${showPlayerSearch ? 'pt-32' : 'pt-20'} space-y-6 transition-all`}>
+      <div className={`${showPlayerSearch ? 'pt-36' : 'pt-24'} space-y-6 transition-all`}>
       {/* 統計 */}
       {rankStatistics && (
         <div className="space-y-3">
@@ -470,7 +490,8 @@ const MatchList = () => {
         </div>
       )}
 
-      {/* フローティングアクションボタン (FAB) */}
+      {/* FAB は上部年月ボタンへ移行済み（2026-05-21） */}
+      {/*
       <button
         onClick={() => setIsFilterOpen(true)}
         className="fixed right-4 z-20 bg-[#4a6b5a] text-white p-4 rounded-full shadow-lg hover:bg-[#3d5a4c] transition-all hover:shadow-xl"
@@ -478,6 +499,7 @@ const MatchList = () => {
       >
         <Filter className="w-6 h-6" />
       </button>
+      */}
 
       {/* ボトムシート */}
       <FilterBottomSheet

--- a/karuta-tracker-ui/src/pages/matches/MatchList.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchList.jsx
@@ -248,15 +248,6 @@ const MatchList = () => {
     setFilteredMatches(filtered);
   }, [searchTerm, filterResult, matches, selectedYear, selectedMonth]);
 
-  const getResultBadge = (result) => {
-    const styles = {
-      勝ち: 'bg-green-100 text-green-700',
-      負け: 'bg-red-100 text-red-700',
-      引き分け: 'bg-gray-100 text-gray-700',
-    };
-    return styles[result] || styles['引き分け'];
-  };
-
   // 日付をM/D形式でフォーマット
   const formatDate = (dateString) => {
     const [, m, d] = dateString.split('-');

--- a/karuta-tracker-ui/src/pages/matches/MatchList.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchList.jsx
@@ -295,7 +295,7 @@ const MatchList = () => {
               <button
                 type="button"
                 onClick={() => setIsFilterOpen(true)}
-                className="mt-0.5 -ml-2 inline-flex items-center gap-1.5 rounded px-2 py-2 text-sm text-white/70 transition-all hover:bg-white/10 active:scale-95 active:bg-white/10"
+                className="mt-0.5 -ml-2 inline-flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 rounded px-2 py-2 text-sm text-white/70 transition-all hover:bg-white/10 active:scale-95 active:bg-white/10"
               >
                 <span className="underline decoration-dotted underline-offset-4">
                   {selectedYear && selectedMonth
@@ -304,9 +304,9 @@ const MatchList = () => {
                     ? `${selectedYear}年`
                     : '全期間'}
                 </span>
-                <ChevronDown className="w-4 h-4" aria-hidden="true" />
+                <ChevronDown className="w-4 h-4 shrink-0" aria-hidden="true" />
                 {activeFilterCount > 0 && (
-                  <span className="ml-1 rounded-full bg-white/20 px-2 py-0.5 text-xs text-white">
+                  <span className="shrink-0 rounded-full bg-white/20 px-2 py-0.5 text-xs text-white">
                     フィルタ {activeFilterCount}件
                   </span>
                 )}


### PR DESCRIPTION
## Summary
- `/matches` 画面のフィルタートリガーを右下FABから上部「YYYY年 M月」テキストに再配置
- 上部年月をボタン化し、`ChevronDown` アイコン・点線下線・hover/active 状態クラスでクリック可能性を視覚化
- 年月以外のフィルタ（級・性別・利き手・対戦相手検索・結果）が適用されているとき「フィルタ N件」バッジを表示
- 右下FABはコメントアウトで保留（将来の参考用、ユーザー指示）
- ヘッダー拡張に伴いコンテンツの上部パディング (`pt-20`→`pt-24`, `pt-32`→`pt-36`) を調整
- 既存の未使用 `getResultBadge` 関数を併せて削除（lint クリーンアップ）

## Related Issues
親Issue: #680

子Issue（マージ時に自動クローズ）:
- #681 import 整理と件数算出ロジック追加
- #682 上部「年月」をフィルタトリガー化
- #683 適用中フィルタ件数バッジ表示
- #684 右下FABのコメントアウト
- #685 開発サーバーでの動作確認
- #686 lint・ビルド・既存テストの実行
- #687 ドキュメントの更新（該当記述なしで更新なし）

## Test plan
- [x] `/matches` で上部の年月テキストが押せる見た目（下線・ChevronDown）
- [x] クリックで `FilterBottomSheet` が開く
- [x] フィルタ設定で件数バッジが表示・解除で消える
- [x] 右下FABが表示されない
- [x] タップ時に縮む/光るアニメーション動作
- [x] 他選手の対戦結果一覧（`?playerId=X`）でも同様動作
- [x] モバイル幅とPC幅両方で確認
- [x] `npx eslint src/pages/matches/MatchList.jsx` でエラー0
- [x] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)