### PR TITLE
fix(test): 時刻依存で失敗していた JUnit テスト 14 件を修正

### DIFF
--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeWriteServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeWriteServiceTest.java
@@ -3,6 +3,7 @@ package com.karuta.matchtracker.service;
 import com.karuta.matchtracker.dto.DensukeWriteStatusDto;
 import com.karuta.matchtracker.entity.*;
 import com.karuta.matchtracker.repository.*;
+import com.karuta.matchtracker.util.JstDateTimeUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,24 +90,30 @@ class DensukeWriteServiceTest {
     @Test
     @DisplayName("dirty=trueの参加者がいない場合は何も書き込まない")
     void testWriteToDensuke_noDirtyParticipants_skipsWrite() {
+        // 実装は writeToDensuke() で今月と来月のURLを取得するため、
+        // 現在の年月を基準にテストデータを構築する
+        LocalDate today = JstDateTimeUtil.today();
+        int currentYear = today.getYear();
+        int currentMonth = today.getMonthValue();
+
         DensukeUrl url = DensukeUrl.builder()
-                .id(1L).year(2026).month(4).organizationId(1L)
+                .id(1L).year(currentYear).month(currentMonth).organizationId(1L)
                 .url("https://densuke.biz/list?cd=test123").build();
         when(densukeUrlRepository.findByYearAndMonth(anyInt(), anyInt()))
                 .thenAnswer(inv -> {
                     int y = (int) inv.getArgument(0);
                     int m = (int) inv.getArgument(1);
-                    if (y == 2026 && m == 4) return List.of(url);
+                    if (y == currentYear && m == currentMonth) return List.of(url);
                     return List.of();
                 });
 
         PracticeSession session = PracticeSession.builder()
-                .id(10L).sessionDate(LocalDate.of(2026, 4, 1)).totalMatches(3).build();
+                .id(10L).sessionDate(today.withDayOfMonth(1)).totalMatches(3).build();
         when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(anyInt(), anyInt(), eq(1L)))
                 .thenAnswer(inv -> {
                     int y = (int) inv.getArgument(0);
                     int m = (int) inv.getArgument(1);
-                    if (y == 2026 && m == 4) return List.of(session);
+                    if (y == currentYear && m == currentMonth) return List.of(session);
                     return Collections.emptyList();
                 });
 
@@ -165,24 +172,30 @@ class DensukeWriteServiceTest {
     @Test
     @DisplayName("BYE(matchNumber=null)のみdirtyの場合はプレイヤーの書き込みが発生しない")
     void testWriteToDensuke_byeOnlyDirty_skipsWrite() {
+        // 実装は writeToDensuke() で今月と来月のURLを取得するため、
+        // 現在の年月を基準にテストデータを構築する
+        LocalDate today = JstDateTimeUtil.today();
+        int currentYear = today.getYear();
+        int currentMonth = today.getMonthValue();
+
         DensukeUrl url = DensukeUrl.builder()
-                .id(1L).year(2026).month(4).organizationId(1L)
+                .id(1L).year(currentYear).month(currentMonth).organizationId(1L)
                 .url("https://densuke.biz/list?cd=test123").build();
         when(densukeUrlRepository.findByYearAndMonth(anyInt(), anyInt()))
                 .thenAnswer(inv -> {
                     int y = (int) inv.getArgument(0);
                     int m = (int) inv.getArgument(1);
-                    if (y == 2026 && m == 4) return List.of(url);
+                    if (y == currentYear && m == currentMonth) return List.of(url);
                     return List.of();
                 });
 
         PracticeSession session = PracticeSession.builder()
-                .id(10L).sessionDate(LocalDate.of(2026, 4, 1)).totalMatches(3).build();
+                .id(10L).sessionDate(today.withDayOfMonth(1)).totalMatches(3).build();
         when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(anyInt(), anyInt(), eq(1L)))
                 .thenAnswer(inv -> {
                     int y = (int) inv.getArgument(0);
                     int m = (int) inv.getArgument(1);
-                    if (y == 2026 && m == 4) return List.of(session);
+                    if (y == currentYear && m == currentMonth) return List.of(session);
                     return Collections.emptyList();
                 });
 

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeWriteServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/DensukeWriteServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -90,40 +91,44 @@ class DensukeWriteServiceTest {
     @Test
     @DisplayName("dirty=trueの参加者がいない場合は何も書き込まない")
     void testWriteToDensuke_noDirtyParticipants_skipsWrite() {
-        // 実装は writeToDensuke() で今月と来月のURLを取得するため、
-        // 現在の年月を基準にテストデータを構築する
-        LocalDate today = JstDateTimeUtil.today();
-        int currentYear = today.getYear();
-        int currentMonth = today.getMonthValue();
+        // 実装は writeToDensuke() で today() を呼んで今月と来月のURLを取得するため、
+        // テストセットアップとサービス呼び出しの間で月またぎが起きないよう today() を固定する
+        LocalDate fixedToday = LocalDate.of(2026, 5, 24);
+        int currentYear = fixedToday.getYear();
+        int currentMonth = fixedToday.getMonthValue();
 
-        DensukeUrl url = DensukeUrl.builder()
-                .id(1L).year(currentYear).month(currentMonth).organizationId(1L)
-                .url("https://densuke.biz/list?cd=test123").build();
-        when(densukeUrlRepository.findByYearAndMonth(anyInt(), anyInt()))
-                .thenAnswer(inv -> {
-                    int y = (int) inv.getArgument(0);
-                    int m = (int) inv.getArgument(1);
-                    if (y == currentYear && m == currentMonth) return List.of(url);
-                    return List.of();
-                });
+        try (MockedStatic<JstDateTimeUtil> jstMock = mockStatic(JstDateTimeUtil.class, CALLS_REAL_METHODS)) {
+            jstMock.when(JstDateTimeUtil::today).thenReturn(fixedToday);
 
-        PracticeSession session = PracticeSession.builder()
-                .id(10L).sessionDate(today.withDayOfMonth(1)).totalMatches(3).build();
-        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(anyInt(), anyInt(), eq(1L)))
-                .thenAnswer(inv -> {
-                    int y = (int) inv.getArgument(0);
-                    int m = (int) inv.getArgument(1);
-                    if (y == currentYear && m == currentMonth) return List.of(session);
-                    return Collections.emptyList();
-                });
+            DensukeUrl url = DensukeUrl.builder()
+                    .id(1L).year(currentYear).month(currentMonth).organizationId(1L)
+                    .url("https://densuke.biz/list?cd=test123").build();
+            when(densukeUrlRepository.findByYearAndMonth(anyInt(), anyInt()))
+                    .thenAnswer(inv -> {
+                        int y = (int) inv.getArgument(0);
+                        int m = (int) inv.getArgument(1);
+                        if (y == currentYear && m == currentMonth) return List.of(url);
+                        return List.of();
+                    });
 
-        when(practiceParticipantRepository.findDirtyForDensukeSync(any()))
-                .thenReturn(Collections.emptyList());
+            PracticeSession session = PracticeSession.builder()
+                    .id(10L).sessionDate(fixedToday.withDayOfMonth(1)).totalMatches(3).build();
+            when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(anyInt(), anyInt(), eq(1L)))
+                    .thenAnswer(inv -> {
+                        int y = (int) inv.getArgument(0);
+                        int m = (int) inv.getArgument(1);
+                        if (y == currentYear && m == currentMonth) return List.of(session);
+                        return Collections.emptyList();
+                    });
 
-        densukeWriteService.writeToDensuke();
+            when(practiceParticipantRepository.findDirtyForDensukeSync(any()))
+                    .thenReturn(Collections.emptyList());
 
-        verify(densukeMemberMappingRepository, never()).findByDensukeUrlIdAndPlayerId(any(), any());
-        assertThat(densukeWriteService.getStatus(1L).getPendingCount()).isEqualTo(0);
+            densukeWriteService.writeToDensuke();
+
+            verify(densukeMemberMappingRepository, never()).findByDensukeUrlIdAndPlayerId(any(), any());
+            assertThat(densukeWriteService.getStatus(1L).getPendingCount()).isEqualTo(0);
+        }
     }
 
     @Test
@@ -172,42 +177,46 @@ class DensukeWriteServiceTest {
     @Test
     @DisplayName("BYE(matchNumber=null)のみdirtyの場合はプレイヤーの書き込みが発生しない")
     void testWriteToDensuke_byeOnlyDirty_skipsWrite() {
-        // 実装は writeToDensuke() で今月と来月のURLを取得するため、
-        // 現在の年月を基準にテストデータを構築する
-        LocalDate today = JstDateTimeUtil.today();
-        int currentYear = today.getYear();
-        int currentMonth = today.getMonthValue();
+        // 実装は writeToDensuke() で today() を呼んで今月と来月のURLを取得するため、
+        // テストセットアップとサービス呼び出しの間で月またぎが起きないよう today() を固定する
+        LocalDate fixedToday = LocalDate.of(2026, 5, 24);
+        int currentYear = fixedToday.getYear();
+        int currentMonth = fixedToday.getMonthValue();
 
-        DensukeUrl url = DensukeUrl.builder()
-                .id(1L).year(currentYear).month(currentMonth).organizationId(1L)
-                .url("https://densuke.biz/list?cd=test123").build();
-        when(densukeUrlRepository.findByYearAndMonth(anyInt(), anyInt()))
-                .thenAnswer(inv -> {
-                    int y = (int) inv.getArgument(0);
-                    int m = (int) inv.getArgument(1);
-                    if (y == currentYear && m == currentMonth) return List.of(url);
-                    return List.of();
-                });
+        try (MockedStatic<JstDateTimeUtil> jstMock = mockStatic(JstDateTimeUtil.class, CALLS_REAL_METHODS)) {
+            jstMock.when(JstDateTimeUtil::today).thenReturn(fixedToday);
 
-        PracticeSession session = PracticeSession.builder()
-                .id(10L).sessionDate(today.withDayOfMonth(1)).totalMatches(3).build();
-        when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(anyInt(), anyInt(), eq(1L)))
-                .thenAnswer(inv -> {
-                    int y = (int) inv.getArgument(0);
-                    int m = (int) inv.getArgument(1);
-                    if (y == currentYear && m == currentMonth) return List.of(session);
-                    return Collections.emptyList();
-                });
+            DensukeUrl url = DensukeUrl.builder()
+                    .id(1L).year(currentYear).month(currentMonth).organizationId(1L)
+                    .url("https://densuke.biz/list?cd=test123").build();
+            when(densukeUrlRepository.findByYearAndMonth(anyInt(), anyInt()))
+                    .thenAnswer(inv -> {
+                        int y = (int) inv.getArgument(0);
+                        int m = (int) inv.getArgument(1);
+                        if (y == currentYear && m == currentMonth) return List.of(url);
+                        return List.of();
+                    });
 
-        // findDirtyForDensukeSync は matchNumber IS NOT NULL なのでBYEを返さない → 空
-        when(practiceParticipantRepository.findDirtyForDensukeSync(any()))
-                .thenReturn(Collections.emptyList());
+            PracticeSession session = PracticeSession.builder()
+                    .id(10L).sessionDate(fixedToday.withDayOfMonth(1)).totalMatches(3).build();
+            when(practiceSessionRepository.findByYearAndMonthAndOrganizationId(anyInt(), anyInt(), eq(1L)))
+                    .thenAnswer(inv -> {
+                        int y = (int) inv.getArgument(0);
+                        int m = (int) inv.getArgument(1);
+                        if (y == currentYear && m == currentMonth) return List.of(session);
+                        return Collections.emptyList();
+                    });
 
-        densukeWriteService.writeToDensuke();
+            // findDirtyForDensukeSync は matchNumber IS NOT NULL なのでBYEを返さない → 空
+            when(practiceParticipantRepository.findDirtyForDensukeSync(any()))
+                    .thenReturn(Collections.emptyList());
 
-        // BYEのみdirtyの場合、書き込み処理に進まない
-        verify(densukeMemberMappingRepository, never()).findByDensukeUrlIdAndPlayerId(any(), any());
-        assertThat(densukeWriteService.getStatus(1L).getPendingCount()).isEqualTo(0);
+            densukeWriteService.writeToDensuke();
+
+            // BYEのみdirtyの場合、書き込み処理に進まない
+            verify(densukeMemberMappingRepository, never()).findByDensukeUrlIdAndPlayerId(any(), any());
+            assertThat(densukeWriteService.getStatus(1L).getPendingCount()).isEqualTo(0);
+        }
     }
 
     // ----------------------------------------------------------------

--- a/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
+++ b/karuta-tracker/src/test/java/com/karuta/matchtracker/service/WaitlistPromotionServiceTest.java
@@ -654,7 +654,7 @@ class WaitlistPromotionServiceTest {
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1).build();
             PracticeSession session = PracticeSession.builder()
-                    .id(100L).sessionDate(LocalDate.of(2026, 5, 1)).build();
+                    .id(100L).sessionDate(JstDateTimeUtil.today().plusDays(7)).build();
             PracticeParticipant waitlisted = PracticeParticipant.builder()
                     .id(2L).sessionId(100L).playerId(20L).matchNumber(1)
                     .status(ParticipantStatus.WAITLISTED).waitlistNumber(2).build();
@@ -671,7 +671,7 @@ class WaitlistPromotionServiceTest {
                             100L, 1, ParticipantStatus.WAITLISTED))
                     .thenReturn(Optional.of(waitlisted));
             when(lotteryDeadlineHelper.calculateOfferDeadline(any()))
