### PR TITLE
fix(home): 次の練習日カードのヘッダーを参加予定時に強調表示

### DIFF
--- a/karuta-tracker-ui/src/pages/Home.jsx
+++ b/karuta-tracker-ui/src/pages/Home.jsx
@@ -162,6 +162,28 @@ const Home = () => {
                   </span>
                 )}
               </div>
+            ) : nextPractice.registered === true ? (
+              <div className="bg-[#374151] px-5 py-3 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <ChevronsRight className="w-6 h-6 text-white/80" />
+                  <h2 className="text-xl font-bold text-white tracking-wide underline underline-offset-2 decoration-white/70 decoration-2">NEXT</h2>
+                  <span className="text-sm font-semibold text-white/90">
+                    {(() => {
+                      const d = new Date(nextPractice.sessionDate);
+                      const weekday = d.toLocaleDateString('ja-JP', { weekday: 'short' });
+                      return `${d.getMonth() + 1}/${d.getDate()}(${weekday})`;
+                    })()}
+                  </span>
+                  {nextPractice.venueName && (
+                    <span className="text-sm text-white/75">{nextPractice.venueName}</span>
+                  )}
+                </div>
+                {nextPractice.matchNumbers && nextPractice.matchNumbers.length > 0 && (
+                  <span className="text-xs text-white/70">
+                    {nextPractice.matchNumbers.join('、')}試合目に参加予定
+                  </span>
+                )}
+              </div>
             ) : (
               <div className="bg-[#f9f6f2] border-b border-[#1A3654]/20 px-5 py-3 flex items-center justify-between">
                 <div className="flex items-center gap-2">
@@ -178,19 +200,15 @@ const Home = () => {
                     <span className="text-sm text-[#1A3654]/70">{nextPractice.venueName}</span>
                   )}
                 </div>
-                {nextPractice.registered === false ? (
+                {nextPractice.registered === false && (
                   <Link to="/practice/participation" className="text-xs font-semibold text-[#1A3654]/70 hover:text-[#1A3654] flex items-center gap-0.5">
                     参加登録 <ArrowRight className="w-3 h-3" />
                   </Link>
-                ) : nextPractice.matchNumbers && nextPractice.matchNumbers.length > 0 && (
-                  <span className="text-xs text-[#1A3654]/60">
-                    {nextPractice.matchNumbers.join('、')}試合目に参加予定
-                  </span>
                 )}
               </div>
             )}
             {/* ボディ */}
-            <div className={`px-5 py-4 ${nextPractice.today ? 'bg-[#1A3654]/5' : 'bg-[#f9f6f2]'}`}>
+            <div className={`px-5 py-4 ${nextPractice.today ? 'bg-[#1A3654]/5' : nextPractice.registered === true ? 'bg-[#374151]/5' : 'bg-[#f9f6f2]'}`}>
               <div className="space-y-2">
                 {nextPractice.startTime && (
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- ホーム画面「次の練習日」カードのヘッダー帯を `today` のみで分岐していたのを、自分が参加予定 (`registered === true`) の場合も強調表示するように拡張
- TODAY = ダークネイビー、NEXT-参加予定 = ダークグレー、NEXT-未登録 = ベージュの3パターンに分岐
- ボディ部の淡色背景もヘッダーと色味が揃うよう3分岐

## Bug
Fixes #820

## Test plan
- [ ] TODAY の練習日（当日）の場合: ヘッダーがダークネイビー＋白文字で表示されること
- [ ] NEXT の練習日で自分が参加登録済みの場合: ヘッダーがダークグレー＋白文字で強調表示されること
- [ ] NEXT の練習日で自分が未登録の場合: ヘッダーがベージュ＋ネイビー文字で従来通りに表示され、「参加登録」リンクが表示されること
- [ ] NEXT 参加予定時に matchNumbers が設定されていれば「X試合目に参加予定」が右側に白文字で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)