### PR TITLE
fix(ui): prevent iOS Safari auto-zoom on input focus

### DIFF
--- a/karuta-tracker-ui/index.html
+++ b/karuta-tracker-ui/index.html
@@ -7,7 +7,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="柄長" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
     <title>柄長</title>
     <meta name="google-site-verification" content="4i9q3IIblawa_IJJtRD3D38wcsgFAqFZei0dHPxaafk" />
   </head>


### PR DESCRIPTION
## Summary
- iOS Safari でテキストボックス（input / textarea / select）にフォーカスした際、画面が自動でズームインする挙動を抑止する
- `karuta-tracker-ui/index.html` の viewport meta に `maximum-scale=1.0` を追加（1行修正）
- `user-scalable=no` は付けないため、ユーザーによる手動ピンチズームは引き続き可能

## 原因
iOS Safari は input/textarea/select のフォントサイズが 16px 未満のときに、フォーカス時に自動でズームインする仕様。アプリ内で Tailwind の `text-sm` (14px) などをフォーム要素に当てているページが多数あるため、フォーカスのたびにズームが発生していた。

## 影響範囲
- 全ページ共通の viewport 設定変更だが、自動ズームの抑止のみで UI レイアウト・スタイルには影響なし
- バックエンド・DB スキーマへの影響なし
- ドキュメント更新不要（仕様・画面・設計に変更なし）

## Test plan
- [ ] iOS Safari 実機で、任意のテキスト入力欄（例: ログイン画面のメール欄、練習会フォーム、伝助テンプレート入力など）をタップしたときに画面ズームが発生しないことを確認
- [ ] iOS Safari 実機で、手動ピンチズーム（指 2 本で拡大）が引き続き可能であることを確認
- [ ] PC ブラウザでの表示・操作に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)