-                    .thenReturn(java.time.LocalDateTime.of(2026, 5, 10, 18, 0));
+                    .thenReturn(JstDateTimeUtil.now().plusDays(7));
 
             service.expireOffer(offered);
 
@@ -1061,16 +1061,16 @@ class WaitlistPromotionServiceTest {
             PracticeParticipant p1 = PracticeParticipant.builder()
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0))
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7))
                     .build();
             PracticeParticipant p2 = PracticeParticipant.builder()
                     .id(2L).sessionId(100L).playerId(10L).matchNumber(3)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0))
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7))
                     .build();
 
             PracticeSession session = PracticeSession.builder().id(100L)
-                    .sessionDate(LocalDate.of(2026, 5, 10)).build();
+                    .sessionDate(JstDateTimeUtil.today().plusDays(7)).build();
             Player triggerPlayer = Player.builder().id(10L).name("テスト選手").build();
 
             when(practiceParticipantRepository.findBySessionIdAndPlayerIdAndStatus(100L, 10L, ParticipantStatus.OFFERED))
@@ -1139,16 +1139,16 @@ class WaitlistPromotionServiceTest {
             PracticeParticipant valid = PracticeParticipant.builder()
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0)) // 未来
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7)) // 未来
                     .build();
             PracticeParticipant expired = PracticeParticipant.builder()
                     .id(2L).sessionId(100L).playerId(10L).matchNumber(3)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2020, 1, 1, 0, 0)) // 過去
