### PR TITLE
style(practice): カレンダーの試合別ステータス〇×△の色を淡く調整

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -236,9 +236,9 @@
 
 | 状態（`CapacityStatus`） | 記号 | 配色 |
 |--------------------------|------|------|
-| `AVAILABLE`（空きあり） | `○` | 緑（`text-green-600`） |
-| `NEARLY_FULL`（残り席数 1〜2） | `△` | オレンジ（`text-orange-500`） |
-| `FULL`（満員） | `×` | 赤（`text-red-600`） |
+| `AVAILABLE`（空きあり） | `○` | 緑（`text-green-400`） |
+| `NEARLY_FULL`（残り席数 1〜2） | `△` | オレンジ（`text-orange-300`） |
+| `FULL`（満員） | `×` | 赤（`text-red-400`） |
 
 - 記号は小さい文字（`text-[9px]` 程度）・`font-bold`
 - グリッドは **3列固定**（`grid-cols-3`）、最大3行 = 最大9試合

--- a/karuta-tracker-ui/src/pages/practice/PracticeList.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeList.jsx
@@ -718,9 +718,9 @@ const PracticeList = () => {
                             const validValues = new Set(['AVAILABLE', 'NEARLY_FULL', 'FULL']);
                             if (!statuses.every((s) => validValues.has(s))) return null;
                             const symbolFor = (s) => {
-                              if (s === 'FULL') return { ch: '×', cls: 'text-red-600' };
-                              if (s === 'NEARLY_FULL') return { ch: '△', cls: 'text-orange-500' };
-                              return { ch: '○', cls: 'text-green-600' };
+                              if (s === 'FULL') return { ch: '×', cls: 'text-red-400' };
+                              if (s === 'NEARLY_FULL') return { ch: '△', cls: 'text-orange-300' };
+                              return { ch: '○', cls: 'text-green-400' };
                             };
                             return (
                               <div

--- a/karuta-tracker-ui/src/pages/practice/PracticeList.matchStatusGrid.test.jsx
+++ b/karuta-tracker-ui/src/pages/practice/PracticeList.matchStatusGrid.test.jsx
@@ -108,11 +108,11 @@ describe('PracticeList 試合別ステータスグリッド', () => {
     const symbols = grid.querySelectorAll('span');
     expect(symbols).toHaveLength(3);
     expect(symbols[0].textContent).toBe('○');
-    expect(symbols[0].className).toContain('text-green-600');
+    expect(symbols[0].className).toContain('text-green-400');
     expect(symbols[1].textContent).toBe('△');
-    expect(symbols[1].className).toContain('text-orange-500');
+    expect(symbols[1].className).toContain('text-orange-300');
     expect(symbols[2].textContent).toBe('×');
-    expect(symbols[2].className).toContain('text-red-600');
+    expect(symbols[2].className).toContain('text-red-400');
   });
 
   it('7試合の場合は3列固定 grid で 3+3+1 のレイアウトとして描画される', async () => {


### PR DESCRIPTION
## Summary
- 練習会場カレンダー画面の試合別ステータス記号（〇×△）の色味を1段ずつ淡く調整
  - `text-red-600` → `text-red-400`（×）
  - `text-orange-500` → `text-orange-300`（△）
  - `text-green-600` → `text-green-400`（○）
- カレンダーセルの背景・枠線（`#a3c4ad`／`#e8d48b` 等）の淡いトーンに合わせて、原色寄りで浮いていた印象を解消
- 対応テスト（`PracticeList.matchStatusGrid.test.jsx`）も同じクラスに追従

## Test plan
- [ ] `npm test` の `PracticeList.matchStatusGrid` 全 7 ケース PASS（ローカル確認済）
- [ ] `npm run build` 成功（ローカル確認済）
- [ ] 練習一覧（カレンダー表示）で、〇×△が原色から落ち着いた色味に変わっていること
- [ ] 自分の参加状況による cell background（confirmed / waitlisted）と重ねたときの視認性が許容範囲か目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)