### PR TITLE
fix: ホーム画面の試合時間表示を hh:mm 形式に変更

### DIFF
--- a/karuta-tracker-ui/src/pages/Home.jsx
+++ b/karuta-tracker-ui/src/pages/Home.jsx
@@ -101,6 +101,11 @@ const Home = () => {
 
   const isMyself = (p) => p.id === currentPlayer?.id;
 
+  const formatTime = (time) => {
+    if (!time) return '';
+    return time.substring(0, 5); // "HH:MM:SS" -> "HH:MM"
+  };
+
   const now = new Date();
   const monthLabel = `${now.getMonth() + 1}月`;
 
@@ -194,7 +199,7 @@ const Home = () => {
                 {nextPractice.startTime && (
                   <div className="flex items-center gap-2">
                     <Clock className="w-4 h-4 text-[#1A3654]" />
-                    <span className="text-[#374151]">{nextPractice.startTime}〜{nextPractice.endTime || ''}</span>
+                    <span className="text-[#374151]">{formatTime(nextPractice.startTime)}〜{formatTime(nextPractice.endTime)}</span>
                   </div>
                 )}
                 {/* 参加者セクション */}


### PR DESCRIPTION
## Summary
- ホーム画面の次の練習カードで startTime/endTime が "17:00:00" のように秒まで表示されていたのを "17:00" 形式に修正
- 既存の PracticeDetail.jsx / VenueList.jsx と同じ `time.substring(0, 5)` パターンで整形

## Test plan
- [ ] ホーム画面で次の練習カードの時間表示が "HH:MM〜HH:MM" 形式になっていることを確認
- [ ] startTime のみ存在し endTime が null のケースでもエラーにならないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)