+                    .offerDeadline(JstDateTimeUtil.now().minusDays(7)) // 過去
                     .build();
 
             PracticeSession session = PracticeSession.builder().id(100L)
-                    .sessionDate(LocalDate.of(2026, 5, 10)).build();
+                    .sessionDate(JstDateTimeUtil.today().plusDays(7)).build();
 
             when(practiceParticipantRepository.findBySessionIdAndPlayerIdAndStatus(100L, 10L, ParticipantStatus.OFFERED))
                     .thenReturn(List.of(valid, expired));
@@ -1212,7 +1212,7 @@ class WaitlistPromotionServiceTest {
             PracticeParticipant participant = PracticeParticipant.builder()
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0))
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7))
                     .build();
 
             PracticeParticipant remaining = PracticeParticipant.builder()
@@ -1244,7 +1244,7 @@ class WaitlistPromotionServiceTest {
             PracticeParticipant participant = PracticeParticipant.builder()
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0))
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7))
                     .build();
             PracticeSession session = PracticeSession.builder().id(100L).build();
             Player triggerPlayer = Player.builder().id(10L).name("テスト選手").build();
@@ -1271,7 +1271,7 @@ class WaitlistPromotionServiceTest {
             PracticeParticipant participant = PracticeParticipant.builder()
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0))
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7))
                     .build();
 
             when(practiceParticipantRepository.findById(1L)).thenReturn(Optional.of(participant));
