### PR TITLE
fix: 参加登録チェックボックスの誤タップを防ぐためセル間4px隙間を確保

### DIFF
--- a/karuta-tracker-ui/src/pages/practice/PracticeParticipation.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeParticipation.jsx
@@ -338,7 +338,7 @@ const PracticeParticipation = () => {
         ) : (
           <div className="bg-[#f9f6f2] rounded-lg shadow-sm overflow-hidden mx-4">
             <div className="overflow-x-auto">
-              <table className="w-full min-w-[404px] table-fixed">
+              <table className="w-full min-w-[432px] table-fixed">
                 <thead className="bg-[#e2d9d0] border-b border-[#d0c5b8]">
                   <tr>
                     <th className="w-[72px] px-2 py-2 text-left text-xs font-semibold text-[#5f3a2d]">
@@ -348,7 +348,7 @@ const PracticeParticipation = () => {
                       場所
                     </th>
                     {Array.from({ length: 7 }, (_, i) => i + 1).map((n) => (
-                      <th key={n} className="px-0 py-2 text-center text-xs font-semibold text-[#5f3a2d]">
+                      <th key={n} className="px-0.5 py-2 text-center text-xs font-semibold text-[#5f3a2d]">
                         {n}
                       </th>
                     ))}
@@ -400,7 +400,7 @@ const PracticeParticipation = () => {
                             const matchStatus = statusList.find(s => s.matchNumber === matchNumber);
 
                             return (
-                              <td key={matchNumber} className="px-0 py-2 text-center align-middle">
+                              <td key={matchNumber} className="px-0.5 py-2 text-center align-middle">
                                 {isAvailable ? (
                                   isLotteryDone && matchStatus ? (
                                     // 抽選済み: ステータス表示


### PR DESCRIPTION
## Summary

- 参加登録画面の試合チェックボックスを iPhone Safari で素早く連続タップすると、隣の試合番号のセルが反応する問題を修正
- テーブル幅を `min-w-[404px]` → `min-w-[432px]` に拡大し、各セル幅を 40px → 44px（Apple HIG 推奨幅）に
- 試合列の `<th>` / `<td>` の padding を `px-0` → `px-0.5` にし、label 間に物理的な 4px の隙間を確保

## Bug

Fixes #723

## 原因

iOS Safari の fuzzy hit testing がタップ位置を補正する際、隣接タップ対象の境目に物理的な隙間がないと隣の要素を選ぶ余地が大きくなる。`touch-manipulation` はダブルタップズーム遅延の抑止が主目的で、ヒットテストの境界ブレは解消しない。

過去の対応:
- #602 (f6b725e): `<div>` → `<label>` 化でタップターゲット領域作成
- #648 (6d1c9fe): `touch-manipulation` 追加でズーム遅延抑止

それでも残っていた「タッチ補正による隣接セル反応」を本PRで解消する。

## Test plan

- [ ] iPhone Safari で `/practice/participation` を開く
- [ ] 試合チェックボックスを素早く連続タップしても、タップしたセル自身のみが反応することを確認
- [ ] 既存の単体テスト (`PracticeParticipation.test.jsx`) が通ること
- [ ] テーブル幅拡大によるレイアウト崩れがないこと（特に幅狭デバイス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)