### PR TITLE
fix(matches): 自分の対戦結果フィルタで年→月の整合性を確保

### DIFF
--- a/karuta-tracker-ui/src/components/FilterBottomSheet.jsx
+++ b/karuta-tracker-ui/src/components/FilterBottomSheet.jsx
@@ -70,7 +70,8 @@ const FilterBottomSheet = ({
               <select
                 value={selectedMonth}
                 onChange={(e) => setSelectedMonth(e.target.value)}
-                className="px-3 py-2 border border-[#d0c5b8] rounded-lg focus:ring-2 focus:ring-[#82655a] focus:border-transparent bg-[#f9f6f2]"
+                disabled={!selectedYear}
+                className="px-3 py-2 border border-[#d0c5b8] rounded-lg focus:ring-2 focus:ring-[#82655a] focus:border-transparent bg-[#f9f6f2] disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <option value="">すべての月</option>
                 {availableMonths.map((month) => (

--- a/karuta-tracker-ui/src/pages/matches/MatchList.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchList.jsx
@@ -54,6 +54,14 @@ const MatchList = () => {
   // ボトムシート表示状態
   const [isFilterOpen, setIsFilterOpen] = useState(false);
 
+  // 年を変更したときに、未選択（すべての年）に切り替えたら月もリセット
+  const handleYearChange = (value) => {
+    setSelectedYear(value);
+    if (value === '') {
+      setSelectedMonth('');
+    }
+  };
+
   // 選手一覧を遅延取得（検索フォーカス時に初めて取得）
   const playersLoadedRef = useRef(false);
   const fetchPlayersIfNeeded = async () => {
@@ -177,7 +185,7 @@ const MatchList = () => {
             sortedMatches
               .filter(m => {
                 const [year] = m.matchDate.split('-').map(Number);
-                return year === selectedYear;
+                return year === Number(selectedYear);
               })
               .map(m => {
                 const [, month] = m.matchDate.split('-').map(Number);
@@ -191,6 +199,9 @@ const MatchList = () => {
           if (months.length > 0 && selectedMonth && !months.includes(Number(selectedMonth))) {
             setSelectedMonth(months[0]);
           }
+        } else {
+          // 「すべての年」選択時は月の選択肢を空にする（月は「すべての月」固定）
+          setAvailableMonths([]);
         }
       } catch (error) {
         if (!cancelled) {
@@ -497,7 +508,7 @@ const MatchList = () => {
         isOpen={isFilterOpen}
         onClose={() => setIsFilterOpen(false)}
         selectedYear={selectedYear}
-        setSelectedYear={setSelectedYear}
+        setSelectedYear={handleYearChange}
         selectedMonth={selectedMonth}
         setSelectedMonth={setSelectedMonth}
         availableYears={availableYears}


### PR DESCRIPTION
## Summary
- `MatchList.jsx` の年/月フィルタで `selectedYear` が文字列と数値の間で揺れていた問題を修正
- 「すべての年」選択時に月リストをクリアし、月の選択値も自動で「すべての月」にリセット
- `FilterBottomSheet.jsx` で年未選択時の月セレクトを `disabled` 化（年→月の依存をUIで明示）

## Bug
Fixes #708

## 変更内容
1. `MatchList.jsx`
   - `handleYearChange` ラッパー追加: 年が空文字列なら月も空文字列にリセット
   - `availableMonths` 抽出時の `year === selectedYear` を `year === Number(selectedYear)` に修正（型不一致を解消）
   - `selectedYear` が空文字列のときは `availableMonths` を `[]` にクリアする `else` 分岐を追加
   - `FilterBottomSheet` に渡す `setSelectedYear` を `handleYearChange` に差し替え
2. `FilterBottomSheet.jsx`
   - 月セレクトに `disabled={!selectedYear}` と `disabled:opacity-50 disabled:cursor-not-allowed` を付与

## Test plan
- [ ] 初期表示で当月の月リスト・統計が表示される
- [ ] 年を別の年に切り替えると、その年の月リストに更新される
- [ ] 月を「すべての月」に切り替えても、年が選ばれている限り月リストは維持される
- [ ] 年を「すべての年」に切り替えると、月が自動で「すべての月」になり、月セレクトが disabled になる
- [ ] 「すべての年」状態から特定年に戻すと、月リストが再表示される
- [ ] 上部の年月ボタン表示（`全期間` / `2026年` / `2026年 5月`）が正しく切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)