@@ -1302,13 +1302,13 @@ class WaitlistPromotionServiceTest {
             PracticeParticipant participant = PracticeParticipant.builder()
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0))
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7))
                     .build();
             PracticeParticipant nextWaitlisted = PracticeParticipant.builder()
                     .id(5L).sessionId(100L).playerId(20L).matchNumber(1)
                     .status(ParticipantStatus.WAITLISTED).waitlistNumber(2).build();
             PracticeSession session = PracticeSession.builder().id(100L)
-                    .sessionDate(LocalDate.of(2026, 5, 10)).build();
+                    .sessionDate(JstDateTimeUtil.today().plusDays(7)).build();
 
             when(practiceParticipantRepository.findById(1L)).thenReturn(Optional.of(participant));
             when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
@@ -1323,7 +1323,7 @@ class WaitlistPromotionServiceTest {
                             100L, 1, ParticipantStatus.WAITLISTED))
                     .thenReturn(Optional.of(nextWaitlisted));
             when(lotteryDeadlineHelper.calculateOfferDeadline(any()))
-                    .thenReturn(java.time.LocalDateTime.of(2026, 5, 10, 18, 0));
+                    .thenReturn(JstDateTimeUtil.now().plusDays(7));
             when(playerRepository.findById(10L)).thenReturn(Optional.of(Player.builder().id(10L).name("テスト選手").build()));
 
             service.respondToOffer(1L, false);
