### PR TITLE
fix: 参加登録画面の連続タップで直前チェックが消える問題を修正 (stale closure)

### DIFF
--- a/karuta-tracker-ui/src/pages/practice/PracticeParticipation.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeParticipation.jsx
@@ -132,20 +132,21 @@ const PracticeParticipation = () => {
     // 締切後の既存登録はチェック外し不可
     if (isLockedRegistration(sessionId, matchNumber)) return;
 
-    const sessionParticipations = participations[sessionId] || [];
-    const isChecked = sessionParticipations.includes(matchNumber);
-
-    if (isChecked) {
-      setParticipations({
-        ...participations,
-        [sessionId]: sessionParticipations.filter((m) => m !== matchNumber),
-      });
-    } else {
-      setParticipations({
-        ...participations,
+    // 連続タップ時の stale closure を避けるため setState を関数形式で呼ぶ
+    setParticipations((prev) => {
+      const sessionParticipations = prev[sessionId] || [];
+      const isChecked = sessionParticipations.includes(matchNumber);
+      if (isChecked) {
+        return {
+          ...prev,
+          [sessionId]: sessionParticipations.filter((m) => m !== matchNumber),
+        };
+      }
+      return {
+        ...prev,
         [sessionId]: [...sessionParticipations, matchNumber],
-      });
-    }
+      };
+    });
   };
 
   // 変更があるかチェック（抽選済みセッションの変更は除外）

--- a/karuta-tracker-ui/src/pages/practice/PracticeParticipation.test.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeParticipation.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const mockNavigate = vi.fn();
@@ -25,6 +25,7 @@ vi.mock('../../api', () => ({
 vi.mock('../../api/organizations', () => ({
   organizationAPI: {
     getAll: vi.fn().mockResolvedValue({ data: [] }),
+    getPlayerOrganizations: vi.fn().mockResolvedValue({ data: [] }),
   },
 }));
 
@@ -314,6 +315,43 @@ describe('PracticeParticipation 保存フロー（SaveProgressOverlay）', () =>
 
     await user.click(screen.getByRole('button', { name: 'カレンダーに戻る' }));
     expect(mockNavigate).toHaveBeenCalledWith('/practice');
+  });
+
+  it('再レンダー前に同一セッションの複数チェックを連続クリックしても両方とも保持される (stale closure 回帰)', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    practiceAPI.registerParticipations.mockResolvedValue({ data: {} });
+
+    render(<PracticeParticipation />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).toBeNull());
+
+    const checkboxes = screen.getAllByRole('checkbox');
+
+    // setParticipations をオブジェクト直接渡しで書くと、同一 act 内の
+    // 2 つ目のクリックが 1 つ目の state 更新を spread で上書きしてしまう。
+    // 関数形式 (prev => ...) で書かれていればこのバッチでも両方残る。
+    act(() => {
+      fireEvent.click(checkboxes[0]);
+      fireEvent.click(checkboxes[1]);
+    });
+
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+
+    const saveButton = await screen.findByRole('button', { name: /保存する/ });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(practiceAPI.registerParticipations).toHaveBeenCalled();
+    });
+
+    const callArgs = practiceAPI.registerParticipations.mock.calls[0][0];
+    expect(callArgs.participations).toEqual(
+      expect.arrayContaining([
+        { sessionId: 100, matchNumber: 1 },
+        { sessionId: 100, matchNumber: 2 },
+      ]),
+    );
+    expect(callArgs.participations).toHaveLength(2);
   });
 
   it('保存失敗: error オーバーレイにサーバーメッセージ表示 →「閉じる」で idle、チェック状態を保持', async () => {


### PR DESCRIPTION
## Summary

- 参加登録画面 (`PracticeParticipation.jsx`) の `toggleMatch` で setState をオブジェクト直接渡しから関数形式に書き換え
- 200ms 以内の高速連続タップ時に古い `participations` を spread して 1 回目のチェックが消える問題を解消
- 同ファイル他箇所 `PracticeCancelPage.toggleMatchSelection` と書き方を揃えた

## Bug

Fixes #725

#723 は「空間的に隣のセル」が反応する fuzzy hit testing の物理隙間問題、本件は「時間的に前のセル」に吸われる React state の stale closure 問題で、別系統です。

## Test plan

- [ ] iPhone Safari `/practice/participation` で同じ行の試合 1 → 試合 2 を 200ms 以内に連続タップ → 両方ともチェックが残ること
- [ ] 別セッション行のチェックボックスを連続タップ → それぞれ正しくトグルされること
- [ ] 単発タップ・チェック解除など既存動作に regression がないこと
- [ ] `PracticeParticipation.test.jsx` の既存テストが通ること（単発操作のみテストしているため挙動互換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)