### PR TITLE
fix(matches): 対戦履歴一覧の対戦相手リンクに下線を追加

### DIFF
--- a/karuta-tracker-ui/src/pages/matches/MatchList.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchList.jsx
@@ -542,7 +542,7 @@ const MatchList = () => {
                         <button
                           type="button"
                           onClick={() => navigate(`/matches?playerId=${opponentId}`)}
-                          className="flex-1 min-w-0 text-sm font-medium text-[#4a6b5a] text-left truncate"
+                          className="flex-1 min-w-0 text-sm font-medium text-[#4a6b5a] text-left truncate underline underline-offset-2"
                         >
                           {match.opponentName}
                         </button>


### PR DESCRIPTION
## Summary
- 対戦履歴一覧画面で対戦相手の名前が緑色テキストのみで、下線が無くリンクと気づきにくかった問題を修正
- 対戦相手名ボタンに `underline underline-offset-2` を追加して常時下線を表示

## 変更ファイル
- `karuta-tracker-ui/src/pages/matches/MatchList.jsx` — 対戦相手名ボタンの className に下線スタイル追加

## Test plan
- [ ] 対戦履歴一覧で対戦相手名に下線が表示されることを確認
- [ ] 下線部分をクリックすると当該対戦相手の対戦履歴ページに遷移することを確認
- [ ] 対戦相手が登録選手でない場合（opponentId が 0）は下線が表示されず、クリック不可であることを確認
- [ ] MatchDetail（対戦詳細画面）の挙動は変わっていないことを確認（hover 時のみ下線のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)