### PR TITLE
fix: 試合詳細画面遷移時にページが下まで自動スクロールされる不具合を修正

### DIFF
--- a/karuta-tracker-ui/src/pages/matches/MatchCommentThread.jsx
+++ b/karuta-tracker-ui/src/pages/matches/MatchCommentThread.jsx
@@ -14,7 +14,7 @@ export default function MatchCommentThread({ matchId, menteeId }) {
   const [error, setError] = useState(null);
   const [notifying, setNotifying] = useState(false);
   const [notifySuccess, setNotifySuccess] = useState(false);
-  const bottomRef = useRef(null);
+  const messagesContainerRef = useRef(null);
   const textareaRef = useRef(null);
   const navTimerRef = useRef(null);
   const { setVisible } = useBottomNav();
@@ -35,7 +35,10 @@ export default function MatchCommentThread({ matchId, menteeId }) {
   }, [matchId, menteeId]);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
   }, [comments]);
 
   const handleSubmit = async (e) => {
@@ -164,7 +167,7 @@ export default function MatchCommentThread({ matchId, menteeId }) {
       )}
 
       {/* コメント一覧 */}
-      <div className="flex-1 overflow-y-auto min-h-0 p-4 space-y-3 bg-[#f0ebe4]">
+      <div ref={messagesContainerRef} className="flex-1 overflow-y-auto min-h-0 p-4 space-y-3 bg-[#f0ebe4]">
         {comments.length === 0 ? (
           <p className="text-gray-400 text-sm text-center py-4">まだコメントはありません</p>
         ) : (
@@ -240,7 +243,6 @@ export default function MatchCommentThread({ matchId, menteeId }) {
             );
           })
         )}
-        <div ref={bottomRef} />
       </div>
 
       {/* LINE通知送信ボタン */}


### PR DESCRIPTION
## Summary
- `MatchCommentThread` のコメント取得後 useEffect で `bottomRef.current?.scrollIntoView()` を呼んでおり、ページ全体がコメント一覧最下端まで smooth スクロールしてしまっていた
- コメント一覧コンテナ自身に `messagesContainerRef` を付け、`container.scrollTop = container.scrollHeight` でコンテナ内部だけスクロールするように変更
- 試合詳細画面遷移時にページは動かず、コメント一覧の中だけ最新コメントが見える状態になる

## Bug
Fixes #800

## Test plan
- [ ] 試合詳細画面を開いたとき、ページが最上部から表示される（試合結果カードが見える）
- [ ] メンター ⇔ メンティーのコメントスレッドで、コメント投稿後にコメント一覧内のスクロールが最下部まで動く
- [ ] ページ全体のスクロール位置はコメント投稿時も変化しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)