@@ -1349,7 +1349,7 @@ class WaitlistPromotionServiceTest {
                     .id(6L).sessionId(100L).playerId(30L).matchNumber(3)
                     .status(ParticipantStatus.WAITLISTED).waitlistNumber(2).build();
             PracticeSession session = PracticeSession.builder().id(100L)
-                    .sessionDate(LocalDate.of(2026, 5, 10)).build();
+                    .sessionDate(JstDateTimeUtil.today().plusDays(7)).build();
 
             when(practiceParticipantRepository.findBySessionIdAndPlayerIdAndStatus(100L, 10L, ParticipantStatus.OFFERED))
                     .thenReturn(List.of(p1, p2));
@@ -1369,7 +1369,7 @@ class WaitlistPromotionServiceTest {
                             100L, 3, ParticipantStatus.WAITLISTED))
                     .thenReturn(Optional.of(nextForMatch3));
             when(lotteryDeadlineHelper.calculateOfferDeadline(any()))
-                    .thenReturn(java.time.LocalDateTime.of(2026, 5, 10, 18, 0));
+                    .thenReturn(JstDateTimeUtil.now().plusDays(7));
             when(playerRepository.findById(10L)).thenReturn(Optional.of(Player.builder().id(10L).name("テスト選手").build()));
 
             service.respondToOfferAll(100L, 10L, false);
@@ -1385,10 +1385,10 @@ class WaitlistPromotionServiceTest {
             PracticeParticipant participant = PracticeParticipant.builder()
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0))
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7))
                     .build();
             PracticeSession session = PracticeSession.builder().id(100L)
-                    .sessionDate(LocalDate.of(2026, 5, 10)).build();
+                    .sessionDate(JstDateTimeUtil.today().plusDays(7)).build();
 
             when(practiceParticipantRepository.findById(1L)).thenReturn(Optional.of(participant));
             when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
@@ -1418,16 +1418,16 @@ class WaitlistPromotionServiceTest {
             PracticeParticipant valid = PracticeParticipant.builder()
                     .id(1L).sessionId(100L).playerId(10L).matchNumber(1)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2026, 5, 10, 18, 0)) // 未来
+                    .offerDeadline(JstDateTimeUtil.now().plusDays(7)) // 未来
                     .build();
             PracticeParticipant expired = PracticeParticipant.builder()
                     .id(2L).sessionId(100L).playerId(10L).matchNumber(3)
                     .status(ParticipantStatus.OFFERED).waitlistNumber(1)
-                    .offerDeadline(java.time.LocalDateTime.of(2020, 1, 1, 0, 0)) // 過去
+                    .offerDeadline(JstDateTimeUtil.now().minusDays(7)) // 過去
                     .build();
 
             PracticeSession session = PracticeSession.builder().id(100L)
-                    .sessionDate(LocalDate.of(2026, 5, 10)).build();
+                    .sessionDate(JstDateTimeUtil.today().plusDays(7)).build();
             Player triggerPlayer = Player.builder().id(10L).name("テスト選手").build();
 
             when(practiceParticipantRepository.findBySessionIdAndPlayerIdAndStatus(100L, 10L, ParticipantStatus.OFFERED))
