### PR TITLE
fix(matches): 対戦履歴一覧の各列幅と左右パディングを詰める

### DIFF
--- a/karuta-tracker-ui/src/pages/matches/MatchList.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchList.jsx
@@ -535,7 +535,7 @@ const MatchList = () => {
                   return (
                     <div
                       key={match.id}
-                      className="grid grid-cols-[2rem_6.125rem_2.5rem_minmax(0,1fr)_1.5rem_2rem] items-center gap-x-2 px-4 py-2"
+                      className="grid grid-cols-[1.75rem_5.25rem_2.5rem_minmax(0,1fr)_1.5rem_2rem] items-center gap-x-0.5 pl-2 pr-1 py-2"
                     >
                       <span className="text-xs text-[#9ca3af]">
                         {formatDate(match.matchDate)}


### PR DESCRIPTION
## Summary
- 対戦履歴一覧の各行レイアウトをローカルで調整した最終値で反映
- 相手名カラム: 全角7文字 → **全角6文字** (`6.125rem` → `5.25rem`)
- 日付カラム: `2rem` → `1.75rem`
- 列間隔: `gap-x-2` → `gap-x-0.5`
- 行 padding: `px-4` → `pl-2 pr-1`（左 8px / 右 4px に詰める）
- 結果として会場カラム (`minmax(0,1fr)`) が受け取れる幅が増え、「すずらん 3試合目」のような会場名が見やすくなる

## Test plan
- [x] ローカル開発サーバで実機サイズ表示確認済み
- [ ] マージ後、本番 (Vercel) で対戦履歴一覧の各行レイアウトを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)