@@ -1488,10 +1488,10 @@ class WaitlistPromotionServiceTest {
                         100L, 1, ParticipantStatus.WAITLISTED))
                 .thenReturn(Optional.of(waitlisted));
         when(lotteryDeadlineHelper.calculateOfferDeadline(any()))
-                .thenReturn(java.time.LocalDateTime.of(2026, 5, 10, 18, 0));
+                .thenReturn(JstDateTimeUtil.now().plusDays(7));
 
         Optional<PracticeParticipant> result = service.promoteNextWaitlisted(
-                100L, 1, LocalDate.of(2026, 5, 5));
+                100L, 1, JstDateTimeUtil.today().plusDays(7));
 
         assertThat(result).isPresent();
         assertThat(result.get().getStatus()).isEqualTo(ParticipantStatus.OFFERED);
@@ -1515,7 +1515,7 @@ class WaitlistPromotionServiceTest {
                     .id(5L).sessionId(100L).playerId(20L).matchNumber(1)
                     .status(ParticipantStatus.WAITLISTED).waitlistNumber(2).build();
             PracticeSession session = PracticeSession.builder().id(100L)
-                    .sessionDate(LocalDate.of(2026, 5, 10)).build();
+                    .sessionDate(JstDateTimeUtil.today().plusDays(7)).build();
 
             when(practiceSessionRepository.findById(100L)).thenReturn(Optional.of(session));
             when(practiceParticipantRepository
@@ -1527,7 +1527,7 @@ class WaitlistPromotionServiceTest {
                             100L, 1, ParticipantStatus.WAITLISTED))
                     .thenReturn(Optional.of(nextWaitlisted));
             when(lotteryDeadlineHelper.calculateOfferDeadline(any()))
-                    .thenReturn(java.time.LocalDateTime.of(2026, 5, 10, 18, 0));
+                    .thenReturn(JstDateTimeUtil.now().plusDays(7));
 
             ExpireOfferResult result = service.expireOfferSuppressed(participant);
 


### PR DESCRIPTION
## Summary
- `DensukeWriteServiceTest` (2件) と `WaitlistPromotionServiceTest` (12件) が時刻依存で常時失敗していたため、テストデータの固定日付を `JstDateTimeUtil.today()` / `now()` ベースの動的日付に書き換えて修正
- プロダクションコードは一切変更なし（テスト内の `LocalDate.of(2026, 5, 10)` などを `today().plusDays(7)` 等に置換）
- 修正後、`DensukeWriteServiceTest` + `WaitlistPromotionServiceTest` 75/75 PASS、全バックエンドテスト BUILD SUCCESSFUL（回帰なし）

## Bug
Fixes #774

## 根本原因
- `WaitlistPromotionService:754` 等で `JstDateTimeUtil.now().isAfter(participant.getOfferDeadline())` の期限切れチェックがあり、テストの「未来」日付 (`LocalDateTime.of(2026, 5, 10, 18, 0)`) が現在時刻 (2026-05-24) で過去となり `IllegalStateException("応答期限が過ぎています")` で 12 件失敗
- `DensukeWriteService.writeToDensuke()` は「今月+来月」の URL を取得する仕様で、テストの DensukeUrl の year/month=2026/4 が範囲外となり `writeToDensukeInternal()` が `if (urls.isEmpty()) return;` で早期 return → 後段のスタブ (`findByYearAndMonthAndOrganizationId`, `findDirtyForDensukeSync`) が未使用扱いで `UnnecessaryStubbingException` で 2 件失敗

## 今後の課題（別Issue推奨）
- `JstDateTimeUtil` は `LocalDateTime.now(JST)` を直接呼ぶ static メソッドで、`Clock` 注入されていない。今回は影響範囲を抑えてテスト側で動的化したが、根本的には `Clock` DI 化＋テストでの `Clock` 差し替えに移行するとテストの堅牢性が増す

## Test plan
- [ ] CI (`Java CI with Gradle`) が green になること
- [ ] `cd karuta-tracker && ./gradlew test --tests "com.karuta.matchtracker.service.DensukeWriteServiceTest"` で全件 PASS
- [ ] `cd karuta-tracker && ./gradlew test --tests "com.karuta.matchtracker.service.WaitlistPromotionServiceTest"` で全件 PASS
- [ ] `cd karuta-tracker && ./gradlew test` で BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)